### PR TITLE
docs: improve readme and add cookbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
+<p align="center">
+  <img src="docs/assets/duckdb-ai-logo.svg" alt="duckdb_ai logo proposal" width="520">
+</p>
+
 # duckdb_ai
 
-Run AI workflows directly inside DuckDB SQL.
+`duckdb_ai` is a DuckDB extension for model-backed analytical workflows inside
+SQL. It adds functions for completions, structured JSON extraction, embeddings,
+natural-language filters, read-only SQL generation, and usage tracking.
 
-`duckdb_ai` adds SQL functions for completions, structured JSON extraction,
-embeddings, natural-language filters, SQL generation, and usage tracking. Use it
-when you want to enrich local DuckDB analytics with models while keeping the
-workflow in SQL.
+The extension is intended for local analytics work where data already lives in
+DuckDB. You can enrich table columns with model output, project JSON responses
+into typed DuckDB values, compare text with embeddings, and ask questions over a
+bounded schema prompt without moving the workflow into a separate application.
 
 ```sql
+INSTALL duckdb_ai FROM community;
 LOAD duckdb_ai;
 
 SELECT ai_summarize(
     'DuckDB is an analytical database built for fast local queries.',
     provider := 'ollama',
-    model := 'llama3.2'
+    model := 'gemma4:e4b'
 );
 ```
+
+The public API keeps provider credentials out of SQL arguments, supports DuckDB
+`TYPE duckdb_ai` secrets, and validates generated SQL as a single read-only
+DuckDB `SELECT` before returning or executing it.
 
 ## What You Can Do
 
@@ -33,25 +44,22 @@ SELECT ai_summarize(
 
 ## Status
 
-This is a preview extension. The current repository is source-first: public
-binary installation is not configured yet. See
-[`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md) for the current distribution
-stance.
+This is a preview extension available through the DuckDB community extension
+repository. The SQL surface is still expected to evolve while the extension
+settles.
 
 ## Quick Start
 
-Build the extension once, then run the bundled DuckDB shell:
-
-```sh
-git submodule update --init --recursive
-GEN=ninja make release
-./build/release/duckdb
-```
-
-Inside DuckDB:
+Install and load the extension from DuckDB:
 
 ```sql
+INSTALL duckdb_ai FROM community;
 LOAD duckdb_ai;
+```
+
+Confirm that the extension loaded:
+
+```sql
 SELECT ai_provider_protocol('openai');
 ```
 
@@ -59,14 +67,15 @@ For a local model with Ollama:
 
 ```sh
 ollama serve
-ollama pull llama3.2
+ollama pull gemma4:e4b
 ```
 
 ```sql
+INSTALL duckdb_ai FROM community;
 LOAD duckdb_ai;
 
 SET duckdb_ai_provider = 'ollama';
-SET duckdb_ai_model = 'llama3.2';
+SET duckdb_ai_model = 'gemma4:e4b';
 
 SELECT ai_complete('Write one sentence about DuckDB.');
 ```
@@ -74,6 +83,7 @@ SELECT ai_complete('Write one sentence about DuckDB.');
 For OpenAI, store the API key in a DuckDB secret:
 
 ```sql
+INSTALL duckdb_ai FROM community;
 LOAD duckdb_ai;
 
 CREATE OR REPLACE SECRET openai_ai (
@@ -94,61 +104,115 @@ listed.
 
 ## Everyday Examples
 
+The examples below use ordinary table columns. For pasteable end-to-end
+walkthroughs, use the docs cookbooks:
+
+- [Create the sample support tickets table](docs/cookbooks/support-ticket-data.md)
+- [Enrich support tickets with AI text functions](docs/cookbooks/support-ticket-enrichment.md)
+- [Compare support tickets with embeddings](docs/cookbooks/support-ticket-similarity.md)
+- [Extract typed records from model output](docs/cookbooks/structured-triage-records.md)
+- [Generate read-only SQL over local tables](docs/cookbooks/sql-assistant.md)
+
 Summarize support notes by customer:
 
 ```sql
 SELECT
     customer_id,
-    ai_summarize_agg(note ORDER BY created_at) AS summary
-FROM support_notes
+    ai_summarize_agg(subject || ': ' || body ORDER BY created_at) AS summary
+FROM support_tickets
 GROUP BY customer_id;
 ```
 
-Classify messages:
+Classify tickets using their subject and body:
 
 ```sql
 SELECT
-    message_id,
-    ai_classify(body, 'billing, support, sales, other') AS category
-FROM inbox;
+    ticket_id,
+    ai_classify(
+        subject || chr(10) || body,
+        'billing, performance, integration, documentation, other'
+    ) AS category
+FROM support_tickets;
 ```
 
-Filter rows with a natural-language predicate:
+Filter rows with a natural-language predicate over multiple text columns:
 
 ```sql
 SELECT *
-FROM tickets
-WHERE ai_filter(description, 'mentions an urgent billing problem');
-```
-
-Extract structured data as typed columns:
-
-```sql
-SELECT *
-FROM ai_complete_record(
-    'Extract a company profile for DuckDB.',
-    '{
-      "type": "object",
-      "properties": {
-        "name": {"type": "string"},
-        "category": {"type": "string"},
-        "confidence": {"type": "number"}
-      },
-      "required": ["name", "category"]
-    }',
-    provider := 'openai',
-    model := 'gpt-4o-mini'
+FROM support_tickets
+WHERE ai_filter(
+    subject || chr(10) || body || chr(10) || internal_note,
+    'mentions urgent production impact or needs engineering follow-up'
 );
+```
+
+Extract compact JSON from a body column:
+
+```sql
+SELECT
+    ticket_id,
+    ai_extract(
+        body,
+        'Return compact JSON with product_area, customer_request, and urgency'
+    ) AS extracted_json
+FROM support_tickets;
+```
+
+Redact internal notes before sharing them:
+
+```sql
+SELECT
+    ticket_id,
+    ai_redact(internal_note) AS redacted_internal_note
+FROM support_tickets;
+```
+
+Translate customer-facing text stored in columns:
+
+```sql
+SELECT
+    ticket_id,
+    ai_translate(subject || ': ' || body, 'Dutch') AS dutch_update
+FROM support_tickets
+WHERE language = 'en';
 ```
 
 Create embeddings and compare text:
 
 ```sql
-SELECT ai_similarity(
-    'DuckDB analytics',
-    'analytical SQL database',
+SELECT
+    left_ticket.ticket_id AS left_ticket_id,
+    right_ticket.ticket_id AS right_ticket_id,
+    ai_similarity(
+        left_ticket.subject || chr(10) || left_ticket.body,
+        right_ticket.subject || chr(10) || right_ticket.body,
+        provider := 'openai',
+        model := 'text-embedding-3-small'
+    ) AS similarity
+FROM support_tickets AS left_ticket
+JOIN support_tickets AS right_ticket
+    ON left_ticket.ticket_id < right_ticket.ticket_id
+ORDER BY similarity DESC;
+```
+
+Create typed columns from one prompt:
+
+```sql
+SELECT *
+FROM ai_complete_record(
+    'Extract a support triage profile for the query regression ticket.',
+    '{
+      "type": "object",
+      "properties": {
+        "product_area": {"type": "string"},
+        "needs_engineering": {"type": "boolean"},
+        "urgency_score": {"type": "integer"},
+        "recommended_owner": {"type": "string"}
+      },
+      "required": ["product_area", "needs_engineering", "urgency_score"]
+    }',
     provider := 'openai',
-    model := 'text-embedding-3-small'
+    model := 'gpt-4o-mini'
 );
 ```
 
@@ -156,28 +220,44 @@ Generate and run read-only SQL over local tables:
 
 ```sql
 SELECT summary
-FROM ai_schema_prompt(include_tables := ['main.orders']);
+FROM ai_schema_prompt(
+    include_tables := ['main.support_tickets'],
+    sample_rows := 3
+);
 
 SELECT ai_sql(
-    'count orders by status',
-    schema_context := (
-        SELECT summary
-        FROM ai_schema_prompt(include_tables := ['main.orders'])
-    )
+    'Which high-priority customers have the lowest satisfaction scores?',
+    include_tables := ['main.support_tickets'],
+    sample_rows := 3
 );
 
 SELECT *
 FROM ai_query_data(
-    'count orders by status',
-    schema_context := (
-        SELECT summary
-        FROM ai_schema_prompt(include_tables := ['main.orders'])
-    )
+    'Count tickets by priority and customer tier',
+    include_tables := ['main.support_tickets'],
+    sample_rows := 3
 );
 ```
 
 `ai_sql` and `ai_query_data` only accept one parser-valid read-only DuckDB
 `SELECT` statement before returning or executing generated SQL.
+
+## Highlighted Functions
+
+These are the main functions most users should start with:
+
+| Function | Use it for |
+| --- | --- |
+| `ai_complete` | General prompt-to-text completions from SQL. |
+| `ai_summarize` / `ai_summarize_agg` | Summarizing one text value or a grouped set of rows. |
+| `ai_classify` | Assigning one label from a controlled list. |
+| `ai_filter` | Filtering rows with a natural-language predicate. |
+| `ai_extract` | Pulling compact structured facts from text. |
+| `ai_complete_record` | Returning model output as typed DuckDB columns from a JSON Schema. |
+| `ai_embed` / `ai_similarity` | Creating embeddings and comparing text semantically. |
+| `ai_schema_prompt` | Building deterministic local table context for SQL generation. |
+| `ai_sql` / `ai_query_data` | Generating, validating, and optionally running read-only DuckDB `SELECT` statements. |
+| `ai_usage` | Inspecting recent model calls, latency, token estimates, and status. |
 
 ## Function Map
 
@@ -235,7 +315,7 @@ CREATE OR REPLACE SECRET local_llm (
     TYPE duckdb_ai,
     AI_PROVIDER 'local',
     BASE_URL 'http://localhost:11434/v1',
-    MODEL 'llama3.2'
+    MODEL 'gemma4:e4b'
 );
 
 SELECT ai_complete('hello', secret := 'local_llm');
@@ -353,6 +433,5 @@ These controls apply to completion and embedding calls.
   every supported provider.
 - [`docs/SMOKE_TESTING.md`](docs/SMOKE_TESTING.md): local mock-provider, Ollama,
   and remote-provider smoke checks.
-- [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md): current install and release
-  stance.
+- [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md): release and distribution notes.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md): development workflow for contributors.

--- a/docs/assets/duckdb-ai-logo.svg
+++ b/docs/assets/duckdb-ai-logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 180" role="img" aria-labelledby="title desc">
+  <title id="title">duckdb_ai logo proposal</title>
+  <desc id="desc">A lemon yellow badge with black AI sparkle marks and the duckdb_ai wordmark.</desc>
+  <rect width="720" height="180" fill="#ffffff"/>
+  <g transform="translate(32 20)">
+    <circle cx="70" cy="70" r="70" fill="#fff100"/>
+    <path d="M67 22C78 51 89 62 118 73C89 84 78 95 67 124C56 95 45 84 16 73C45 62 56 51 67 22Z" fill="#0d0d0d"/>
+    <path d="M108 18C113 33 119 39 134 44C119 49 113 55 108 70C103 55 97 49 82 44C97 39 103 33 108 18Z" fill="#0d0d0d"/>
+  </g>
+  <g transform="translate(205 49)" fill="#0d0d0d">
+    <text x="0" y="55" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="64" font-weight="760" letter-spacing="0">duckdb_ai</text>
+    <text x="3" y="91" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="19" font-weight="600" fill="#626262">model-backed analytics in DuckDB SQL</text>
+  </g>
+</svg>

--- a/docs/cookbooks/index.md
+++ b/docs/cookbooks/index.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 1
+---
+
+# Cookbooks
+
+These cookbooks show practical `duckdb_ai` workflows over local DuckDB tables.
+They use the same `support_tickets` sample data so you can move from one example
+to the next without changing context.
+
+## Start with sample data
+
+- [Create the sample support tickets table](support-ticket-data.md): pasteable
+  setup data with text, metadata, numeric, and timestamp columns.
+
+## Try common workflows
+
+- [Enrich support tickets with AI text functions](support-ticket-enrichment.md):
+  summarize, classify, filter, extract, redact, and translate table columns.
+- [Compare support tickets with embeddings](support-ticket-similarity.md): rank
+  tickets by semantic similarity.
+- [Extract typed records from model output](structured-triage-records.md): project
+  structured JSON into DuckDB columns.
+- [Generate read-only SQL over local tables](sql-assistant.md): use local schema
+  context with `ai_schema_prompt`, `ai_sql`, and `ai_query_data`.
+
+Provider setup is covered separately in the [provider guides](../provider-guides.md).

--- a/docs/cookbooks/sql-assistant.md
+++ b/docs/cookbooks/sql-assistant.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 6
+---
+
+# Generate read-only SQL over local tables
+
+Use this cookbook when you want a model to write DuckDB `SELECT` statements from
+local table context. The SQL assistant functions validate that generated SQL is
+one parser-valid read-only `SELECT` before returning or executing it.
+
+## Prerequisites
+
+- Configure a completion provider.
+- Create the [sample `support_tickets` table](support-ticket-data.md).
+
+## Inspect the schema prompt
+
+Start by checking what table context the model will see:
+
+```sql
+SELECT summary
+FROM ai_schema_prompt(
+    include_tables := ['main.support_tickets'],
+    sample_rows := 3
+);
+```
+
+The context includes table names, column names, types, and bounded sample rows.
+
+## Generate SQL without running it
+
+Use `ai_sql` when you want to inspect or store the generated query:
+
+```sql
+SELECT ai_sql(
+    'Which high-priority customers have the lowest satisfaction scores?',
+    include_tables := ['main.support_tickets'],
+    sample_rows := 3
+) AS generated_sql;
+```
+
+## Generate and run SQL
+
+Use `ai_query_data` when you want the generated query to run immediately:
+
+```sql
+SELECT *
+FROM ai_query_data(
+    'Count tickets by priority and customer tier',
+    include_tables := ['main.support_tickets'],
+    sample_rows := 3
+);
+```
+
+## Keep context scoped
+
+Limit `include_tables` to the tables relevant to the question. For a larger
+database, this keeps the prompt smaller and reduces the chance that the model
+uses the wrong table.
+
+```sql
+SELECT ai_sql(
+    'Show the average satisfaction score by channel for high priority tickets',
+    include_tables := ['main.support_tickets'],
+    sample_rows := 2
+);
+```
+
+## Validate generated SQL yourself
+
+If you store generated SQL before running it, validate it again at the boundary:
+
+```sql
+WITH generated AS (
+    SELECT ai_sql(
+        'Count tickets by customer tier',
+        include_tables := ['main.support_tickets'],
+        sample_rows := 3
+    ) AS sql_text
+)
+SELECT ai_validate_read_only_sql(sql_text) AS validated_sql
+FROM generated;
+```

--- a/docs/cookbooks/structured-triage-records.md
+++ b/docs/cookbooks/structured-triage-records.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 5
+---
+
+# Extract typed records from model output
+
+Use this cookbook when you want a model to return structured JSON and project the
+result into typed DuckDB columns.
+
+## Prerequisites
+
+- Configure a completion provider.
+- Create the [sample `support_tickets` table](support-ticket-data.md) if you want
+  local ticket context for your prompt.
+
+## Create one triage record
+
+`ai_complete_record` takes a prompt and a JSON Schema. Top-level schema
+properties become DuckDB columns.
+
+```sql
+SELECT *
+FROM ai_complete_record(
+    'Extract a support triage profile for the query regression ticket.',
+    '{
+      "type": "object",
+      "properties": {
+        "product_area": {"type": "string"},
+        "needs_engineering": {"type": "boolean"},
+        "urgency_score": {"type": "integer"},
+        "recommended_owner": {"type": "string"}
+      },
+      "required": ["product_area", "needs_engineering", "urgency_score"]
+    }',
+    provider := 'openai',
+    model := 'gpt-4o-mini'
+);
+```
+
+Result shape:
+
+| Column | Type |
+| --- | --- |
+| `product_area` | `VARCHAR` |
+| `needs_engineering` | `BOOLEAN` |
+| `urgency_score` | `BIGINT` |
+| `recommended_owner` | `VARCHAR` |
+
+## Prepare table context for the prompt
+
+`ai_complete_record` is a table function, so its prompt is bound as a constant
+argument. For a row-specific record, first prepare the prompt text you want to
+send:
+
+```sql
+SELECT
+    'Extract a support triage profile from this ticket: ' ||
+    subject || chr(10) ||
+    body || chr(10) ||
+    internal_note AS prompt
+FROM support_tickets
+WHERE ticket_id = 1004;
+```
+
+Then use that text as the prompt argument to `ai_complete_record`.
+
+## Choose this over JSON text when types matter
+
+Use this pattern when downstream SQL needs typed fields:
+
+```sql
+WITH triage AS (
+    SELECT *
+    FROM ai_complete_record(
+        'Extract a support triage profile for ticket 1004.',
+        '{
+          "type": "object",
+          "properties": {
+            "product_area": {"type": "string"},
+            "needs_engineering": {"type": "boolean"},
+            "urgency_score": {"type": "integer"}
+          },
+          "required": ["product_area", "needs_engineering", "urgency_score"]
+        }',
+        provider := 'openai',
+        model := 'gpt-4o-mini'
+    )
+)
+SELECT *
+FROM triage
+WHERE needs_engineering
+  AND urgency_score >= 7;
+```

--- a/docs/cookbooks/support-ticket-data.md
+++ b/docs/cookbooks/support-ticket-data.md
@@ -1,0 +1,106 @@
+---
+sidebar_position: 2
+---
+
+# Create the sample support tickets table
+
+Use this small table to try the cookbook examples. It includes customer
+metadata, timestamps, free-text ticket fields, numeric account context, and an
+internal note column with realistic content for redaction tests.
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE TABLE support_tickets AS
+SELECT *
+FROM (
+    VALUES
+        (
+            1001,
+            'acme_corp',
+            'enterprise',
+            TIMESTAMP '2026-06-28 09:15:00',
+            'email',
+            'high',
+            120000,
+            2,
+            'en',
+            'Slack export delayed',
+            'The Slack export has been stuck for two hours and blocks the finance close.',
+            'Escalated by CSM. Mentions workspace ws_prod_eu and user pat@acme.test.'
+        ),
+        (
+            1002,
+            'acme_corp',
+            'enterprise',
+            TIMESTAMP '2026-06-28 10:40:00',
+            'chat',
+            'medium',
+            120000,
+            3,
+            'en',
+            'Invoice owner changed',
+            'Please update the billing owner before the next renewal invoice is issued.',
+            'Billing contact moved teams; keep renewal risk on the account watchlist.'
+        ),
+        (
+            1003,
+            'northwind',
+            'startup',
+            TIMESTAMP '2026-06-29 13:05:00',
+            'web',
+            'low',
+            18000,
+            5,
+            'nl',
+            'Documentation request',
+            'Customer asks for an example that joins order rows with shipment status.',
+            'Good candidate for a docs snippet; no production impact.'
+        ),
+        (
+            1004,
+            'globex',
+            'business',
+            TIMESTAMP '2026-06-30 08:20:00',
+            'email',
+            'high',
+            64000,
+            1,
+            'en',
+            'Query regression after upgrade',
+            'Dashboard query that used to finish in 8 seconds now times out after the upgrade.',
+            'Likely performance regression. Ask engineering to inspect query_id q_8842.'
+        )
+) AS t(
+    ticket_id,
+    customer_id,
+    customer_tier,
+    created_at,
+    channel,
+    priority,
+    arr_usd,
+    satisfaction_score,
+    language,
+    subject,
+    body,
+    internal_note
+);
+```
+
+Check that the table is ready:
+
+```sql
+SELECT
+    count(*) AS ticket_count,
+    min(created_at) AS first_ticket,
+    max(created_at) AS last_ticket
+FROM support_tickets;
+```
+
+Expected shape:
+
+| ticket_count | first_ticket | last_ticket |
+| --- | --- | --- |
+| `4` | `2026-06-28 09:15:00` | `2026-06-30 08:20:00` |
+
+Next: [enrich support tickets with AI text functions](support-ticket-enrichment.md).

--- a/docs/cookbooks/support-ticket-enrichment.md
+++ b/docs/cookbooks/support-ticket-enrichment.md
@@ -1,0 +1,116 @@
+---
+sidebar_position: 3
+---
+
+# Enrich support tickets with AI text functions
+
+Use this cookbook when you have text columns in a local table and want to add AI
+summaries, labels, extraction, redaction, or translations in SQL.
+
+## Prerequisites
+
+- Build and load the extension.
+- Configure a completion provider with settings or a `TYPE duckdb_ai` secret.
+- Create the [sample `support_tickets` table](support-ticket-data.md).
+
+## Summarize each ticket
+
+Combine the columns that give the model enough context:
+
+```sql
+SELECT
+    ticket_id,
+    ai_summarize(subject || chr(10) || body) AS ticket_summary
+FROM support_tickets;
+```
+
+## Summarize by customer
+
+Use the aggregate form when several rows belong to the same account:
+
+```sql
+SELECT
+    customer_id,
+    ai_summarize_agg(subject || ': ' || body ORDER BY created_at) AS summary
+FROM support_tickets
+GROUP BY customer_id;
+```
+
+## Classify tickets
+
+Keep labels short and mutually exclusive:
+
+```sql
+SELECT
+    ticket_id,
+    ai_classify(
+        subject || chr(10) || body,
+        'billing, performance, integration, documentation, other'
+    ) AS category
+FROM support_tickets;
+```
+
+## Filter rows with a natural-language predicate
+
+Use `ai_filter` when keyword logic would be too brittle:
+
+```sql
+SELECT *
+FROM support_tickets
+WHERE ai_filter(
+    subject || chr(10) || body || chr(10) || internal_note,
+    'mentions urgent production impact or needs engineering follow-up'
+);
+```
+
+## Extract compact JSON
+
+Use `ai_extract` for lightweight structured values that can stay in a JSON text
+column:
+
+```sql
+SELECT
+    ticket_id,
+    ai_extract(
+        body,
+        'Return compact JSON with product_area, customer_request, and urgency'
+    ) AS extracted_json
+FROM support_tickets;
+```
+
+Use [`ai_complete_record`](structured-triage-records.md) instead when you need
+typed DuckDB columns.
+
+## Redact internal notes
+
+Redact notes before sharing operational context outside the team:
+
+```sql
+SELECT
+    ticket_id,
+    ai_redact(internal_note) AS redacted_internal_note
+FROM support_tickets;
+```
+
+## Translate customer-facing text
+
+Translate only the rows that need it:
+
+```sql
+SELECT
+    ticket_id,
+    ai_translate(subject || ': ' || body, 'Dutch') AS dutch_update
+FROM support_tickets
+WHERE language = 'en';
+```
+
+## Inspect usage
+
+After running provider calls, inspect recent usage events:
+
+```sql
+SELECT provider, model, request_tokens_estimated, output_tokens_estimated, elapsed_ms
+FROM ai_usage()
+ORDER BY event_id DESC
+LIMIT 10;
+```

--- a/docs/cookbooks/support-ticket-similarity.md
+++ b/docs/cookbooks/support-ticket-similarity.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 4
+---
+
+# Compare support tickets with embeddings
+
+Use this cookbook to find semantically similar support tickets from text columns.
+`ai_similarity` embeds both inputs with the same model and returns cosine
+similarity.
+
+## Prerequisites
+
+- Configure an embedding-capable provider.
+- Create the [sample `support_tickets` table](support-ticket-data.md).
+
+For OpenAI, use an embedding model such as `text-embedding-3-small`.
+
+## Rank ticket pairs
+
+Compare every ticket pair and rank the closest matches:
+
+```sql
+SELECT
+    left_ticket.ticket_id AS left_ticket_id,
+    right_ticket.ticket_id AS right_ticket_id,
+    ai_similarity(
+        left_ticket.subject || chr(10) || left_ticket.body,
+        right_ticket.subject || chr(10) || right_ticket.body,
+        provider := 'openai',
+        model := 'text-embedding-3-small'
+    ) AS similarity
+FROM support_tickets AS left_ticket
+JOIN support_tickets AS right_ticket
+    ON left_ticket.ticket_id < right_ticket.ticket_id
+ORDER BY similarity DESC;
+```
+
+## Compare against a target description
+
+Use a fixed description when you want to find rows that match a theme:
+
+```sql
+SELECT
+    ticket_id,
+    subject,
+    ai_similarity(
+        subject || chr(10) || body,
+        'production incident blocking an important business workflow',
+        provider := 'openai',
+        model := 'text-embedding-3-small'
+    ) AS similarity
+FROM support_tickets
+ORDER BY similarity DESC;
+```
+
+## Keep batches bounded
+
+Pairwise comparison grows quickly. For larger tables, filter first:
+
+```sql
+SELECT
+    left_ticket.ticket_id AS left_ticket_id,
+    right_ticket.ticket_id AS right_ticket_id,
+    ai_similarity(
+        left_ticket.subject || chr(10) || left_ticket.body,
+        right_ticket.subject || chr(10) || right_ticket.body,
+        provider := 'openai',
+        model := 'text-embedding-3-small'
+    ) AS similarity
+FROM support_tickets AS left_ticket
+JOIN support_tickets AS right_ticket
+    ON left_ticket.ticket_id < right_ticket.ticket_id
+WHERE left_ticket.priority = 'high'
+   OR right_ticket.priority = 'high'
+ORDER BY similarity DESC;
+```
+
+For repeated large workloads, store embeddings with `ai_embed` and compare those
+vectors in a separate workflow instead of recomputing every pair.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,8 @@ SQL, usage logging, and local validation evidence.
 
 - [SQL function reference](functions.md): every scalar, aggregate, and table
   function exposed by the extension, with examples and result shapes.
+- [Cookbooks](cookbooks/index.md): practical workflows over local tables,
+  including text enrichment, similarity, structured records, and SQL generation.
 - [Provider guides](provider-guides.md): end-to-end examples for Ollama, OpenAI,
   Azure OpenAI, Claude, Gemini, Mistral, Z.ai, DeepSeek, OpenRouter, and local
   OpenAI-compatible gateways.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -15,6 +15,21 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   docsSidebar: [
     'index',
+    {
+      type: 'category',
+      label: 'Cookbooks',
+      link: {
+        type: 'doc',
+        id: 'cookbooks/index',
+      },
+      items: [
+        'cookbooks/support-ticket-data',
+        'cookbooks/support-ticket-enrichment',
+        'cookbooks/support-ticket-similarity',
+        'cookbooks/structured-triage-records',
+        'cookbooks/sql-assistant',
+      ],
+    },
     'functions',
     'provider-guides',
     'VALIDATION',


### PR DESCRIPTION
Refreshes the public README and docs so the community-extension install path, common function entry points, cookbook workflows, and a simple logo proposal are easier for new users to understand.

### Codex description

- Adds a more serious README opening, community-extension quick start, highlighted functions, Gemma 4 Ollama examples, and logo proposal
- Adds cookbook docs for sample support-ticket data, text enrichment, similarity, structured records, and SQL assistant workflows
- Wires the cookbook docs into the Docusaurus landing page and sidebar