### PR TITLE
document duckdb ai functions and provider usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# Repository Instructions
+
+This repository contains the `duckdb_ai` DuckDB extension. Keep changes scoped,
+source-backed, and validated against the local DuckDB extension tooling.
+
+## Project Layout
+
+- `src/` contains the C++ extension implementation and public headers.
+- `test/sql/duckdb_ai.test` contains deterministic SQLLogic coverage.
+- `test/smoke/mock_provider_smoke.py` covers mock HTTP provider behavior without
+  external network calls.
+- `docs/` is the Docusaurus docs source.
+- `website/` contains the Docusaurus site configuration and frontend.
+- `duckdb/` and `extension-ci-tools/` are submodules/vendor tooling; avoid
+  editing them unless the task explicitly requires it.
+- `local-docs/` is an ignored local research corpus and should stay out of git.
+
+## Build And Test
+
+Use the repo Makefile from the root:
+
+```sh
+GEN=ninja make release
+GEN=ninja make test
+python3 test/smoke/mock_provider_smoke.py
+```
+
+The formatter gate uses DuckDB's formatter. On this machine, the formatter tools
+are available in `/tmp/duckdb_ai_format_venv/bin`:
+
+```sh
+PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
+PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-fix
+```
+
+For docs changes, also run from `website/`:
+
+```sh
+npm run typecheck
+npm run build
+```
+
+## Implementation Guidance
+
+- Prefer DuckDB extension patterns already used in `src/duckdb_ai_extension.cpp`
+  and `src/duckdb_ai_provider.cpp`.
+- Keep SQL function names, argument order, named options, table result schemas,
+  and usage-log fields stable unless the task explicitly changes the public API.
+- Keep provider credentials out of SQL arguments. Use environment variables or
+  `TYPE duckdb_ai` DuckDB secrets.
+- Keep deterministic tests free of live network calls. Use
+  `ai_request_json(...)` and mock-provider tests for request-shape and provider
+  behavior.
+- Only run live Ollama or remote-provider smoke tests when the task explicitly
+  asks for them or provides credentials/context.
+- If Linux container validation is needed on this machine, prefer a copy under
+  `/Users/leov/Documents/...` and set `CMAKE_BUILD_PARALLEL_LEVEL=1` to avoid
+  local Docker/Colima memory pressure.
+
+## Documentation Guidance
+
+- Document public SQL functions in `docs/functions.md` using DuckDB-style
+  reference sections: overview table, description, example, and result shape.
+- Keep `README.md` as the high-level usage entry point and link to deeper docs
+  instead of duplicating the full function reference.
+- When adding a Docusaurus page, wire it through `website/sidebars.ts` and run
+  the website typecheck/build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Thanks for improving `duckdb_ai`. This repository follows DuckDB extension
+tooling, keeps public SQL behavior stable, and makes provider interactions
+deterministic in the default test suite.
+
+## Before You Start
+
+- Keep changes scoped to the issue you are solving.
+- Avoid editing `duckdb/` and `extension-ci-tools/` unless the change explicitly
+  needs upstream extension infrastructure updates.
+- Keep `local-docs/` and other local corpora out of git.
+- Do not commit provider credentials, API keys, tokens, or generated secrets.
+- Prefer environment variables or `TYPE duckdb_ai` secrets for provider
+  configuration.
+- Do not add live-provider network calls to deterministic tests.
+
+## Project Layout
+
+- `src/` contains the C++ extension, SQL function registration, and provider
+  request handling.
+- `test/sql/duckdb_ai.test` contains SQLLogicTest coverage for deterministic
+  function behavior.
+- `test/smoke/mock_provider_smoke.py` runs the Python mock-provider smoke test.
+- `docs/` contains source documentation for the extension.
+- `website/` contains the Docusaurus documentation site.
+- `duckdb/` and `extension-ci-tools/` are vendored extension build
+  dependencies.
+
+## Local Validation
+
+Run extension checks from the repository root:
+
+```bash
+PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
+GEN=ninja make release
+GEN=ninja make test
+python3 test/smoke/mock_provider_smoke.py
+```
+
+Run documentation site checks from `website/`:
+
+```bash
+npm run typecheck
+npm run build
+```
+
+If a command cannot be run in your environment, note the reason in the pull
+request.
+
+## SQL API Changes
+
+- Preserve public function names, named options, result schemas, and defaults
+  unless the change intentionally updates the SQL API.
+- Add or update SQLLogicTest coverage when function behavior, option parsing, or
+  result shape changes.
+- Prefer `ai_request_json` and deterministic mock-provider paths for request
+  shape coverage.
+- Keep live Ollama or remote-provider checks optional unless the task explicitly
+  requires them.
+- Update `README.md` for high-level user-facing changes.
+- Update `docs/functions.md` for every public SQL function that is added,
+  removed, or changed.
+
+## Documentation Changes
+
+- Use DuckDB-style function documentation: overview table, signature,
+  description, example, result shape, and option details where relevant.
+- Keep `README.md` focused on setup and common examples.
+- Put complete function reference material in `docs/functions.md`.
+- Wire new documentation pages through `website/sidebars.ts`.
+- Run the Docusaurus typecheck and build when changing the docs site.
+
+## Pull Request Checklist
+
+- The change is scoped and avoids unrelated formatting churn.
+- Relevant tests, builds, or docs checks pass locally.
+- Public SQL API changes are documented.
+- No credentials, generated secrets, or local-only corpora are committed.
+- Any skipped validation is called out with a concrete reason.

--- a/README.md
+++ b/README.md
@@ -1,233 +1,236 @@
 # duckdb_ai
 
-`duckdb_ai` is a DuckDB extension that lets SQL call AI model providers.
-It is based on [`duckdb/extension-template`](https://github.com/duckdb/extension-template).
+Run AI workflows directly inside DuckDB SQL.
 
-The first implementation slice includes:
-
-- `ai_complete(prompt[, model[, provider]])`: calls a configured AI provider and returns the completion text.
-- `ai_complete_json(prompt[, model[, provider]])`: asks for JSON-only output,
-  sends structured-output hints to providers that support them, validates the
-  returned text as a top-level JSON object or array, and returns it as `VARCHAR`.
-- `ai_complete_record(prompt, response_schema[, model[, provider]])`: table
-  function that asks for JSON, validates it against a top-level object schema,
-  and projects declared schema properties as typed DuckDB columns.
-- `ai_request_json(prompt[, model[, provider]])`: returns the provider request body without making a network call.
-- `ai_embed(text[, model[, provider]])`: calls a configured embedding provider and returns a `DOUBLE[]`.
-- `ai_embedding_request_json(text[, model[, provider]])`: returns the embedding request body without making a network call.
-- Task wrappers over completion models: `ai_summarize`, `ai_sentiment`,
-  `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, and
-  `ai_extract`.
-- Aggregate wrappers over completion models: `ai_summarize_agg(text)` and
-  `ai_agg(text, instruction)`, with constant model/provider/options evaluated
-  once per aggregate group.
-- `ai_similarity(left_text, right_text[, model[, provider]])`: embeds two
-  strings and returns cosine similarity.
-- `ai_is_read_only_sql(sql)` and `ai_validate_read_only_sql(sql)`: deterministic
-  parser gates for generated SQL; currently only a single `SELECT` statement is
-  accepted.
-- `ai_sql(question[, schema_context[, model[, provider]]])`: asks a model
-  for one DuckDB `SELECT` statement, strips common markdown code fences, and
-  rejects anything that does not pass the read-only parser gate. When
-  `schema_context` is omitted, the extension supplies local catalog context from
-  `ai_schema_prompt()`.
-- `ai_schema_prompt([include_tables])`: returns one `summary` row with deterministic
-  DuckDB catalog context for the current database. `include_tables` and
-  `exclude_tables` accept table, `schema.table`, or `catalog.schema.table`
-  names. `sample_rows` includes bounded per-table sample rows for local DuckDB
-  tables when the context is built during execution, and otherwise emits safe
-  sample query hints for bind-time SQL-assistant paths.
-- `ai_query_data(question[, schema_context[, model[, provider]]])`: table
-  function that generates one read-only DuckDB `SELECT` at bind time and runs it
-  as a subquery. It also defaults to `ai_schema_prompt()` context when
-  `schema_context` is omitted.
-- `ai_explain_sql(sql[, ...])`: table function that explains one read-only
-  DuckDB `SELECT` statement using optional schema context.
-- `ai_fix_sql(sql[, ...])`: table function that asks the model to rewrite a
-  broken query as one corrected read-only DuckDB `SELECT` statement.
-- `ai_fix_sql_line(sql[, error][, ...])`: table function that asks the model to
-  rewrite only the line identified by an error message.
-- Completion named options: `model`, `provider`, `temperature`,
-  `system_prompt`, `max_tokens`, `base_url`, `timeout_seconds`,
-  `retry_count`, `retry_backoff_ms`, `fail_on_error`, `secret`,
-  `response_format`, `response_schema`, `max_concurrent_requests`,
-  `min_request_interval_ms`, `input_token_price_per_million`,
-  `output_token_price_per_million`, `use_builtin_model_prices`, `log_tags`, and
-  `log_sample_rate`.
-- Embedding named options: `model`, `provider`, `base_url`,
-  `timeout_seconds`, `retry_count`, `retry_backoff_ms`, `secret`,
-  `fail_on_error`, `max_concurrent_requests`, `min_request_interval_ms`,
-  `input_token_price_per_million`, `use_builtin_model_prices`, `log_tags`, and
-  `log_sample_rate`.
-- `ai_provider_base_url(provider)`: returns the default base URL for a supported provider.
-- `ai_provider_protocol(provider)`: returns the internal request protocol for a supported provider.
-- `ai_usage()`: returns recent in-process AI completion and embedding usage events.
-- `ai_clear_usage()`: clears the in-process usage event buffer.
-- `ai_secrets()`: lists configured `duckdb_ai` secrets with credentials redacted.
-- `ai_models()`: returns the small built-in provider/model pricing catalog
-  used by opt-in cost estimation.
-
-Supported providers in this slice:
-
-| Provider | Protocol | Default base URL | API key environment variable |
-| --- | --- | --- | --- |
-| `ollama` | `ollama_chat` | `http://localhost:11434` | optional `OLLAMA_API_KEY` |
-| `openai` | `openai_chat` | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
-| `azure` | `openai_chat` | set `BASE_URL` or `AZURE_OPENAI_BASE_URL`; `/openai/v1` is appended when needed | `AZURE_OPENAI_API_KEY` |
-| `claude` / `anthropic` | `anthropic_messages` | `https://api.anthropic.com/v1` | `ANTHROPIC_API_KEY` |
-| `gemini` / `gcp` / `google` | `openai_chat` | `https://generativelanguage.googleapis.com/v1beta/openai` | `GEMINI_API_KEY` |
-| `mistral` | `openai_chat` | `https://api.mistral.ai/v1` | `MISTRAL_API_KEY` |
-| `zai` | `openai_chat` | `https://open.bigmodel.cn/api/paas/v4` | `ZAI_API_KEY` |
-| `deepseek` | `openai_chat` | `https://api.deepseek.com` | `DEEPSEEK_API_KEY` |
-| `openrouter` | `openai_chat` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
-| `openai_compatible` / `local` | `openai_chat` | set `BASE_URL` for the gateway, e.g. Ollama `/v1`, vLLM, LM Studio, or LiteLLM | optional `OPENAI_COMPATIBLE_API_KEY` |
-
-Provider-specific values can be overridden with `<PROVIDER>_BASE_URL`,
-`<PROVIDER>_MODEL`, and `<PROVIDER>_API_KEY`. Generic overrides are
-`DUCKDB_AI_PROVIDER`, `DUCKDB_AI_MODEL`, `DUCKDB_AI_BASE_URL`, and
-`DUCKDB_AI_API_KEY`.
-
-DuckDB settings can also provide session defaults:
-
-```sql
-SET duckdb_ai_provider = 'openai';
-SET duckdb_ai_model = 'gpt-4o-mini';
-SET duckdb_ai_base_url = 'https://api.openai.com/v1';
-SET duckdb_ai_timeout_seconds = 120;
-SET duckdb_ai_retry_count = 0;
-SET duckdb_ai_retry_backoff_ms = 1000;
-SET duckdb_ai_max_concurrent_requests = 4;
-SET duckdb_ai_min_request_interval_ms = 100;
-SET duckdb_ai_response_format = 'json_object';
-SET duckdb_ai_input_token_price_per_million = 0.15;
-SET duckdb_ai_output_token_price_per_million = 0.60;
-SET duckdb_ai_use_builtin_model_prices = true;
-SET duckdb_ai_log_endpoint = 'https://collector.example/ai-usage';
-SET duckdb_ai_log_format = 'generic_json';
-SET duckdb_ai_log_tags = 'warehouse=local,app=duckdb';
-SET duckdb_ai_log_sample_rate = 0.25;
-```
-
-## Usage
+`duckdb_ai` adds SQL functions for completions, structured JSON extraction,
+embeddings, natural-language filters, SQL generation, and usage tracking. Use it
+when you want to enrich local DuckDB analytics with models while keeping the
+workflow in SQL.
 
 ```sql
 LOAD duckdb_ai;
 
-SELECT ai_request_json('summarize this text', 'gpt-4o-mini', 'openai');
-SELECT ai_request_json(
-    'summarize this text',
-    provider := 'openai',
-    model := 'gpt-4o-mini',
-    system_prompt := 'answer tersely',
-    temperature := 0.2,
-    max_tokens := 128,
-    timeout_seconds := 30
+SELECT ai_summarize(
+    'DuckDB is an analytical database built for fast local queries.',
+    provider := 'ollama',
+    model := 'llama3.2'
 );
-SELECT ai_complete('write one sentence about DuckDB', 'llama3.2', 'ollama');
-SELECT ai_complete(
-    'write one sentence about DuckDB',
-    provider := 'openai',
-    model := 'gpt-4o-mini',
-    fail_on_error := false
-);
-CREATE OR REPLACE SECRET openai_ai (
-    TYPE duckdb_ai,
-    API_KEY '...',
-    AI_PROVIDER 'openai'
-);
-SELECT ai_complete(
-    'write one sentence about DuckDB',
-    secret := 'openai_ai'
-);
-SELECT ai_request_json(
-    'extract a summary',
-    provider := 'openai',
-    response_format := 'json_object'
-);
-SELECT ai_complete_json(
-    'extract a compact company profile for DuckDB',
-    provider := 'openai',
-    response_schema := '{"type":"object","properties":{"name":{"type":"string"},"summary":{"type":"string"}},"required":["name","summary"],"additionalProperties":false}'
-);
-SELECT *
-FROM ai_complete_record(
-    'extract a compact company profile for DuckDB',
-    '{"type":"object","properties":{"name":{"type":"string"},"score":{"type":"number"},"tags":{"type":"array","items":{"type":"string"}}},"required":["name"],"additionalProperties":false}',
-    provider := 'openai'
-);
-SELECT ai_embed(
-    'DuckDB is an analytical database',
-    provider := 'openai',
-    model := 'text-embedding-3-small'
-);
-SELECT ai_similarity('DuckDB analytics', 'analytical SQL database');
-SELECT ai_summarize('DuckDB is an analytical database built for fast local queries.');
-SELECT ai_translate('hello', 'Dutch');
-SELECT ai_classify('invoice overdue', 'billing, support');
-SELECT ai_extract('name: DuckDB', 'name');
-SELECT customer_id, ai_summarize_agg(note ORDER BY created_at)
-FROM support_notes
-GROUP BY customer_id;
-SELECT ai_agg(message, 'List the top three recurring themes')
-FROM customer_feedback;
-SELECT summary
-FROM ai_schema_prompt(
-    include_tables := ['main.orders'],
-    exclude_tables := ['main.internal_audit'],
-    sample_rows := 3
-);
-SELECT ai_sql(
-    'count orders by status'
-);
-SELECT *
-FROM ai_query_data(
-    'count orders by status',
-    schema_context := (SELECT summary FROM ai_schema_prompt(include_tables := ['main.orders']))
-);
-SELECT explanation
-FROM ai_explain_sql(
-    'SELECT status, count(*) FROM orders GROUP BY status',
-    include_tables := ['main.orders'],
-    sample_rows := 3
-);
-SELECT sql
-FROM ai_fix_sql('SEELECT status, count(*) FRUM orders GROUP BY status');
-SELECT line_number, replacement_line
-FROM ai_fix_sql_line(
-    'SEELECT status FROM orders',
-    error := 'Parser Error: syntax error at or near "SEELECT" LINE 1'
-);
-SELECT ai_validate_read_only_sql('SELECT count(*) FROM my_table');
-SELECT * FROM ai_usage();
-SELECT * FROM ai_secrets();
-SELECT * FROM ai_models();
 ```
 
-`base_url` is useful for local gateways and tests. API keys are resolved from
-environment variables or DuckDB Secrets, not from direct function arguments.
+## What You Can Do
 
-DuckDB Secrets are also supported for credentials:
+- Summarize, translate, redact, classify, and extract text from SQL queries.
+- Generate valid JSON or typed DuckDB columns from model output.
+- Create embeddings and compare text with cosine similarity.
+- Ask questions about local tables and generate read-only DuckDB `SELECT`
+  statements.
+- Route model calls across local Ollama, hosted providers, and
+  OpenAI-compatible gateways.
+- Store credentials in DuckDB secrets instead of passing API keys through SQL
+  function arguments.
+- Inspect local usage events and optionally send privacy-minimized usage logs to
+  your own collector.
+
+## Status
+
+This is a preview extension. The current repository is source-first: public
+binary installation is not configured yet. See
+[`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md) for the current distribution
+stance.
+
+## Quick Start
+
+Build the extension once, then run the bundled DuckDB shell:
+
+```sh
+git submodule update --init --recursive
+GEN=ninja make release
+./build/release/duckdb
+```
+
+Inside DuckDB:
 
 ```sql
+LOAD duckdb_ai;
+SELECT ai_provider_protocol('openai');
+```
+
+For a local model with Ollama:
+
+```sh
+ollama serve
+ollama pull llama3.2
+```
+
+```sql
+LOAD duckdb_ai;
+
+SET duckdb_ai_provider = 'ollama';
+SET duckdb_ai_model = 'llama3.2';
+
+SELECT ai_complete('Write one sentence about DuckDB.');
+```
+
+For OpenAI, store the API key in a DuckDB secret:
+
+```sql
+LOAD duckdb_ai;
+
 CREATE OR REPLACE SECRET openai_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'openai',
     API_KEY '...',
-    MODEL 'gpt-4o-mini',
-    BASE_URL 'https://api.openai.com/v1'
+    MODEL 'gpt-4o-mini'
 );
 
-SELECT ai_complete('hello', secret := 'openai_ai');
+SELECT ai_complete(
+    'Write one sentence about DuckDB.',
+    secret := 'openai_ai'
+);
 ```
 
-`API_KEY` is redacted by `duckdb_secrets()`. `AI_PROVIDER` is required.
-`MODEL` and `BASE_URL` are optional. If no explicit `SCOPE` is provided, the
-extension scopes the secret to the normalized provider name so calls with
-`provider := 'openai'` can discover it automatically.
+`API_KEY` values stored in `TYPE duckdb_ai` secrets are redacted when secrets are
+listed.
 
-Use the same secret shape for every provider:
+## Everyday Examples
+
+Summarize support notes by customer:
 
 ```sql
+SELECT
+    customer_id,
+    ai_summarize_agg(note ORDER BY created_at) AS summary
+FROM support_notes
+GROUP BY customer_id;
+```
+
+Classify messages:
+
+```sql
+SELECT
+    message_id,
+    ai_classify(body, 'billing, support, sales, other') AS category
+FROM inbox;
+```
+
+Filter rows with a natural-language predicate:
+
+```sql
+SELECT *
+FROM tickets
+WHERE ai_filter(description, 'mentions an urgent billing problem');
+```
+
+Extract structured data as typed columns:
+
+```sql
+SELECT *
+FROM ai_complete_record(
+    'Extract a company profile for DuckDB.',
+    '{
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "category": {"type": "string"},
+        "confidence": {"type": "number"}
+      },
+      "required": ["name", "category"]
+    }',
+    provider := 'openai',
+    model := 'gpt-4o-mini'
+);
+```
+
+Create embeddings and compare text:
+
+```sql
+SELECT ai_similarity(
+    'DuckDB analytics',
+    'analytical SQL database',
+    provider := 'openai',
+    model := 'text-embedding-3-small'
+);
+```
+
+Generate and run read-only SQL over local tables:
+
+```sql
+SELECT summary
+FROM ai_schema_prompt(include_tables := ['main.orders']);
+
+SELECT ai_sql(
+    'count orders by status',
+    schema_context := (
+        SELECT summary
+        FROM ai_schema_prompt(include_tables := ['main.orders'])
+    )
+);
+
+SELECT *
+FROM ai_query_data(
+    'count orders by status',
+    schema_context := (
+        SELECT summary
+        FROM ai_schema_prompt(include_tables := ['main.orders'])
+    )
+);
+```
+
+`ai_sql` and `ai_query_data` only accept one parser-valid read-only DuckDB
+`SELECT` statement before returning or executing generated SQL.
+
+## Function Map
+
+| Need | Functions |
+| --- | --- |
+| Completion text | `ai_complete`, `ai_request_json` |
+| Structured output | `ai_complete_json`, `ai_complete_record` |
+| Text tasks | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_extract`, `ai_filter` |
+| Aggregates | `ai_summarize_agg`, `ai_agg` |
+| Embeddings | `ai_embed`, `ai_embedding_request_json`, `ai_similarity` |
+| SQL assistant | `ai_schema_prompt`, `ai_sql`, `ai_query_data`, `ai_explain_sql`, `ai_fix_sql`, `ai_fix_sql_line` |
+| SQL safety checks | `ai_is_read_only_sql`, `ai_validate_read_only_sql` |
+| Provider metadata | `ai_provider_base_url`, `ai_provider_protocol`, `ai_models` |
+| Usage and secrets | `ai_usage`, `ai_clear_usage`, `ai_secrets` |
+| Local utility | `ai_count_tokens` |
+
+The full SQL reference is in [`docs/functions.md`](docs/functions.md).
+End-to-end setup examples for each provider are in
+[`docs/provider-guides.md`](docs/provider-guides.md).
+
+## Providers
+
+| Provider | Use it with | Default base URL / key |
+| --- | --- | --- |
+| `ollama` | Local Ollama chat and embedding models | `http://localhost:11434`; optional `OLLAMA_API_KEY` |
+| `openai` | OpenAI chat and embedding models | `https://api.openai.com/v1`; `OPENAI_API_KEY` |
+| `azure` | Azure OpenAI deployments | Set `BASE_URL` or `AZURE_OPENAI_BASE_URL`; `AZURE_OPENAI_API_KEY` |
+| `claude` / `anthropic` | Anthropic Claude models | `https://api.anthropic.com/v1`; `ANTHROPIC_API_KEY` |
+| `gemini` / `gcp` / `google` | Gemini through the OpenAI-compatible endpoint | `GEMINI_API_KEY` |
+| `mistral` | Mistral chat models | `https://api.mistral.ai/v1`; `MISTRAL_API_KEY` |
+| `zai` | Z.ai / BigModel chat models | `https://open.bigmodel.cn/api/paas/v4`; `ZAI_API_KEY` |
+| `deepseek` | DeepSeek chat models | `https://api.deepseek.com`; `DEEPSEEK_API_KEY` |
+| `openrouter` | OpenRouter model routing | `https://openrouter.ai/api/v1`; `OPENROUTER_API_KEY` |
+| `openai_compatible` / `local` | vLLM, LM Studio, LiteLLM, Ollama `/v1`, or another gateway | Set `BASE_URL`; optional `OPENAI_COMPATIBLE_API_KEY` |
+
+You can configure providers three ways:
+
+```sql
+-- Session defaults.
+SET duckdb_ai_provider = 'openai';
+SET duckdb_ai_model = 'gpt-4o-mini';
+SET duckdb_ai_timeout_seconds = 120;
+
+-- Per-call overrides.
+SELECT ai_complete(
+    'Summarize this in one sentence.',
+    provider := 'openai',
+    model := 'gpt-4o-mini',
+    temperature := 0.2,
+    max_tokens := 128
+);
+
+-- DuckDB secrets.
 CREATE OR REPLACE SECRET local_llm (
     TYPE duckdb_ai,
     AI_PROVIDER 'local',
@@ -235,155 +238,121 @@ CREATE OR REPLACE SECRET local_llm (
     MODEL 'llama3.2'
 );
 
-CREATE OR REPLACE SECRET azure_llm (
-    TYPE duckdb_ai,
-    AI_PROVIDER 'azure',
-    API_KEY '...',
-    BASE_URL 'https://my-resource.openai.azure.com',
-    MODEL 'gpt-4o'
+SELECT ai_complete('hello', secret := 'local_llm');
+```
+
+Provider-specific environment variables such as `OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, and `GEMINI_API_KEY` are also supported. Generic overrides
+include `DUCKDB_AI_PROVIDER`, `DUCKDB_AI_MODEL`, `DUCKDB_AI_BASE_URL`, and
+`DUCKDB_AI_API_KEY`.
+
+## Structured Output
+
+Use `ai_complete_json` when you need valid JSON:
+
+```sql
+SELECT ai_complete_json(
+    'Return {"name": "...", "summary": "..."} for DuckDB.',
+    provider := 'openai',
+    response_schema := '{
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "summary": {"type": "string"}
+      },
+      "required": ["name", "summary"]
+    }'
 );
-
-SELECT name, provider, model, base_url, has_api_key
-FROM ai_secrets();
 ```
 
-`response_format` accepts `text`, `json_object`, or `json_schema`.
-`response_schema` should be a JSON Schema object; when present, it implies
-`json_schema` mode. OpenAI-compatible providers receive a native
-`response_format` payload, and Ollama receives `format`. Claude has no native
-payload field in this slice; use `ai_complete_json` for JSON-only prompting and
-local validation. Local `ai_complete_json` validation enforces the common JSON
-Schema keywords `type`, `properties`, `required`, `additionalProperties`,
-`patternProperties`, `propertyNames`, `dependentRequired`, `minProperties`,
-`maxProperties`, `items`, `minItems`, `maxItems`, `uniqueItems`, `contains`,
-`minContains`, `maxContains`, `minimum`, `maximum`, `exclusiveMinimum`,
-`exclusiveMaximum`, `multipleOf`, `minLength`, `maxLength`, `pattern`, `enum`,
-`const`, `allOf`, `anyOf`, `oneOf`, and `not`.
-This is the initial pragmatic local subset, not a claim of full JSON Schema
-draft parity.
+Use `ai_complete_record` when you want DuckDB columns. Scalar schema properties
+become `VARCHAR`, `BOOLEAN`, `BIGINT`, or `DOUBLE`; supported nested objects and
+arrays become `STRUCT` and `LIST` values.
 
-`ai_complete_record` uses the same validation path and projects supported
-object schemas as DuckDB columns. Scalar properties become `VARCHAR`, `BOOLEAN`,
-`BIGINT`, or `DOUBLE`; nested object schemas become `STRUCT`; supported arrays
-become typed `LIST`s, including arrays of nested object schemas. Unsupported
-schema shapes are returned as JSON text.
+## Safety And Privacy
 
-Retries are explicit and disabled by default. Set `retry_count := 2` or
-`SET duckdb_ai_retry_count = 2` to retry curl failures and HTTP 429/5xx
-responses. `retry_backoff_ms` controls the fixed delay between attempts.
-Set `max_concurrent_requests := 4` to cap in-process provider HTTP calls, and
-`min_request_interval_ms := 100` to enforce a minimum gap between provider
-request starts. These controls apply to completion and embedding provider calls;
-usage-log delivery is not counted against the provider limit.
+- Request-preview functions such as `ai_request_json` and
+  `ai_embedding_request_json` build provider request bodies without making a
+  network call.
+- API keys are resolved from environment variables or DuckDB secrets, not direct
+  SQL arguments.
+- Provider error messages redact the active API key before surfacing errors.
+- Usage logs do not include prompt, input, or response text unless
+  `duckdb_ai_log_include_text` or `DUCKDB_AI_LOG_INCLUDE_TEXT=1` is enabled.
+- Generated SQL is guarded by `ai_validate_read_only_sql`, which only accepts one
+  read-only DuckDB `SELECT`.
 
-For OpenAI-compatible providers, set the provider API key in the environment
-before starting DuckDB:
+By default, provider errors fail the SQL query. For exploratory workflows, use
+`fail_on_error := false` to return `NULL` instead:
 
-```sh
-export OPENAI_API_KEY='...'
+```sql
+SELECT ai_complete(
+    'Try this with a best-effort provider call.',
+    provider := 'openai',
+    fail_on_error := false
+);
 ```
 
-For local Ollama, start Ollama first:
+## Usage And Cost Visibility
 
-```sh
-ollama serve
-ollama pull llama3.2
+Successful completions, embeddings, and local `ai_schema_prompt` calls are kept
+in a local in-process ring buffer:
+
+```sql
+SELECT * FROM ai_usage();
+SELECT * FROM ai_clear_usage();
 ```
 
-## Usage logging
+Cost estimates are opt-in. Either pass prices per call or enable the built-in
+model price catalog:
 
-Set `DUCKDB_AI_LOG_ENDPOINT` to POST privacy-minimized usage events after a
-successful completion or embedding request. The event includes provider, protocol, model,
-prompt/response character counts for completions, dimensions for embeddings,
-token counts when the provider returns them, elapsed milliseconds, and HTTP
-status. It does not include prompt, input, or response text unless
-`DUCKDB_AI_LOG_INCLUDE_TEXT=1` is set.
-
-`DUCKDB_AI_LOG_FORMAT`, `SET duckdb_ai_log_format = ...`, or
-`log_format := ...` controls the outbound payload shape. `generic_json` is the
-default compact extension payload. `otlp_json` emits an OpenTelemetry Protocol
-JSON logs envelope for collectors; point the endpoint at the collector's log
-ingest path, usually `/v1/logs`.
-
-Successful completions, embeddings, and local `ai_schema_prompt` calls are also
-recorded in a local in-process ring buffer. Query it with
-`SELECT * FROM ai_usage();`. The buffer keeps the latest 1,024 events and can be
-cleared with `SELECT * FROM ai_clear_usage();`.
-
-Cost estimates are disabled by default. Pass
-`input_token_price_per_million := ...` and, for completions,
-`output_token_price_per_million := ...`, or set the matching DuckDB settings, to
-add `estimated_cost_usd` to usage events and logs when the provider returns token
-counts.
-
-You can also opt into the small built-in catalog with
-`use_builtin_model_prices := true`,
-`SET duckdb_ai_use_builtin_model_prices = true`, or
-`DUCKDB_AI_USE_BUILTIN_MODEL_PRICES=1`. Explicit per-call or per-session
-prices take precedence over catalog prices. Inspect the catalog with
-`SELECT * FROM ai_models();`; each row includes the provider, model,
-operation, USD-per-million-token prices, source URL, source note, and
-`last_reviewed` date. Provider pricing changes often, so treat the built-in
-catalog as a convenience for common models rather than a billing authority.
-
-By default, logging failures do not fail the SQL query. Set
-`DUCKDB_AI_LOG_STRICT=1` or `SET duckdb_ai_log_strict = true` to make log
-delivery failures raise an error. `SET duckdb_ai_log_include_text = true`
-has the same effect as `DUCKDB_AI_LOG_INCLUDE_TEXT=1`.
-
-Attach lightweight labels with `log_tags := 'tenant=dev,job=nightly'`,
-`SET duckdb_ai_log_tags = '...'`, or `DUCKDB_AI_LOG_TAGS`. Sample outbound
-log delivery with `log_sample_rate := 0.1`,
-`SET duckdb_ai_log_sample_rate = 0.1`, or `DUCKDB_AI_LOG_SAMPLE_RATE=0.1`.
-Sampling is deterministic for the event provider, model, event type, and input
-text; the default rate is `1.0`.
-
-## Provider errors and redaction
-
-Non-2xx provider responses are normalized into errors that include provider,
-protocol, model, HTTP status, and provider error `type`/`code` when present.
-The active API key is redacted before provider error bodies are surfaced.
-Request-preview functions do not include credentials, and usage logs do not
-include credentials.
-
-## Building
-
-Initialize submodules, then build:
-
-```sh
-git submodule update --init --recursive
-make
+```sql
+SET duckdb_ai_use_builtin_model_prices = true;
+SELECT * FROM ai_models();
 ```
 
-The main artifacts are:
+Provider pricing changes often, so treat the built-in catalog as a convenience
+for common models rather than a billing authority.
 
-```sh
-./build/release/duckdb
-./build/release/test/unittest
-./build/release/extension/duckdb_ai/duckdb_ai.duckdb_extension
+To send usage events to your own collector:
+
+```sql
+SET duckdb_ai_log_endpoint = 'https://collector.example/ai-usage';
+SET duckdb_ai_log_format = 'generic_json';
+SET duckdb_ai_log_tags = 'warehouse=local,app=duckdb';
 ```
 
-See [`docs/UPDATING.md`](docs/UPDATING.md) for DuckDB submodule update notes,
-[`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md) for the current CI and
-distribution stance, and [`docs/RELEASING.md`](docs/RELEASING.md) for preview
-and stable release/versioning gates. Current local platform evidence is recorded in
-[`docs/VALIDATION.md`](docs/VALIDATION.md).
+Use `otlp_json` when sending logs to an OpenTelemetry collector endpoint.
 
-## Testing
+## Reliability Controls
 
-```sh
-make test
+Retries are disabled by default. Enable them explicitly for transient provider
+errors:
+
+```sql
+SELECT ai_complete(
+    'Summarize this.',
+    retry_count := 2,
+    retry_backoff_ms := 1000
+);
 ```
 
-The checked-in SQL tests avoid live network calls. Use `ai_request_json` for
-deterministic request-shape checks and run provider smoke tests manually with
-real credentials or a local Ollama server. See
-[`docs/SMOKE_TESTING.md`](docs/SMOKE_TESTING.md) for mock, Ollama, and remote
-provider smoke commands.
+For batch workloads, cap provider concurrency and rate:
 
-To run a local mock-provider smoke test for `ai_complete`, `ai_usage()`, and the
-HTTP log endpoint:
-
-```sh
-python3 test/smoke/mock_provider_smoke.py
+```sql
+SET duckdb_ai_max_concurrent_requests = 4;
+SET duckdb_ai_min_request_interval_ms = 100;
 ```
+
+These controls apply to completion and embedding calls.
+
+## Learn More
+
+- [`docs/functions.md`](docs/functions.md): complete SQL function reference.
+- [`docs/provider-guides.md`](docs/provider-guides.md): end-to-end examples for
+  every supported provider.
+- [`docs/SMOKE_TESTING.md`](docs/SMOKE_TESTING.md): local mock-provider, Ollama,
+  and remote-provider smoke checks.
+- [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md): current install and release
+  stance.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md): development workflow for contributors.

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1,0 +1,625 @@
+---
+sidebar_position: 2
+---
+
+# SQL function reference
+
+This page documents the public SQL surface registered by the `duckdb_ai`
+extension. The layout follows the DuckDB function reference style: a compact
+overview table first, then each function with description, example, and result
+shape.
+
+Table functions must be called from `FROM` or with `CALL`, for example:
+
+```sql
+SELECT *
+FROM ai_usage();
+```
+
+## Function overview
+
+| Function | Type | Description |
+| --- | --- | --- |
+| `ai_complete(prompt[, model[, provider]])` | Scalar | Calls a completion model and returns text. |
+| `ai_complete_json(prompt[, model[, provider]])` | Scalar | Calls a completion model and validates the response as a JSON object or array. |
+| `ai_complete_record(prompt, response_schema[, model[, provider]])` | Table | Calls a completion model and projects a JSON object into typed columns from a JSON Schema. |
+| `ai_request_json(prompt[, model[, provider]])` | Scalar | Returns the completion request JSON without making a network call. |
+| `ai_embed(text[, model[, provider]])` | Scalar | Calls an embedding model and returns `DOUBLE[]`. |
+| `ai_embedding_request_json(text[, model[, provider]])` | Scalar | Returns the embedding request JSON without making a network call. |
+| `ai_similarity(left_text, right_text[, model[, provider]])` | Scalar | Embeds two strings and returns cosine similarity. |
+| `ai_summarize(text[, model[, provider]])` | Scalar | Summarizes text with a completion model. |
+| `ai_sentiment(text[, model[, provider]])` | Scalar | Classifies text as positive, neutral, or negative. |
+| `ai_fix_grammar(text[, model[, provider]])` | Scalar | Rewrites text with corrected grammar, spelling, and punctuation. |
+| `ai_redact(text[, model[, provider]])` | Scalar | Masks direct personal data, credentials, secrets, and payment identifiers. |
+| `ai_translate(text, target_language[, model[, provider]])` | Scalar | Translates text to the target language. |
+| `ai_classify(text, labels[, model[, provider]])` | Scalar | Chooses one label from a comma-separated label list. |
+| `ai_extract(text, instruction[, model[, provider]])` | Scalar | Extracts requested information from text. |
+| `ai_filter(text, predicate[, model[, provider]])` | Scalar | Evaluates a natural-language predicate and returns `BOOLEAN`. |
+| `ai_agg(text, instruction[, model[, provider]])` | Aggregate | Runs one completion over grouped text values and an instruction. |
+| `ai_summarize_agg(text[, model[, provider]])` | Aggregate | Summarizes grouped text values. |
+| `ai_sql(question[, schema_context[, model[, provider]]])` | Scalar | Generates one read-only DuckDB `SELECT` statement. |
+| `ai_query_data(question[, schema_context[, model[, provider]]])` | Table | Generates one read-only `SELECT` at bind time and executes it as a subquery. |
+| `ai_schema_prompt([include_tables])` | Table | Returns deterministic local catalog context for prompting SQL models. |
+| `ai_explain_sql(sql[, ...])` | Table | Explains one read-only DuckDB `SELECT` statement. |
+| `ai_fix_sql(sql[, ...])` | Table | Rewrites a broken query as one corrected read-only DuckDB `SELECT`. |
+| `ai_fix_sql_line(sql[, error][, ...])` | Table | Rewrites only the line identified by an error message. |
+| `ai_is_read_only_sql(sql)` | Scalar | Returns whether SQL is one parser-valid read-only `SELECT`. |
+| `ai_validate_read_only_sql(sql)` | Scalar | Returns normalized SQL or raises if it is not one read-only `SELECT`. |
+| `ai_count_tokens(text[, model[, provider]])` | Scalar | Returns a local approximate token count. |
+| `ai_provider_base_url(provider)` | Scalar | Returns the default base URL for a supported provider. |
+| `ai_provider_protocol(provider)` | Scalar | Returns the internal provider protocol. |
+| `ai_usage()` | Table | Returns recent in-process AI usage events. |
+| `ai_clear_usage()` | Table | Clears the in-process usage event buffer. |
+| `ai_secrets()` | Table | Lists configured `duckdb_ai` secrets with credentials redacted. |
+| `ai_models()` | Table | Returns the built-in provider/model pricing catalog. |
+
+## Completion functions
+
+#### `ai_complete(prompt[, model[, provider]])`
+
+Description: Calls a configured completion provider and returns the completion
+text as `VARCHAR`.
+
+Example:
+
+```sql
+SELECT ai_complete(
+    'Write one sentence about DuckDB.',
+    provider := 'openai',
+    model := 'gpt-4o-mini'
+);
+```
+
+Result: `VARCHAR`
+
+#### `ai_complete_json(prompt[, model[, provider]])`
+
+Description: Calls a completion provider, asks for JSON-only output, and
+validates that the returned text is a top-level JSON object or array. If
+`response_schema` or `json_schema` is supplied, the output is also validated
+against the supported JSON Schema subset.
+
+Example:
+
+```sql
+SELECT ai_complete_json(
+    'Extract a compact company profile for DuckDB.',
+    provider := 'openai',
+    response_schema := '{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}'
+);
+```
+
+Result: `VARCHAR` containing valid JSON
+
+#### `ai_complete_record(prompt, response_schema[, model[, provider]])`
+
+Description: Table function that calls a completion provider, validates the JSON
+response against `response_schema`, and projects top-level schema properties as
+typed DuckDB columns.
+
+Example:
+
+```sql
+SELECT *
+FROM ai_complete_record(
+    'Extract a compact company profile for DuckDB.',
+    '{"type":"object","properties":{"name":{"type":"string"},"score":{"type":"number"}},"required":["name"]}',
+    provider := 'openai'
+);
+```
+
+Result: one row with columns derived from `response_schema`
+
+#### `ai_request_json(prompt[, model[, provider]])`
+
+Description: Builds the provider completion request body and returns it without
+making a network call. Use this for deterministic tests and provider debugging.
+
+Example:
+
+```sql
+SELECT ai_request_json(
+    'Summarize this text.',
+    provider := 'openai',
+    model := 'gpt-4o-mini',
+    temperature := 0.2
+);
+```
+
+Result: `VARCHAR` containing provider request JSON
+
+## Embedding functions
+
+#### `ai_embed(text[, model[, provider]])`
+
+Description: Calls an embedding provider and returns a DuckDB list of doubles.
+
+Example:
+
+```sql
+SELECT ai_embed(
+    'DuckDB is an analytical database.',
+    provider := 'openai',
+    model := 'text-embedding-3-small'
+);
+```
+
+Result: `DOUBLE[]`
+
+#### `ai_embedding_request_json(text[, model[, provider]])`
+
+Description: Builds the provider embedding request body and returns it without
+making a network call.
+
+Example:
+
+```sql
+SELECT ai_embedding_request_json(
+    'DuckDB vector smoke',
+    provider := 'openai',
+    model := 'text-embedding-3-small'
+);
+```
+
+Result: `VARCHAR` containing provider request JSON
+
+#### `ai_similarity(left_text, right_text[, model[, provider]])`
+
+Description: Embeds both input strings with the same provider/model and returns
+cosine similarity.
+
+Example:
+
+```sql
+SELECT ai_similarity(
+    'DuckDB analytics',
+    'analytical SQL database',
+    provider := 'openai',
+    model := 'text-embedding-3-small'
+);
+```
+
+Result: `DOUBLE`
+
+## Task wrappers
+
+#### `ai_summarize(text[, model[, provider]])`
+
+Description: Summarizes text and returns only the summary.
+
+Example:
+
+```sql
+SELECT ai_summarize('DuckDB is an analytical database built for fast local queries.');
+```
+
+Result: `VARCHAR`
+
+#### `ai_sentiment(text[, model[, provider]])`
+
+Description: Classifies the sentiment of text as positive, neutral, or negative.
+
+Example:
+
+```sql
+SELECT ai_sentiment('The import finished quickly and the query is fast.');
+```
+
+Result: `VARCHAR`
+
+#### `ai_fix_grammar(text[, model[, provider]])`
+
+Description: Fixes grammar, spelling, and punctuation while preserving meaning.
+
+Example:
+
+```sql
+SELECT ai_fix_grammar('duckdb are fast');
+```
+
+Result: `VARCHAR`
+
+#### `ai_redact(text[, model[, provider]])`
+
+Description: Masks direct personal data, credentials, secrets, and payment
+identifiers.
+
+Example:
+
+```sql
+SELECT ai_redact('email alice@example.com');
+```
+
+Result: `VARCHAR`
+
+#### `ai_translate(text, target_language[, model[, provider]])`
+
+Description: Translates text to `target_language` while preserving meaning and
+formatting.
+
+Example:
+
+```sql
+SELECT ai_translate('hello', 'Dutch');
+```
+
+Result: `VARCHAR`
+
+#### `ai_classify(text, labels[, model[, provider]])`
+
+Description: Classifies text into exactly one label from `labels`.
+
+Example:
+
+```sql
+SELECT ai_classify('invoice overdue', 'billing, support');
+```
+
+Result: `VARCHAR`
+
+#### `ai_extract(text, instruction[, model[, provider]])`
+
+Description: Extracts requested information from text. When the instruction asks
+for structured data, the function prompts for concise JSON.
+
+Example:
+
+```sql
+SELECT ai_extract('name: DuckDB', 'name');
+```
+
+Result: `VARCHAR`
+
+#### `ai_filter(text, predicate[, model[, provider]])`
+
+Description: Evaluates whether `text` matches a natural-language predicate. The
+model output must parse as true or false.
+
+Example:
+
+```sql
+SELECT ai_filter('invoice overdue', 'is about billing');
+```
+
+Result: `BOOLEAN`
+
+## Aggregate functions
+
+#### `ai_agg(text, instruction[, model[, provider]])`
+
+Description: Collects grouped input text up to `max_context_chars`, then calls
+one completion model with `instruction`.
+
+Example:
+
+```sql
+SELECT ai_agg(message, 'List the top three recurring themes')
+FROM customer_feedback;
+```
+
+Result: `VARCHAR`
+
+#### `ai_summarize_agg(text[, model[, provider]])`
+
+Description: Collects grouped input text and returns one summary per group.
+
+Example:
+
+```sql
+SELECT customer_id, ai_summarize_agg(note ORDER BY created_at)
+FROM support_notes
+GROUP BY customer_id;
+```
+
+Result: `VARCHAR`
+
+## SQL assistant functions
+
+#### `ai_sql(question[, schema_context[, model[, provider]]])`
+
+Description: Calls a completion model to generate one DuckDB `SELECT` statement,
+strips common markdown code fences, and rejects output that is not one read-only
+`SELECT`. When `schema_context` is omitted, the function builds local catalog
+context from `ai_schema_prompt()`.
+
+Example:
+
+```sql
+SELECT ai_sql('count orders by status');
+```
+
+Result: `VARCHAR` containing a read-only DuckDB `SELECT`
+
+#### `ai_query_data(question[, schema_context[, model[, provider]]])`
+
+Description: Table function that generates one read-only DuckDB `SELECT` at bind
+time and executes it as a subquery. Use `fail_on_error := false` to return an
+empty error-shaped relation instead of failing the bind.
+
+Example:
+
+```sql
+SELECT *
+FROM ai_query_data(
+    'count orders by status',
+    schema_context := (SELECT summary FROM ai_schema_prompt(include_tables := ['main.orders']))
+);
+```
+
+Result: the result columns of the generated query
+
+#### `ai_schema_prompt([include_tables])`
+
+Description: Table function that returns one `summary` row with deterministic
+DuckDB catalog context. `include_tables` and `exclude_tables` accept table,
+`schema.table`, or `catalog.schema.table` names. `sample_rows` includes bounded
+sample rows for local DuckDB tables during execution.
+
+Example:
+
+```sql
+SELECT summary
+FROM ai_schema_prompt(
+    include_tables := ['main.orders'],
+    exclude_tables := ['main.internal_audit'],
+    sample_rows := 3
+);
+```
+
+Result: one `summary VARCHAR` column
+
+#### `ai_explain_sql(sql[, ...])`
+
+Description: Table function that explains one read-only DuckDB `SELECT`
+statement using optional schema context.
+
+Example:
+
+```sql
+SELECT explanation
+FROM ai_explain_sql(
+    'SELECT status, count(*) FROM orders GROUP BY status',
+    include_tables := ['main.orders']
+);
+```
+
+Result: one `explanation VARCHAR` column
+
+#### `ai_fix_sql(sql[, ...])`
+
+Description: Table function that asks the model to rewrite a broken query as one
+corrected read-only DuckDB `SELECT` statement.
+
+Example:
+
+```sql
+SELECT sql
+FROM ai_fix_sql('SEELECT status, count(*) FRUM orders GROUP BY status');
+```
+
+Result: one `sql VARCHAR` column
+
+#### `ai_fix_sql_line(sql[, error][, ...])`
+
+Description: Table function that asks the model to rewrite only the line
+identified by an error message. The result includes the detected line number and
+replacement line.
+
+Example:
+
+```sql
+SELECT line_number, replacement_line
+FROM ai_fix_sql_line(
+    'SEELECT status FROM orders',
+    error := 'Parser Error: syntax error at or near "SEELECT" LINE 1'
+);
+```
+
+Result: `line_number BIGINT`, `replacement_line VARCHAR`
+
+## SQL validation functions
+
+#### `ai_is_read_only_sql(sql)`
+
+Description: Returns whether `sql` parses as exactly one read-only DuckDB
+`SELECT` statement.
+
+Example:
+
+```sql
+SELECT ai_is_read_only_sql('SELECT 42');
+```
+
+Result: `BOOLEAN`
+
+#### `ai_validate_read_only_sql(sql)`
+
+Description: Returns the input SQL when it is one read-only DuckDB `SELECT`;
+otherwise raises an error.
+
+Example:
+
+```sql
+SELECT ai_validate_read_only_sql('SELECT count(*) FROM my_table');
+```
+
+Result: `VARCHAR`
+
+#### `ai_count_tokens(text[, model[, provider]])`
+
+Description: Returns a local approximate token count. This function does not
+call a provider.
+
+Example:
+
+```sql
+SELECT ai_count_tokens('DuckDB local analytics');
+```
+
+Result: `BIGINT`
+
+## Provider metadata functions
+
+#### `ai_provider_base_url(provider)`
+
+Description: Returns the default base URL for a supported provider after alias
+normalization.
+
+Example:
+
+```sql
+SELECT ai_provider_base_url('ollama');
+```
+
+Result: `VARCHAR`
+
+#### `ai_provider_protocol(provider)`
+
+Description: Returns the internal request protocol used for provider request and
+response shaping.
+
+Example:
+
+```sql
+SELECT ai_provider_protocol('anthropic');
+```
+
+Result: `VARCHAR`
+
+## Usage and catalog table functions
+
+#### `ai_usage()`
+
+Description: Returns recent in-process completion, embedding, and local usage
+events. The buffer keeps the latest 1,024 events.
+
+Example:
+
+```sql
+SELECT *
+FROM ai_usage()
+ORDER BY event_id DESC;
+```
+
+Result columns: `event_id`, `created_at`, `event`, `provider`, `protocol`,
+`model`, character counts, token counts, elapsed time, HTTP status, and
+estimated cost.
+
+#### `ai_clear_usage()`
+
+Description: Clears the in-process usage event buffer and returns one
+confirmation row.
+
+Example:
+
+```sql
+SELECT *
+FROM ai_clear_usage();
+```
+
+Result: one `cleared BOOLEAN` column
+
+#### `ai_secrets()`
+
+Description: Lists configured `duckdb_ai` secrets with credential values
+redacted.
+
+Example:
+
+```sql
+SELECT name, provider, model, base_url, has_api_key
+FROM ai_secrets();
+```
+
+Result columns: `name`, `provider`, `model`, `base_url`, `scope`,
+`has_api_key`
+
+#### `ai_models()`
+
+Description: Returns the small built-in provider/model pricing catalog used by
+opt-in cost estimation.
+
+Example:
+
+```sql
+SELECT provider, model, operation, input_token_price_per_million
+FROM ai_models();
+```
+
+Result columns: `provider`, `model`, `operation`,
+`input_token_price_per_million`, `output_token_price_per_million`,
+`source_url`, `source_note`, `last_reviewed`
+
+## Named options
+
+Completion functions accept constant named options unless noted otherwise.
+Provider credentials are resolved from environment variables or DuckDB secrets,
+not from direct API key arguments.
+
+| Option | Type | Applies to | Description |
+| --- | --- | --- | --- |
+| `model` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider model name. |
+| `provider` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider name or alias. |
+| `profile`, `secret`, `secret_name` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | DuckDB secret name or profile. |
+| `temperature` | `DOUBLE` | Completion, SQL assistant, aggregate | Sampling temperature between 0 and 2. |
+| `system_prompt` | `VARCHAR` | Completion, SQL assistant, aggregate | Optional system message for providers that support chat-style payloads. |
+| `max_tokens` | `BIGINT` | Completion, SQL assistant, aggregate | Maximum provider output tokens. Must be greater than 0. |
+| `base_url` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider or gateway base URL override. |
+| `timeout_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | HTTP timeout. Must be greater than 0. |
+| `retry_count` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Retry count from 0 to 10 for curl failures and retryable HTTP status codes. |
+| `retry_backoff_ms` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Base retry backoff from 0 to 60000 milliseconds. |
+| `max_concurrent_requests` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Process-local request concurrency cap from 0 to 1024. |
+| `min_request_interval_ms` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Process-local minimum interval between provider request starts. |
+| `fail_on_error` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | If false, supported functions return `NULL` or an empty result instead of raising provider errors. |
+| `response_format` | `VARCHAR` | Completion and SQL assistant | `text`, `json_object`, or `json_schema`. |
+| `response_schema`, `json_schema` | `VARCHAR` | Completion and SQL assistant | JSON Schema object for structured output hints and validation. |
+| `input_token_price_per_million` | `DOUBLE` | Completion, embedding, SQL assistant, aggregate | Manual input-token price for cost estimation. |
+| `output_token_price_per_million` | `DOUBLE` | Completion, SQL assistant, aggregate | Manual output-token price for cost estimation. |
+| `use_builtin_model_prices` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Enables lookup from `ai_models()` when manual prices are not supplied. |
+| `log_format` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | `generic_json` or `otlp_json`. |
+| `log_tags` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Comma-separated tags copied into usage log payloads. |
+| `log_sample_rate` | `DOUBLE` | Completion, embedding, SQL assistant, aggregate | Stable sampling rate from 0 to 1. |
+| `log_include_text` | `BOOLEAN` | `ai_complete_record` | Include prompt/output text in outbound usage logs. Defaults to false. |
+| `log_strict` | `BOOLEAN` | `ai_complete_record` | Fail the SQL query when outbound usage logging fails. |
+
+SQL assistant table functions also accept:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `schema_context`, `schema` | `VARCHAR` | Prompt context to use instead of generated local catalog context. |
+| `include_tables` | `VARCHAR[]` | Limit generated local catalog context to matching tables. |
+| `exclude_tables` | `VARCHAR[]` | Remove matching tables from generated local catalog context. |
+| `sample_rows` | `BIGINT` | Include up to 100 sample rows per local table. |
+| `error` | `VARCHAR` | `ai_fix_sql_line` only. Error text used to identify the target line. |
+
+Aggregate functions also accept:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `instruction`, `task` | `VARCHAR` | Constant instruction for `ai_agg`. |
+| `separator` | `VARCHAR` | Separator inserted between grouped input values. |
+| `max_context_chars` | `BIGINT` | Maximum grouped text characters sent to the model. |
+
+## Provider settings and secrets
+
+Session defaults can be configured with DuckDB settings:
+
+```sql
+SET duckdb_ai_provider = 'openai';
+SET duckdb_ai_model = 'gpt-4o-mini';
+SET duckdb_ai_base_url = 'https://api.openai.com/v1';
+SET duckdb_ai_timeout_seconds = 120;
+```
+
+Credentials should use environment variables or DuckDB secrets:
+
+```sql
+CREATE OR REPLACE SECRET openai_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai',
+    API_KEY '...',
+    MODEL 'gpt-4o-mini'
+);
+
+SELECT ai_complete('hello', secret := 'openai_ai');
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,11 @@ SQL, usage logging, and local validation evidence.
 
 ## Start here
 
+- [SQL function reference](functions.md): every scalar, aggregate, and table
+  function exposed by the extension, with examples and result shapes.
+- [Provider guides](provider-guides.md): end-to-end examples for Ollama, OpenAI,
+  Azure OpenAI, Claude, Gemini, Mistral, Z.ai, DeepSeek, OpenRouter, and local
+  OpenAI-compatible gateways.
 - [Validation](VALIDATION.md): local build, test, and smoke evidence for the
   pinned DuckDB extension build.
 - [Smoke testing](SMOKE_TESTING.md): deterministic mock-provider checks plus

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -1,0 +1,379 @@
+---
+sidebar_position: 3
+---
+
+# Provider guides
+
+This page gives one simple end-to-end example for each supported provider.
+Examples assume you have built the extension and are running the bundled DuckDB
+shell:
+
+```sh
+GEN=ninja make release
+./build/release/duckdb
+```
+
+Each guide uses a DuckDB secret for provider, model, and base URL settings. The
+API key is read from the matching environment variable when the provider call
+runs. If you prefer a fully DuckDB-managed secret, add `API_KEY '...'` to the
+`CREATE SECRET` statement.
+
+After any provider call, inspect the local usage buffer:
+
+```sql
+SELECT provider, protocol, model, http_status, elapsed_ms
+FROM ai_usage()
+ORDER BY event_id DESC
+LIMIT 1;
+```
+
+## Ollama
+
+Use Ollama for local models without a hosted API key.
+
+```sh
+ollama serve
+ollama pull llama3.2
+ollama pull nomic-embed-text
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET ollama_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'ollama',
+    MODEL 'llama3.2'
+);
+
+SELECT ai_complete(
+    'Write one sentence about why DuckDB is useful for analytics.',
+    secret := 'ollama_ai',
+    timeout_seconds := 120
+) AS answer;
+
+SELECT ai_embed(
+    'DuckDB local analytics',
+    secret := 'ollama_ai',
+    model := 'nomic-embed-text'
+)[1] AS first_embedding_value;
+```
+
+If Ollama runs on a non-default host, set `OLLAMA_HOST` before starting DuckDB or
+add `BASE_URL 'http://host:11434'` to the secret.
+
+## OpenAI
+
+```sh
+export OPENAI_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET openai_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai',
+    MODEL 'gpt-4o-mini'
+);
+
+SELECT ai_complete(
+    'Summarize DuckDB in one short sentence.',
+    secret := 'openai_ai'
+) AS answer;
+
+SELECT ai_complete_json(
+    'Return a JSON object with keys "name" and "kind" for DuckDB.',
+    secret := 'openai_ai',
+    response_schema := '{
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "kind": {"type": "string"}
+      },
+      "required": ["name", "kind"]
+    }'
+) AS profile_json;
+
+SELECT ai_embed(
+    'DuckDB vector search',
+    secret := 'openai_ai',
+    model := 'text-embedding-3-small'
+)[1] AS first_embedding_value;
+```
+
+## Azure OpenAI
+
+Use your Azure OpenAI resource URL and deployment name. The extension appends
+`/openai/v1` to the base URL when needed.
+
+```sh
+export AZURE_OPENAI_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET azure_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'azure',
+    BASE_URL 'https://my-resource.openai.azure.com',
+    MODEL 'gpt-4o'
+);
+
+SELECT ai_complete(
+    'Explain DuckDB to a data analyst in one sentence.',
+    secret := 'azure_ai'
+) AS answer;
+
+SELECT ai_embed(
+    'DuckDB vector search',
+    secret := 'azure_ai',
+    model := 'text-embedding-3-small'
+)[1] AS first_embedding_value;
+```
+
+If your Azure deployment names differ from the model names above, use the
+deployment name in `MODEL` or `model := ...`.
+
+## Claude / Anthropic
+
+```sh
+export ANTHROPIC_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET claude_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'anthropic',
+    MODEL 'claude-3-5-haiku-latest'
+);
+
+SELECT ai_complete(
+    'Explain DuckDB in one concise paragraph.',
+    secret := 'claude_ai',
+    max_tokens := 160
+) AS answer;
+
+SELECT ai_summarize(
+    'DuckDB is an in-process analytical database built for fast local queries.',
+    secret := 'claude_ai',
+    max_tokens := 80
+) AS summary;
+```
+
+Claude is configured for completion calls. Embeddings are not configured for this
+provider.
+
+## Gemini
+
+Gemini uses Google's OpenAI-compatible endpoint.
+
+```sh
+export GEMINI_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET gemini_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'gemini',
+    MODEL 'gemini-2.5-flash'
+);
+
+SELECT ai_complete(
+    'Write one sentence about DuckDB extensions.',
+    secret := 'gemini_ai'
+) AS answer;
+
+SELECT ai_embed(
+    'DuckDB vector search',
+    secret := 'gemini_ai',
+    model := 'text-embedding-004'
+)[1] AS first_embedding_value;
+```
+
+Provider aliases `gcp`, `google`, and `google_gemini` also resolve to Gemini.
+
+## Mistral
+
+```sh
+export MISTRAL_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET mistral_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'mistral',
+    MODEL 'mistral-small-latest'
+);
+
+SELECT ai_complete(
+    'Give one practical use case for DuckDB and AI functions.',
+    secret := 'mistral_ai'
+) AS answer;
+
+SELECT ai_embed(
+    'DuckDB vector search',
+    secret := 'mistral_ai',
+    model := 'mistral-embed'
+)[1] AS first_embedding_value;
+```
+
+## Z.ai
+
+```sh
+export ZAI_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET zai_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'zai',
+    MODEL 'glm-4-flash'
+);
+
+SELECT ai_complete(
+    'Summarize DuckDB in one sentence.',
+    secret := 'zai_ai'
+) AS answer;
+
+SELECT ai_embed(
+    'DuckDB vector search',
+    secret := 'zai_ai',
+    model := 'embedding-3'
+)[1] AS first_embedding_value;
+```
+
+Provider aliases `zai` and `zhipu` resolve to the same provider.
+
+## DeepSeek
+
+```sh
+export DEEPSEEK_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET deepseek_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'deepseek',
+    MODEL 'deepseek-chat'
+);
+
+SELECT ai_complete(
+    'Write one sentence about using SQL with language models.',
+    secret := 'deepseek_ai'
+) AS answer;
+
+SELECT ai_classify(
+    'Customer says the invoice is overdue.',
+    'billing, support, sales, other',
+    secret := 'deepseek_ai'
+) AS category;
+```
+
+DeepSeek is configured for completion calls. Embeddings are not configured for
+this provider.
+
+## OpenRouter
+
+```sh
+export OPENROUTER_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET openrouter_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openrouter',
+    MODEL 'openai/gpt-4o-mini'
+);
+
+SELECT ai_complete(
+    'Explain DuckDB extensions in one sentence.',
+    secret := 'openrouter_ai'
+) AS answer;
+
+SELECT ai_embed(
+    'DuckDB vector search',
+    secret := 'openrouter_ai',
+    model := 'openai/text-embedding-3-small'
+)[1] AS first_embedding_value;
+```
+
+OpenRouter model names include the upstream provider prefix, for example
+`openai/gpt-4o-mini`.
+
+## OpenAI-compatible / Local gateway
+
+Use this path for vLLM, LM Studio, LiteLLM, Ollama's `/v1` endpoint, or any
+gateway that exposes an OpenAI-compatible chat API.
+
+For local Ollama's OpenAI-compatible endpoint:
+
+```sh
+ollama serve
+ollama pull llama3.2
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET local_openai_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'local',
+    BASE_URL 'http://localhost:11434/v1',
+    MODEL 'llama3.2'
+);
+
+SELECT ai_complete(
+    'Write one sentence about local AI models in DuckDB.',
+    secret := 'local_openai_ai'
+) AS answer;
+```
+
+For a hosted OpenAI-compatible gateway, add an API key:
+
+```sh
+export OPENAI_COMPATIBLE_API_KEY='...'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET gateway_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai_compatible',
+    BASE_URL 'https://gateway.example/v1',
+    MODEL 'provider/model-name'
+);
+
+SELECT ai_complete(
+    'Write one sentence about DuckDB.',
+    secret := 'gateway_ai'
+) AS answer;
+```
+
+Aliases `local`, `openai_compatible`, `openai-compatible`, `local_openai`,
+`local-models`, and `local_models` all use the OpenAI-compatible protocol.

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -416,25 +416,38 @@ void ValidateResponseSchemaValue(const std::string &schema, const std::string &f
 	}
 }
 
-LogicalType OptionType(const std::string &name) {
+bool TryGetOptionType(const std::string &name, LogicalType &type) {
 	if (name == "model" || name == "provider" || name == "profile" || name == "secret" || name == "secret_name" ||
 	    name == "system_prompt" || name == "base_url" || name == "response_format" || name == "response_schema" ||
 	    name == "json_schema" || name == "log_format" || name == "log_tags") {
-		return LogicalType::VARCHAR;
+		type = LogicalType::VARCHAR;
+		return true;
 	}
 	if (name == "temperature" || name == "log_sample_rate" || name == "input_token_price_per_million" ||
 	    name == "output_token_price_per_million") {
-		return LogicalType::DOUBLE;
+		type = LogicalType::DOUBLE;
+		return true;
 	}
 	if (name == "max_tokens" || name == "retry_count" || name == "retry_backoff_ms" ||
 	    name == "max_concurrent_requests" || name == "min_request_interval_ms") {
-		return LogicalType::BIGINT;
+		type = LogicalType::BIGINT;
+		return true;
 	}
 	if (name == "timeout_seconds") {
-		return LogicalType::BIGINT;
+		type = LogicalType::BIGINT;
+		return true;
 	}
 	if (name == "fail_on_error" || name == "use_builtin_model_prices") {
-		return LogicalType::BOOLEAN;
+		type = LogicalType::BOOLEAN;
+		return true;
+	}
+	return false;
+}
+
+LogicalType OptionType(const std::string &name) {
+	LogicalType type;
+	if (TryGetOptionType(name, type)) {
+		return type;
 	}
 	throw BinderException("Unsupported AI option \"%s\". Supported options: model, provider, temperature, "
 	                      "system_prompt, max_tokens, base_url, timeout_seconds, retry_count, retry_backoff_ms, "
@@ -469,139 +482,202 @@ Value EvaluateConstantOption(ClientContext &context, Expression &expr, const std
 	return value;
 }
 
+Value CastOptionValue(const Value &value_p, const std::string &function_name, const std::string &name,
+                      const LogicalType &target_type) {
+	if (value_p.IsNull()) {
+		throw BinderException("%s option \"%s\" must not be NULL", function_name, name);
+	}
+	return value_p.DefaultCastAs(target_type);
+}
+
+std::string OptionStringValue(const Value &value, const std::string &function_name, const std::string &name) {
+	return StringValue::Get(CastOptionValue(value, function_name, name, LogicalType::VARCHAR));
+}
+
+double OptionDoubleValue(const Value &value, const std::string &function_name, const std::string &name) {
+	return DoubleValue::Get(CastOptionValue(value, function_name, name, LogicalType::DOUBLE));
+}
+
+int64_t OptionBigIntValue(const Value &value, const std::string &function_name, const std::string &name) {
+	return BigIntValue::Get(CastOptionValue(value, function_name, name, LogicalType::BIGINT));
+}
+
+bool OptionBoolValue(const Value &value, const std::string &function_name, const std::string &name) {
+	return BooleanValue::Get(CastOptionValue(value, function_name, name, LogicalType::BOOLEAN));
+}
+
+std::string NormalizeLogFormatValue(const std::string &value, const std::string &function_name) {
+	auto log_format = LowerAscii(value);
+	if (log_format == "generic_json" || log_format == "generic" || log_format == "json" || log_format == "otlp_json" ||
+	    log_format == "otlp") {
+		return log_format;
+	}
+	throw BinderException("%s option \"log_format\" must be one of: generic_json, otlp_json", function_name);
+}
+
+bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std::string &function_name,
+                                const std::string &name, const Value &value, bool allow_response_options,
+                                bool allow_log_payload_options) {
+	if (name == "model") {
+		options.model = OptionStringValue(value, function_name, name);
+		return true;
+	}
+	if (name == "provider") {
+		options.provider = OptionStringValue(value, function_name, name);
+		return true;
+	}
+	if (name == "profile" || name == "secret" || name == "secret_name") {
+		options.secret_name = OptionStringValue(value, function_name, name);
+		return true;
+	}
+	if (name == "system_prompt") {
+		options.system_prompt = OptionStringValue(value, function_name, name);
+		return true;
+	}
+	if (name == "base_url") {
+		options.base_url = OptionStringValue(value, function_name, name);
+		return true;
+	}
+	if (name == "log_tags") {
+		options.log_tags = OptionStringValue(value, function_name, name);
+		return true;
+	}
+	if (name == "log_format") {
+		options.log_format = NormalizeLogFormatValue(OptionStringValue(value, function_name, name), function_name);
+		return true;
+	}
+	if (name == "response_format") {
+		if (!allow_response_options) {
+			return false;
+		}
+		options.response_format =
+		    NormalizeResponseFormatValue(OptionStringValue(value, function_name, name), function_name);
+		return true;
+	}
+	if (name == "response_schema" || name == "json_schema") {
+		if (!allow_response_options) {
+			return false;
+		}
+		options.response_schema = OptionStringValue(value, function_name, name);
+		ValidateResponseSchemaValue(options.response_schema, function_name);
+		return true;
+	}
+	if (name == "temperature") {
+		options.temperature = OptionDoubleValue(value, function_name, name);
+		if (options.temperature < 0 || options.temperature > 2) {
+			throw BinderException("%s option \"temperature\" must be between 0 and 2", function_name);
+		}
+		options.has_temperature = true;
+		return true;
+	}
+	if (name == "log_sample_rate") {
+		options.log_sample_rate = OptionDoubleValue(value, function_name, name);
+		if (options.log_sample_rate < 0 || options.log_sample_rate > 1) {
+			throw BinderException("%s option \"log_sample_rate\" must be between 0 and 1", function_name);
+		}
+		options.has_log_sample_rate = true;
+		return true;
+	}
+	if (name == "input_token_price_per_million") {
+		options.input_token_price_per_million = OptionDoubleValue(value, function_name, name);
+		if (!std::isfinite(options.input_token_price_per_million) || options.input_token_price_per_million < 0) {
+			throw BinderException("%s option \"input_token_price_per_million\" must be greater than or equal to 0",
+			                      function_name);
+		}
+		options.has_input_token_price_per_million = true;
+		return true;
+	}
+	if (name == "output_token_price_per_million") {
+		options.output_token_price_per_million = OptionDoubleValue(value, function_name, name);
+		if (!std::isfinite(options.output_token_price_per_million) || options.output_token_price_per_million < 0) {
+			throw BinderException("%s option \"output_token_price_per_million\" must be greater than or equal to 0",
+			                      function_name);
+		}
+		options.has_output_token_price_per_million = true;
+		return true;
+	}
+	if (name == "use_builtin_model_prices") {
+		options.use_builtin_model_prices = OptionBoolValue(value, function_name, name);
+		options.has_use_builtin_model_prices = true;
+		return true;
+	}
+	if (name == "max_tokens") {
+		options.max_tokens = OptionBigIntValue(value, function_name, name);
+		if (options.max_tokens <= 0) {
+			throw BinderException("%s option \"max_tokens\" must be greater than 0", function_name);
+		}
+		options.has_max_tokens = true;
+		return true;
+	}
+	if (name == "retry_count") {
+		options.retry_count = OptionBigIntValue(value, function_name, name);
+		if (options.retry_count < 0 || options.retry_count > 10) {
+			throw BinderException("%s option \"retry_count\" must be between 0 and 10", function_name);
+		}
+		options.has_retry_count = true;
+		return true;
+	}
+	if (name == "retry_backoff_ms") {
+		options.retry_backoff_ms = OptionBigIntValue(value, function_name, name);
+		if (options.retry_backoff_ms < 0 || options.retry_backoff_ms > 60000) {
+			throw BinderException("%s option \"retry_backoff_ms\" must be between 0 and 60000", function_name);
+		}
+		options.has_retry_backoff_ms = true;
+		return true;
+	}
+	if (name == "max_concurrent_requests") {
+		options.max_concurrent_requests = OptionBigIntValue(value, function_name, name);
+		if (options.max_concurrent_requests < 0 || options.max_concurrent_requests > 1024) {
+			throw BinderException("%s option \"max_concurrent_requests\" must be between 0 and 1024", function_name);
+		}
+		options.has_max_concurrent_requests = true;
+		return true;
+	}
+	if (name == "min_request_interval_ms") {
+		options.min_request_interval_ms = OptionBigIntValue(value, function_name, name);
+		if (options.min_request_interval_ms < 0 || options.min_request_interval_ms > 60000) {
+			throw BinderException("%s option \"min_request_interval_ms\" must be between 0 and 60000", function_name);
+		}
+		options.has_min_request_interval_ms = true;
+		return true;
+	}
+	if (name == "timeout_seconds") {
+		options.timeout_seconds = OptionBigIntValue(value, function_name, name);
+		if (options.timeout_seconds <= 0) {
+			throw BinderException("%s option \"timeout_seconds\" must be greater than 0", function_name);
+		}
+		options.has_timeout_seconds = true;
+		return true;
+	}
+	if (name == "fail_on_error") {
+		options.fail_on_error = OptionBoolValue(value, function_name, name);
+		return true;
+	}
+	if (name == "log_include_text") {
+		if (!allow_log_payload_options) {
+			return false;
+		}
+		options.log_include_text = OptionBoolValue(value, function_name, name);
+		options.has_log_include_text = true;
+		return true;
+	}
+	if (name == "log_strict") {
+		if (!allow_log_payload_options) {
+			return false;
+		}
+		options.log_strict = OptionBoolValue(value, function_name, name);
+		options.has_log_strict = true;
+		return true;
+	}
+	return false;
+}
+
 void ApplyNamedOption(ClientContext &context, duckdb_ai::CompletionOptions &options, Expression &expr,
                       const std::string &name) {
 	auto target_type = OptionType(name);
 	auto value = EvaluateConstantOption(context, expr, name, target_type);
-	if (name == "model") {
-		options.model = StringValue::Get(value);
-		return;
-	}
-	if (name == "provider") {
-		options.provider = StringValue::Get(value);
-		return;
-	}
-	if (name == "profile" || name == "secret" || name == "secret_name") {
-		options.secret_name = StringValue::Get(value);
-		return;
-	}
-	if (name == "system_prompt") {
-		options.system_prompt = StringValue::Get(value);
-		return;
-	}
-	if (name == "base_url") {
-		options.base_url = StringValue::Get(value);
-		return;
-	}
-	if (name == "log_tags") {
-		options.log_tags = StringValue::Get(value);
-		return;
-	}
-	if (name == "log_format") {
-		auto log_format = LowerAscii(StringValue::Get(value));
-		if (log_format != "generic_json" && log_format != "generic" && log_format != "json" &&
-		    log_format != "otlp_json" && log_format != "otlp") {
-			throw BinderException("AI option \"log_format\" must be one of: generic_json, otlp_json");
-		}
-		options.log_format = log_format;
-		return;
-	}
-	if (name == "response_format") {
-		options.response_format = NormalizeResponseFormatValue(StringValue::Get(value), "AI");
-		return;
-	}
-	if (name == "response_schema" || name == "json_schema") {
-		options.response_schema = StringValue::Get(value);
-		ValidateResponseSchemaValue(options.response_schema, "AI");
-		return;
-	}
-	if (name == "temperature") {
-		options.temperature = DoubleValue::Get(value);
-		if (options.temperature < 0 || options.temperature > 2) {
-			throw BinderException("AI option \"temperature\" must be between 0 and 2");
-		}
-		options.has_temperature = true;
-		return;
-	}
-	if (name == "log_sample_rate") {
-		options.log_sample_rate = DoubleValue::Get(value);
-		if (options.log_sample_rate < 0 || options.log_sample_rate > 1) {
-			throw BinderException("AI option \"log_sample_rate\" must be between 0 and 1");
-		}
-		options.has_log_sample_rate = true;
-		return;
-	}
-	if (name == "input_token_price_per_million") {
-		options.input_token_price_per_million = DoubleValue::Get(value);
-		if (!std::isfinite(options.input_token_price_per_million) || options.input_token_price_per_million < 0) {
-			throw BinderException("AI option \"input_token_price_per_million\" must be greater than or equal to 0");
-		}
-		options.has_input_token_price_per_million = true;
-		return;
-	}
-	if (name == "output_token_price_per_million") {
-		options.output_token_price_per_million = DoubleValue::Get(value);
-		if (!std::isfinite(options.output_token_price_per_million) || options.output_token_price_per_million < 0) {
-			throw BinderException("AI option \"output_token_price_per_million\" must be greater than or equal to 0");
-		}
-		options.has_output_token_price_per_million = true;
-		return;
-	}
-	if (name == "use_builtin_model_prices") {
-		options.use_builtin_model_prices = BooleanValue::Get(value);
-		options.has_use_builtin_model_prices = true;
-		return;
-	}
-	if (name == "max_tokens") {
-		options.max_tokens = BigIntValue::Get(value);
-		if (options.max_tokens <= 0) {
-			throw BinderException("AI option \"max_tokens\" must be greater than 0");
-		}
-		options.has_max_tokens = true;
-		return;
-	}
-	if (name == "retry_count") {
-		options.retry_count = BigIntValue::Get(value);
-		if (options.retry_count < 0 || options.retry_count > 10) {
-			throw BinderException("AI option \"retry_count\" must be between 0 and 10");
-		}
-		options.has_retry_count = true;
-		return;
-	}
-	if (name == "retry_backoff_ms") {
-		options.retry_backoff_ms = BigIntValue::Get(value);
-		if (options.retry_backoff_ms < 0 || options.retry_backoff_ms > 60000) {
-			throw BinderException("AI option \"retry_backoff_ms\" must be between 0 and 60000");
-		}
-		options.has_retry_backoff_ms = true;
-		return;
-	}
-	if (name == "max_concurrent_requests") {
-		options.max_concurrent_requests = BigIntValue::Get(value);
-		if (options.max_concurrent_requests < 0 || options.max_concurrent_requests > 1024) {
-			throw BinderException("AI option \"max_concurrent_requests\" must be between 0 and 1024");
-		}
-		options.has_max_concurrent_requests = true;
-		return;
-	}
-	if (name == "min_request_interval_ms") {
-		options.min_request_interval_ms = BigIntValue::Get(value);
-		if (options.min_request_interval_ms < 0 || options.min_request_interval_ms > 60000) {
-			throw BinderException("AI option \"min_request_interval_ms\" must be between 0 and 60000");
-		}
-		options.has_min_request_interval_ms = true;
-		return;
-	}
-	if (name == "timeout_seconds") {
-		options.timeout_seconds = BigIntValue::Get(value);
-		if (options.timeout_seconds <= 0) {
-			throw BinderException("AI option \"timeout_seconds\" must be greater than 0");
-		}
-		options.has_timeout_seconds = true;
-		return;
-	}
-	if (name == "fail_on_error") {
-		options.fail_on_error = BooleanValue::Get(value);
+	if (!ApplyCompletionValueOption(options, "AI", name, value, true, false)) {
+		throw InternalException("Unhandled AI option \"%s\"", name);
 	}
 }
 
@@ -935,16 +1011,40 @@ unique_ptr<FunctionData> AiCompleteJsonBind(ClientContext &context, ScalarFuncti
 	return bind_data;
 }
 
-bool ReadStringArgument(DataChunk &args, idx_t column, idx_t row, std::string &value) {
-	auto &vector = args.data[column];
+struct StringVectorReader {
+	// DuckDB vectors are chunk-oriented; cache the unified format once instead of per row.
+	StringVectorReader(DataChunk &args, idx_t column) {
+		args.data[column].ToUnifiedFormat(args.size(), data);
+		values = UnifiedVectorFormat::GetData<string_t>(data);
+	}
+
+	bool Read(idx_t row, std::string &value) const {
+		auto mapped_row = data.sel->get_index(row);
+		if (!data.validity.RowIsValid(mapped_row)) {
+			return false;
+		}
+		value = values[mapped_row].GetString();
+		return true;
+	}
+
 	UnifiedVectorFormat data;
-	vector.ToUnifiedFormat(args.size(), data);
-	auto mapped_row = data.sel->get_index(row);
-	if (!data.validity.RowIsValid(mapped_row)) {
+	const string_t *values;
+};
+
+unique_ptr<StringVectorReader> OptionalStringReader(DataChunk &args, bool enabled, idx_t column) {
+	return enabled ? make_uniq<StringVectorReader>(args, column) : nullptr;
+}
+
+bool ReadRuntimeOptions(const duckdb_ai::CompletionOptions &base_options, bool has_model_arg,
+                        const StringVectorReader *model_reader, bool has_provider_arg,
+                        const StringVectorReader *provider_reader, idx_t row, duckdb_ai::CompletionOptions &options) {
+	options = base_options;
+	if (has_model_arg && !model_reader->Read(row, options.model)) {
 		return false;
 	}
-	auto values = UnifiedVectorFormat::GetData<string_t>(data);
-	value = values[mapped_row].GetString();
+	if (has_provider_arg && !provider_reader->Read(row, options.provider)) {
+		return false;
+	}
 	return true;
 }
 
@@ -1002,20 +1102,20 @@ void AiCompletionFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<string_t>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader prompt_reader(args, bind_data.prompt_index);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string prompt;
-		if (!ReadStringArgument(args, bind_data.prompt_index, row, prompt)) {
+		if (!prompt_reader.Read(row, prompt)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
 
-		auto options = bind_data.options;
-		if (bind_data.has_model_arg && !ReadStringArgument(args, bind_data.model_index, row, options.model)) {
-			result_validity.SetInvalid(row);
-			continue;
-		}
-		if (bind_data.has_provider_arg && !ReadStringArgument(args, bind_data.provider_index, row, options.provider)) {
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
@@ -1136,145 +1236,9 @@ AiRecordColumn BuildAiRecordColumn(const duckdb_ai::JsonSchemaProperty &property
 }
 
 void ApplyAiRecordValueOption(duckdb_ai::CompletionOptions &options, const std::string &name, const Value &value_p) {
-	if (value_p.IsNull()) {
-		throw BinderException("ai_complete_record option \"%s\" must not be NULL", name);
+	if (!ApplyCompletionValueOption(options, "ai_complete_record", name, value_p, false, true)) {
+		throw BinderException("Unsupported ai_complete_record option \"%s\"", name);
 	}
-	auto value = value_p;
-	if (name == "model") {
-		options.model = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "provider") {
-		options.provider = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "profile" || name == "secret" || name == "secret_name") {
-		options.secret_name = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "system_prompt") {
-		options.system_prompt = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "base_url") {
-		options.base_url = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "log_format") {
-		auto log_format = LowerAscii(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)));
-		if (log_format != "generic_json" && log_format != "generic" && log_format != "json" &&
-		    log_format != "otlp_json" && log_format != "otlp") {
-			throw BinderException("ai_complete_record option \"log_format\" must be one of: generic_json, otlp_json");
-		}
-		options.log_format = log_format;
-		return;
-	}
-	if (name == "log_tags") {
-		options.log_tags = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "temperature") {
-		options.temperature = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (options.temperature < 0 || options.temperature > 2) {
-			throw BinderException("ai_complete_record option \"temperature\" must be between 0 and 2");
-		}
-		options.has_temperature = true;
-		return;
-	}
-	if (name == "max_tokens") {
-		options.max_tokens = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.max_tokens <= 0) {
-			throw BinderException("ai_complete_record option \"max_tokens\" must be greater than 0");
-		}
-		options.has_max_tokens = true;
-		return;
-	}
-	if (name == "timeout_seconds") {
-		options.timeout_seconds = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.timeout_seconds <= 0) {
-			throw BinderException("ai_complete_record option \"timeout_seconds\" must be greater than 0");
-		}
-		options.has_timeout_seconds = true;
-		return;
-	}
-	if (name == "retry_count") {
-		options.retry_count = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.retry_count < 0 || options.retry_count > 10) {
-			throw BinderException("ai_complete_record option \"retry_count\" must be between 0 and 10");
-		}
-		options.has_retry_count = true;
-		return;
-	}
-	if (name == "retry_backoff_ms") {
-		options.retry_backoff_ms = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.retry_backoff_ms < 0 || options.retry_backoff_ms > 60000) {
-			throw BinderException("ai_complete_record option \"retry_backoff_ms\" must be between 0 and 60000");
-		}
-		options.has_retry_backoff_ms = true;
-		return;
-	}
-	if (name == "max_concurrent_requests") {
-		options.max_concurrent_requests = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.max_concurrent_requests < 0 || options.max_concurrent_requests > 1024) {
-			throw BinderException("ai_complete_record option \"max_concurrent_requests\" must be between 0 and 1024");
-		}
-		options.has_max_concurrent_requests = true;
-		return;
-	}
-	if (name == "min_request_interval_ms") {
-		options.min_request_interval_ms = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.min_request_interval_ms < 0 || options.min_request_interval_ms > 60000) {
-			throw BinderException("ai_complete_record option \"min_request_interval_ms\" must be between 0 and 60000");
-		}
-		options.has_min_request_interval_ms = true;
-		return;
-	}
-	if (name == "input_token_price_per_million") {
-		options.input_token_price_per_million = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (!std::isfinite(options.input_token_price_per_million) || options.input_token_price_per_million < 0) {
-			throw BinderException(
-			    "ai_complete_record option \"input_token_price_per_million\" must be greater than or equal to 0");
-		}
-		options.has_input_token_price_per_million = true;
-		return;
-	}
-	if (name == "output_token_price_per_million") {
-		options.output_token_price_per_million = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (!std::isfinite(options.output_token_price_per_million) || options.output_token_price_per_million < 0) {
-			throw BinderException(
-			    "ai_complete_record option \"output_token_price_per_million\" must be greater than or equal to 0");
-		}
-		options.has_output_token_price_per_million = true;
-		return;
-	}
-	if (name == "use_builtin_model_prices") {
-		options.use_builtin_model_prices = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		options.has_use_builtin_model_prices = true;
-		return;
-	}
-	if (name == "log_sample_rate") {
-		options.log_sample_rate = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (options.log_sample_rate < 0 || options.log_sample_rate > 1) {
-			throw BinderException("ai_complete_record option \"log_sample_rate\" must be between 0 and 1");
-		}
-		options.has_log_sample_rate = true;
-		return;
-	}
-	if (name == "log_include_text") {
-		options.log_include_text = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		options.has_log_include_text = true;
-		return;
-	}
-	if (name == "log_strict") {
-		options.log_strict = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		options.has_log_strict = true;
-		return;
-	}
-	if (name == "fail_on_error") {
-		options.fail_on_error = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		return;
-	}
-	throw BinderException("Unsupported ai_complete_record option \"%s\"", name);
 }
 
 const duckdb_ai::JsonExtractedValue *FindExtractedField(const duckdb_ai::JsonExtractedValue &value,
@@ -1536,18 +1500,15 @@ unique_ptr<FunctionData> AiSimilarityBind(ClientContext &context, ScalarFunction
 	return std::move(bind_data);
 }
 
-void ReadEmbeddingInputs(DataChunk &args, const AiCompletionBindData &bind_data, idx_t row, std::string &input,
-                         duckdb_ai::CompletionOptions &options, bool &is_null) {
-	if (!ReadStringArgument(args, bind_data.prompt_index, row, input)) {
+void ReadEmbeddingInputs(const StringVectorReader &input_reader, const StringVectorReader *model_reader,
+                         const StringVectorReader *provider_reader, const AiCompletionBindData &bind_data, idx_t row,
+                         std::string &input, duckdb_ai::CompletionOptions &options, bool &is_null) {
+	if (!input_reader.Read(row, input)) {
 		is_null = true;
 		return;
 	}
-	options = bind_data.options;
-	if (bind_data.has_model_arg && !ReadStringArgument(args, bind_data.model_index, row, options.model)) {
-		is_null = true;
-		return;
-	}
-	if (bind_data.has_provider_arg && !ReadStringArgument(args, bind_data.provider_index, row, options.provider)) {
+	if (!ReadRuntimeOptions(bind_data.options, bind_data.has_model_arg, model_reader, bind_data.has_provider_arg,
+	                        provider_reader, row, options)) {
 		is_null = true;
 	}
 }
@@ -1578,21 +1539,22 @@ void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<double>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader left_reader(args, 0);
+	StringVectorReader right_reader(args, 1);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string left;
 		std::string right;
-		if (!ReadStringArgument(args, 0, row, left) || !ReadStringArgument(args, 1, row, right)) {
+		if (!left_reader.Read(row, left) || !right_reader.Read(row, right)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
 
-		auto options = bind_data.options;
-		if (bind_data.has_model_arg && !ReadStringArgument(args, bind_data.model_index, row, options.model)) {
-			result_validity.SetInvalid(row);
-			continue;
-		}
-		if (bind_data.has_provider_arg && !ReadStringArgument(args, bind_data.provider_index, row, options.provider)) {
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
@@ -1618,12 +1580,16 @@ void AiEmbeddingRequestJsonFunction(DataChunk &args, ExpressionState &state, Vec
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<string_t>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, bind_data.prompt_index);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
 		duckdb_ai::CompletionOptions options;
 		bool is_null = false;
-		ReadEmbeddingInputs(args, bind_data, row, input, options, is_null);
+		ReadEmbeddingInputs(input_reader, model_reader.get(), provider_reader.get(), bind_data, row, input, options,
+		                    is_null);
 		if (is_null) {
 			result_validity.SetInvalid(row);
 			continue;
@@ -1649,12 +1615,16 @@ void AiEmbedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<list_entry_t>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, bind_data.prompt_index);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
 		duckdb_ai::CompletionOptions options;
 		bool is_null = false;
-		ReadEmbeddingInputs(args, bind_data, row, input, options, is_null);
+		ReadEmbeddingInputs(input_reader, model_reader.get(), provider_reader.get(), bind_data, row, input, options,
+		                    is_null);
 		if (is_null) {
 			result_validity.SetInvalid(row);
 			continue;
@@ -2473,25 +2443,26 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<string_t>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, 0);
+	auto parameter_reader = OptionalStringReader(args, bind_data.required_args == 2, 1);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
-		if (!ReadStringArgument(args, 0, row, input)) {
+		if (!input_reader.Read(row, input)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
 		std::string parameter;
-		if (bind_data.required_args == 2 && !ReadStringArgument(args, 1, row, parameter)) {
+		if (bind_data.required_args == 2 && !parameter_reader->Read(row, parameter)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
 
-		auto options = bind_data.options;
-		if (bind_data.has_model_arg && !ReadStringArgument(args, bind_data.model_index, row, options.model)) {
-			result_validity.SetInvalid(row);
-			continue;
-		}
-		if (bind_data.has_provider_arg && !ReadStringArgument(args, bind_data.provider_index, row, options.provider)) {
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
@@ -2533,21 +2504,22 @@ void AiFilterFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<bool>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, 0);
+	StringVectorReader predicate_reader(args, 1);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
 		std::string predicate;
-		if (!ReadStringArgument(args, 0, row, input) || !ReadStringArgument(args, 1, row, predicate)) {
+		if (!input_reader.Read(row, input) || !predicate_reader.Read(row, predicate)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
 
-		auto options = bind_data.options;
-		if (bind_data.has_model_arg && !ReadStringArgument(args, bind_data.model_index, row, options.model)) {
-			result_validity.SetInvalid(row);
-			continue;
-		}
-		if (bind_data.has_provider_arg && !ReadStringArgument(args, bind_data.provider_index, row, options.provider)) {
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
@@ -2591,10 +2563,11 @@ void AiCountTokensFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<int64_t>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, bind_data.prompt_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
-		if (!ReadStringArgument(args, bind_data.prompt_index, row, input)) {
+		if (!input_reader.Read(row, input)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
@@ -2788,141 +2761,9 @@ void ApplyPromptQueryValueOption(duckdb_ai::CompletionOptions &options, std::str
 		schema_options.sample_rows = ReadSampleRowsValue(value, "ai_query_data");
 		return;
 	}
-	if (name == "model") {
-		options.model = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
+	if (!ApplyCompletionValueOption(options, "ai_query_data", name, value_p, true, false)) {
+		throw BinderException("Unsupported ai_query_data option \"%s\"", name);
 	}
-	if (name == "provider") {
-		options.provider = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "profile" || name == "secret" || name == "secret_name") {
-		options.secret_name = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "system_prompt") {
-		options.system_prompt = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "base_url") {
-		options.base_url = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "log_format") {
-		auto log_format = LowerAscii(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)));
-		if (log_format != "generic_json" && log_format != "generic" && log_format != "json" &&
-		    log_format != "otlp_json" && log_format != "otlp") {
-			throw BinderException("ai_query_data option \"log_format\" must be one of: generic_json, otlp_json");
-		}
-		options.log_format = log_format;
-		return;
-	}
-	if (name == "log_tags") {
-		options.log_tags = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "response_format") {
-		options.response_format =
-		    NormalizeResponseFormatValue(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)), "ai_query_data");
-		return;
-	}
-	if (name == "response_schema" || name == "json_schema") {
-		options.response_schema = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		ValidateResponseSchemaValue(options.response_schema, "ai_query_data");
-		return;
-	}
-	if (name == "temperature") {
-		options.temperature = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (options.temperature < 0 || options.temperature > 2) {
-			throw BinderException("ai_query_data option \"temperature\" must be between 0 and 2");
-		}
-		options.has_temperature = true;
-		return;
-	}
-	if (name == "log_sample_rate") {
-		options.log_sample_rate = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (options.log_sample_rate < 0 || options.log_sample_rate > 1) {
-			throw BinderException("ai_query_data option \"log_sample_rate\" must be between 0 and 1");
-		}
-		options.has_log_sample_rate = true;
-		return;
-	}
-	if (name == "input_token_price_per_million") {
-		options.input_token_price_per_million = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (!std::isfinite(options.input_token_price_per_million) || options.input_token_price_per_million < 0) {
-			throw BinderException(
-			    "ai_query_data option \"input_token_price_per_million\" must be greater than or equal to 0");
-		}
-		options.has_input_token_price_per_million = true;
-		return;
-	}
-	if (name == "output_token_price_per_million") {
-		options.output_token_price_per_million = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (!std::isfinite(options.output_token_price_per_million) || options.output_token_price_per_million < 0) {
-			throw BinderException(
-			    "ai_query_data option \"output_token_price_per_million\" must be greater than or equal to 0");
-		}
-		options.has_output_token_price_per_million = true;
-		return;
-	}
-	if (name == "use_builtin_model_prices") {
-		options.use_builtin_model_prices = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		options.has_use_builtin_model_prices = true;
-		return;
-	}
-	if (name == "max_tokens") {
-		options.max_tokens = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.max_tokens <= 0) {
-			throw BinderException("ai_query_data option \"max_tokens\" must be greater than 0");
-		}
-		options.has_max_tokens = true;
-		return;
-	}
-	if (name == "retry_count") {
-		options.retry_count = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.retry_count < 0 || options.retry_count > 10) {
-			throw BinderException("ai_query_data option \"retry_count\" must be between 0 and 10");
-		}
-		options.has_retry_count = true;
-		return;
-	}
-	if (name == "retry_backoff_ms") {
-		options.retry_backoff_ms = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.retry_backoff_ms < 0 || options.retry_backoff_ms > 60000) {
-			throw BinderException("ai_query_data option \"retry_backoff_ms\" must be between 0 and 60000");
-		}
-		options.has_retry_backoff_ms = true;
-		return;
-	}
-	if (name == "max_concurrent_requests") {
-		options.max_concurrent_requests = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.max_concurrent_requests < 0 || options.max_concurrent_requests > 1024) {
-			throw BinderException("ai_query_data option \"max_concurrent_requests\" must be between 0 and 1024");
-		}
-		options.has_max_concurrent_requests = true;
-		return;
-	}
-	if (name == "min_request_interval_ms") {
-		options.min_request_interval_ms = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.min_request_interval_ms < 0 || options.min_request_interval_ms > 60000) {
-			throw BinderException("ai_query_data option \"min_request_interval_ms\" must be between 0 and 60000");
-		}
-		options.has_min_request_interval_ms = true;
-		return;
-	}
-	if (name == "timeout_seconds") {
-		options.timeout_seconds = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (options.timeout_seconds <= 0) {
-			throw BinderException("ai_query_data option \"timeout_seconds\" must be greater than 0");
-		}
-		options.has_timeout_seconds = true;
-		return;
-	}
-	if (name == "fail_on_error") {
-		options.fail_on_error = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		return;
-	}
-	throw BinderException("Unsupported ai_query_data option \"%s\"", name);
 }
 
 unique_ptr<TableRef> EmptyPromptQueryResult(const ParserOptions &options) {
@@ -2970,17 +2811,21 @@ void AiPromptSqlFunction(DataChunk &args, ExpressionState &state, Vector &result
 	auto &result_validity = FlatVector::Validity(result);
 	std::string auto_schema_context;
 	bool has_auto_schema_context = false;
+	StringVectorReader question_reader(args, 0);
+	auto schema_context_reader =
+	    OptionalStringReader(args, bind_data.has_schema_context_arg, bind_data.schema_context_index);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string question;
-		if (!ReadStringArgument(args, 0, row, question)) {
+		if (!question_reader.Read(row, question)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
 
 		auto schema_context = bind_data.schema_context;
-		if (bind_data.has_schema_context_arg &&
-		    !ReadStringArgument(args, bind_data.schema_context_index, row, schema_context)) {
+		if (bind_data.has_schema_context_arg && !schema_context_reader->Read(row, schema_context)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
@@ -2992,12 +2837,9 @@ void AiPromptSqlFunction(DataChunk &args, ExpressionState &state, Vector &result
 			schema_context = auto_schema_context;
 		}
 
-		auto options = bind_data.options;
-		if (bind_data.has_model_arg && !ReadStringArgument(args, bind_data.model_index, row, options.model)) {
-			result_validity.SetInvalid(row);
-			continue;
-		}
-		if (bind_data.has_provider_arg && !ReadStringArgument(args, bind_data.provider_index, row, options.provider)) {
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
 			result_validity.SetInvalid(row);
 			continue;
 		}
@@ -3171,143 +3013,9 @@ void ApplyPromptAssistantValueOption(PromptAssistantBindData &bind_data, PromptS
 		has_error = true;
 		return;
 	}
-	if (name == "model") {
-		bind_data.options.model = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
+	if (!ApplyCompletionValueOption(bind_data.options, function_name, name, value_p, true, false)) {
+		throw BinderException("Unsupported %s option \"%s\"", function_name, name);
 	}
-	if (name == "provider") {
-		bind_data.options.provider = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "profile" || name == "secret" || name == "secret_name") {
-		bind_data.options.secret_name = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "system_prompt") {
-		bind_data.options.system_prompt = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "base_url") {
-		bind_data.options.base_url = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "log_format") {
-		auto log_format = LowerAscii(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)));
-		if (log_format != "generic_json" && log_format != "generic" && log_format != "json" &&
-		    log_format != "otlp_json" && log_format != "otlp") {
-			throw BinderException("%s option \"log_format\" must be one of: generic_json, otlp_json", function_name);
-		}
-		bind_data.options.log_format = log_format;
-		return;
-	}
-	if (name == "log_tags") {
-		bind_data.options.log_tags = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		return;
-	}
-	if (name == "response_format") {
-		bind_data.options.response_format =
-		    NormalizeResponseFormatValue(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)), function_name);
-		return;
-	}
-	if (name == "response_schema" || name == "json_schema") {
-		bind_data.options.response_schema = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
-		ValidateResponseSchemaValue(bind_data.options.response_schema, function_name);
-		return;
-	}
-	if (name == "temperature") {
-		bind_data.options.temperature = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (bind_data.options.temperature < 0 || bind_data.options.temperature > 2) {
-			throw BinderException("%s option \"temperature\" must be between 0 and 2", function_name);
-		}
-		bind_data.options.has_temperature = true;
-		return;
-	}
-	if (name == "log_sample_rate") {
-		bind_data.options.log_sample_rate = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (bind_data.options.log_sample_rate < 0 || bind_data.options.log_sample_rate > 1) {
-			throw BinderException("%s option \"log_sample_rate\" must be between 0 and 1", function_name);
-		}
-		bind_data.options.has_log_sample_rate = true;
-		return;
-	}
-	if (name == "input_token_price_per_million") {
-		bind_data.options.input_token_price_per_million = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (!std::isfinite(bind_data.options.input_token_price_per_million) ||
-		    bind_data.options.input_token_price_per_million < 0) {
-			throw BinderException("%s option \"input_token_price_per_million\" must be greater than or equal to 0",
-			                      function_name);
-		}
-		bind_data.options.has_input_token_price_per_million = true;
-		return;
-	}
-	if (name == "output_token_price_per_million") {
-		bind_data.options.output_token_price_per_million = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
-		if (!std::isfinite(bind_data.options.output_token_price_per_million) ||
-		    bind_data.options.output_token_price_per_million < 0) {
-			throw BinderException("%s option \"output_token_price_per_million\" must be greater than or equal to 0",
-			                      function_name);
-		}
-		bind_data.options.has_output_token_price_per_million = true;
-		return;
-	}
-	if (name == "use_builtin_model_prices") {
-		bind_data.options.use_builtin_model_prices = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		bind_data.options.has_use_builtin_model_prices = true;
-		return;
-	}
-	if (name == "max_tokens") {
-		bind_data.options.max_tokens = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (bind_data.options.max_tokens <= 0) {
-			throw BinderException("%s option \"max_tokens\" must be greater than 0", function_name);
-		}
-		bind_data.options.has_max_tokens = true;
-		return;
-	}
-	if (name == "retry_count") {
-		bind_data.options.retry_count = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (bind_data.options.retry_count < 0 || bind_data.options.retry_count > 10) {
-			throw BinderException("%s option \"retry_count\" must be between 0 and 10", function_name);
-		}
-		bind_data.options.has_retry_count = true;
-		return;
-	}
-	if (name == "retry_backoff_ms") {
-		bind_data.options.retry_backoff_ms = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (bind_data.options.retry_backoff_ms < 0 || bind_data.options.retry_backoff_ms > 60000) {
-			throw BinderException("%s option \"retry_backoff_ms\" must be between 0 and 60000", function_name);
-		}
-		bind_data.options.has_retry_backoff_ms = true;
-		return;
-	}
-	if (name == "max_concurrent_requests") {
-		bind_data.options.max_concurrent_requests = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (bind_data.options.max_concurrent_requests < 0 || bind_data.options.max_concurrent_requests > 1024) {
-			throw BinderException("%s option \"max_concurrent_requests\" must be between 0 and 1024", function_name);
-		}
-		bind_data.options.has_max_concurrent_requests = true;
-		return;
-	}
-	if (name == "min_request_interval_ms") {
-		bind_data.options.min_request_interval_ms = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (bind_data.options.min_request_interval_ms < 0 || bind_data.options.min_request_interval_ms > 60000) {
-			throw BinderException("%s option \"min_request_interval_ms\" must be between 0 and 60000", function_name);
-		}
-		bind_data.options.has_min_request_interval_ms = true;
-		return;
-	}
-	if (name == "timeout_seconds") {
-		bind_data.options.timeout_seconds = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
-		if (bind_data.options.timeout_seconds <= 0) {
-			throw BinderException("%s option \"timeout_seconds\" must be greater than 0", function_name);
-		}
-		bind_data.options.has_timeout_seconds = true;
-		return;
-	}
-	if (name == "fail_on_error") {
-		bind_data.options.fail_on_error = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-		return;
-	}
-	throw BinderException("Unsupported %s option \"%s\"", function_name, name);
 }
 
 unique_ptr<FunctionData> PromptAssistantBindInternal(ClientContext &context, TableFunctionBindInput &input,
@@ -3873,36 +3581,50 @@ void RegisterAiAggregateFunction(ExtensionLoader &loader, const std::string &nam
 	loader.RegisterFunction(functions);
 }
 
+void AddCompletionNamedParameters(TableFunction &function, bool include_response_options,
+                                  bool include_log_payload_options) {
+	static const char *completion_options[] = {"model",
+	                                           "provider",
+	                                           "profile",
+	                                           "secret",
+	                                           "secret_name",
+	                                           "temperature",
+	                                           "system_prompt",
+	                                           "max_tokens",
+	                                           "base_url",
+	                                           "timeout_seconds",
+	                                           "retry_count",
+	                                           "retry_backoff_ms",
+	                                           "max_concurrent_requests",
+	                                           "min_request_interval_ms",
+	                                           "input_token_price_per_million",
+	                                           "output_token_price_per_million",
+	                                           "use_builtin_model_prices",
+	                                           "log_format",
+	                                           "log_tags",
+	                                           "log_sample_rate",
+	                                           "fail_on_error"};
+	for (auto name : completion_options) {
+		function.named_parameters[name] = OptionType(name);
+	}
+	if (include_response_options) {
+		function.named_parameters["response_format"] = LogicalType::VARCHAR;
+		function.named_parameters["response_schema"] = LogicalType::VARCHAR;
+		function.named_parameters["json_schema"] = LogicalType::VARCHAR;
+	}
+	if (include_log_payload_options) {
+		function.named_parameters["log_include_text"] = LogicalType::BOOLEAN;
+		function.named_parameters["log_strict"] = LogicalType::BOOLEAN;
+	}
+}
+
 void AddPromptQueryNamedParameters(TableFunction &function) {
 	function.named_parameters["schema_context"] = LogicalType::VARCHAR;
 	function.named_parameters["schema"] = LogicalType::VARCHAR;
 	function.named_parameters["include_tables"] = LogicalType::LIST(LogicalType::VARCHAR);
 	function.named_parameters["exclude_tables"] = LogicalType::LIST(LogicalType::VARCHAR);
 	function.named_parameters["sample_rows"] = LogicalType::BIGINT;
-	function.named_parameters["model"] = LogicalType::VARCHAR;
-	function.named_parameters["provider"] = LogicalType::VARCHAR;
-	function.named_parameters["profile"] = LogicalType::VARCHAR;
-	function.named_parameters["secret"] = LogicalType::VARCHAR;
-	function.named_parameters["secret_name"] = LogicalType::VARCHAR;
-	function.named_parameters["temperature"] = LogicalType::DOUBLE;
-	function.named_parameters["system_prompt"] = LogicalType::VARCHAR;
-	function.named_parameters["max_tokens"] = LogicalType::BIGINT;
-	function.named_parameters["base_url"] = LogicalType::VARCHAR;
-	function.named_parameters["retry_count"] = LogicalType::BIGINT;
-	function.named_parameters["retry_backoff_ms"] = LogicalType::BIGINT;
-	function.named_parameters["max_concurrent_requests"] = LogicalType::BIGINT;
-	function.named_parameters["min_request_interval_ms"] = LogicalType::BIGINT;
-	function.named_parameters["input_token_price_per_million"] = LogicalType::DOUBLE;
-	function.named_parameters["output_token_price_per_million"] = LogicalType::DOUBLE;
-	function.named_parameters["use_builtin_model_prices"] = LogicalType::BOOLEAN;
-	function.named_parameters["response_format"] = LogicalType::VARCHAR;
-	function.named_parameters["response_schema"] = LogicalType::VARCHAR;
-	function.named_parameters["json_schema"] = LogicalType::VARCHAR;
-	function.named_parameters["log_format"] = LogicalType::VARCHAR;
-	function.named_parameters["log_tags"] = LogicalType::VARCHAR;
-	function.named_parameters["log_sample_rate"] = LogicalType::DOUBLE;
-	function.named_parameters["timeout_seconds"] = LogicalType::BIGINT;
-	function.named_parameters["fail_on_error"] = LogicalType::BOOLEAN;
+	AddCompletionNamedParameters(function, true, false);
 }
 
 void AddPromptSchemaNamedParameters(TableFunction &function) {
@@ -3912,29 +3634,7 @@ void AddPromptSchemaNamedParameters(TableFunction &function) {
 }
 
 void AddAiRecordNamedParameters(TableFunction &function) {
-	function.named_parameters["model"] = LogicalType::VARCHAR;
-	function.named_parameters["provider"] = LogicalType::VARCHAR;
-	function.named_parameters["profile"] = LogicalType::VARCHAR;
-	function.named_parameters["secret"] = LogicalType::VARCHAR;
-	function.named_parameters["secret_name"] = LogicalType::VARCHAR;
-	function.named_parameters["temperature"] = LogicalType::DOUBLE;
-	function.named_parameters["system_prompt"] = LogicalType::VARCHAR;
-	function.named_parameters["max_tokens"] = LogicalType::BIGINT;
-	function.named_parameters["base_url"] = LogicalType::VARCHAR;
-	function.named_parameters["timeout_seconds"] = LogicalType::BIGINT;
-	function.named_parameters["retry_count"] = LogicalType::BIGINT;
-	function.named_parameters["retry_backoff_ms"] = LogicalType::BIGINT;
-	function.named_parameters["max_concurrent_requests"] = LogicalType::BIGINT;
-	function.named_parameters["min_request_interval_ms"] = LogicalType::BIGINT;
-	function.named_parameters["input_token_price_per_million"] = LogicalType::DOUBLE;
-	function.named_parameters["output_token_price_per_million"] = LogicalType::DOUBLE;
-	function.named_parameters["use_builtin_model_prices"] = LogicalType::BOOLEAN;
-	function.named_parameters["log_format"] = LogicalType::VARCHAR;
-	function.named_parameters["log_tags"] = LogicalType::VARCHAR;
-	function.named_parameters["log_sample_rate"] = LogicalType::DOUBLE;
-	function.named_parameters["log_include_text"] = LogicalType::BOOLEAN;
-	function.named_parameters["log_strict"] = LogicalType::BOOLEAN;
-	function.named_parameters["fail_on_error"] = LogicalType::BOOLEAN;
+	AddCompletionNamedParameters(function, false, true);
 }
 
 void AddPromptAssistantNamedParameters(TableFunction &function, bool include_error) {

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -108,42 +108,44 @@ std::string CurrentTimestamp() {
 }
 
 std::string JsonEscape(const std::string &input) {
-	std::ostringstream out;
+	std::string out;
+	out.reserve(input.size());
+	const char *hex = "0123456789abcdef";
 	for (auto c : input) {
 		switch (c) {
 		case '\\':
-			out << "\\\\";
+			out += "\\\\";
 			break;
 		case '"':
-			out << "\\\"";
+			out += "\\\"";
 			break;
 		case '\b':
-			out << "\\b";
+			out += "\\b";
 			break;
 		case '\f':
-			out << "\\f";
+			out += "\\f";
 			break;
 		case '\n':
-			out << "\\n";
+			out += "\\n";
 			break;
 		case '\r':
-			out << "\\r";
+			out += "\\r";
 			break;
 		case '\t':
-			out << "\\t";
+			out += "\\t";
 			break;
 		default:
 			if (static_cast<unsigned char>(c) < 0x20) {
 				auto value = static_cast<unsigned char>(c);
-				out << "\\u";
-				const char *hex = "0123456789abcdef";
-				out << "00" << hex[(value >> 4) & 0xf] << hex[value & 0xf];
+				out += "\\u00";
+				out.push_back(hex[(value >> 4) & 0xf]);
+				out.push_back(hex[value & 0xf]);
 			} else {
-				out << c;
+				out.push_back(c);
 			}
 		}
 	}
-	return out.str();
+	return out;
 }
 
 std::string JsonDouble(double input) {

--- a/src/include/duckdb_ai_extension.hpp
+++ b/src/include/duckdb_ai_extension.hpp
@@ -4,10 +4,14 @@
 
 namespace duckdb {
 
+//! DuckDB extension entry point for registering the duckdb_ai SQL surface.
 class DuckdbAiExtension : public Extension {
 public:
+	//! Register settings, secrets, scalar functions, aggregate functions, and table functions.
 	void Load(ExtensionLoader &db) override;
+	//! Return the extension catalog name.
 	std::string Name() override;
+	//! Return the build/version string exposed by DuckDB.
 	std::string Version() const override;
 };
 

--- a/src/include/duckdb_ai_provider.hpp
+++ b/src/include/duckdb_ai_provider.hpp
@@ -7,6 +7,7 @@
 namespace duckdb {
 namespace duckdb_ai {
 
+//! Runtime provider configuration after aliases, defaults, environment variables, and explicit options are resolved.
 struct ProviderConfig {
 	std::string provider;
 	std::string protocol;
@@ -18,6 +19,7 @@ struct ProviderConfig {
 	bool requires_api_key;
 };
 
+//! Per-call completion, embedding, retry, rate-limit, logging, and cost-estimation options.
 struct CompletionOptions {
 	std::string model;
 	std::string provider;
@@ -59,6 +61,7 @@ struct CompletionOptions {
 	std::string response_schema;
 };
 
+//! Parsed result from a text-generation provider response.
 struct CompletionResult {
 	std::string text;
 	std::string raw_response;
@@ -69,6 +72,7 @@ struct CompletionResult {
 	int64_t elapsed_ms;
 };
 
+//! Parsed result from an embedding provider response.
 struct EmbeddingResult {
 	std::vector<double> values;
 	std::string raw_response;
@@ -78,6 +82,7 @@ struct EmbeddingResult {
 	int64_t elapsed_ms;
 };
 
+//! In-process usage record exposed through ai_usage().
 struct UsageEvent {
 	uint64_t event_id;
 	std::string created_at;
@@ -97,6 +102,7 @@ struct UsageEvent {
 	double estimated_cost_usd;
 };
 
+//! Built-in model pricing row exposed through ai_models().
 struct ModelPrice {
 	std::string provider;
 	std::string model;
@@ -108,6 +114,7 @@ struct ModelPrice {
 	std::string last_reviewed;
 };
 
+//! A JSON Schema property projected by ai_complete_record().
 struct JsonSchemaProperty {
 	std::string name;
 	std::string type;
@@ -117,8 +124,10 @@ struct JsonSchemaProperty {
 	std::vector<JsonSchemaProperty> item_children;
 };
 
+//! JSON value category used by ai_complete_record() projection.
 enum class JsonExtractedKind : uint8_t { MISSING, NULL_VALUE, BOOLEAN, NUMBER, STRING, ARRAY, OBJECT };
 
+//! JSON value extracted from an object field for typed DuckDB projection.
 struct JsonExtractedValue {
 	JsonExtractedKind kind = JsonExtractedKind::MISSING;
 	bool boolean_value = false;
@@ -131,27 +140,48 @@ struct JsonExtractedValue {
 	std::string json_value;
 };
 
+//! Resolve a provider/model pair using provider aliases, defaults, and environment overrides.
 ProviderConfig ResolveProvider(const std::string &provider, const std::string &model);
+//! Resolve provider configuration from a full option set.
 ProviderConfig ResolveProvider(const CompletionOptions &options);
+//! Normalize provider aliases such as anthropic -> claude and local -> openai_compatible.
 std::string NormalizeProviderName(const std::string &provider);
+//! Return the default base URL for a supported provider.
 std::string ProviderBaseUrl(const std::string &provider);
+//! Return the provider protocol used for request/response shaping.
 std::string ProviderProtocol(const std::string &provider);
+//! Build a completion request payload without making a network call.
 std::string BuildRequestJson(const std::string &prompt, const std::string &model, const std::string &provider);
+//! Build a completion request payload from a full option set.
 std::string BuildRequestJson(const std::string &prompt, const CompletionOptions &options);
+//! Execute a completion request and parse the provider response.
 CompletionResult Complete(const std::string &prompt, const std::string &model, const std::string &provider);
+//! Execute a completion request from a full option set.
 CompletionResult Complete(const std::string &prompt, const CompletionOptions &options);
+//! Build an embedding request payload without making a network call.
 std::string BuildEmbeddingRequestJson(const std::string &input, const std::string &model, const std::string &provider);
+//! Build an embedding request payload from a full option set.
 std::string BuildEmbeddingRequestJson(const std::string &input, const CompletionOptions &options);
+//! Execute an embedding request and parse the provider response.
 EmbeddingResult Embed(const std::string &input, const std::string &model, const std::string &provider);
+//! Execute an embedding request from a full option set.
 EmbeddingResult Embed(const std::string &input, const CompletionOptions &options);
+//! Return a snapshot of the bounded in-process usage buffer.
 std::vector<UsageEvent> UsageEvents();
+//! Clear the in-process usage buffer.
 void ClearUsageEvents();
+//! Record local deterministic work that does not call a provider, such as ai_schema_prompt().
 void RecordLocalUsageEvent(const std::string &event, int64_t input_chars, int64_t response_chars);
+//! Return the built-in model pricing catalog.
 std::vector<ModelPrice> ModelPrices();
+//! Validate that the input is one complete JSON document.
 bool ValidateJsonDocument(const std::string &input, std::string &error);
+//! Validate a JSON document against the supported JSON Schema subset.
 bool ValidateJsonAgainstSchema(const std::string &input, const std::string &schema, std::string &error);
+//! Extract top-level object properties from a JSON Schema object.
 bool ExtractJsonSchemaProperties(const std::string &schema, std::vector<JsonSchemaProperty> &properties,
                                  std::string &error);
+//! Extract named fields from a top-level JSON object for typed projection.
 bool ExtractJsonObjectFields(const std::string &input, const std::vector<std::string> &field_names,
                              std::vector<JsonExtractedValue> &values, std::string &error);
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -15,6 +15,8 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   docsSidebar: [
     'index',
+    'functions',
+    'provider-guides',
     'VALIDATION',
     'SMOKE_TESTING',
     'DISTRIBUTION',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -9,9 +9,12 @@ import styles from './index.module.css';
 const functionGroups = [
   'ai_complete',
   'ai_complete_json',
+  'ai_complete_record',
   'ai_embed',
+  'ai_filter',
   'ai_sql',
   'ai_query_data',
+  'ai_count_tokens',
   'ai_usage',
 ];
 
@@ -64,9 +67,13 @@ function DocsSummary(): ReactNode {
             <p>
               The extension is source-first while the public SQL surface and
               provider configuration contract settle. The docs include local
-              validation evidence, smoke-test commands, and release notes.
+              function reference, validation evidence, smoke-test commands, and
+              release notes.
             </p>
             <ul className={styles.linkList}>
+              <li>
+                <Link to="/docs/functions">SQL function reference</Link>
+              </li>
               <li>
                 <Link to="/docs/VALIDATION">Validation evidence</Link>
               </li>


### PR DESCRIPTION
## Summary

Make the repository easier to use from a customer-facing entry point:

- rewrite the README around quick start, common workflows, provider setup, safety, usage visibility, and links to deeper docs
- add a DuckDB-style SQL function reference for every public function
- add provider guides with end-to-end examples for every supported provider
- wire the new docs into Docusaurus and the site landing page
- add AGENTS.md, CLAUDE.md symlink, and CONTRIBUTING.md so repo-local working conventions are explicit
- reduce duplicated completion option handling and document the public extension/provider APIs in code

## Why

The previous README was accurate but read like an implementation inventory. This change gives users a straightforward path from loading the extension to running real provider-backed SQL, while moving full reference material into docs pages that are easier to navigate and maintain.

The small implementation cleanup keeps the public SQL surface unchanged while making the option parsing paths less repetitive and easier to extend safely.

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release`
- `GEN=ninja make test`
- `python3 test/smoke/mock_provider_smoke.py`
- `npm run typecheck` in `website/`
- `npm run build` in `website/`
