### PR TITLE
ci: deploy docs on main updates

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - 'website/**'
-      - '.github/workflows/deploy-docs.yml'
   pull_request:
     paths:
       - 'docs/**'


### PR DESCRIPTION
Ensures the Docusaurus site is rebuilt whenever a PR merge updates `main`, instead of only when GitHub detects docs-site path changes.

### Codex description

- remove the `push` path filter from the docs deployment workflow
- keep the pull-request path filter so docs checks only run on relevant PRs
