### PR TITLE
ci: skip pages deploy for private repos

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -54,7 +54,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !github.event.repository.private
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Keeps the docs workflow green while the repository is private on a plan that does not support GitHub Pages, without removing the Pages deployment path for a future public repo.

### Codex description

- keep Docusaurus build/typecheck running for docs changes
- skip the GitHub Pages deployment job while `github.event.repository.private` is true
