### PR TITLE
feat(providers): add managed providers and privacy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ FROM support_tickets;
 Redact internal notes before sharing them:
 
 ```sql
+-- Run OpenAI Privacy Filter locally, or point BASE_URL at a cloud-hosted wrapper.
+SET duckdb_ai_provider = 'openai_privacy_filter';
+SET duckdb_ai_base_url = 'http://localhost:8080';
+
 SELECT
     ticket_id,
     ai_redact(internal_note) AS redacted_internal_note
@@ -291,6 +295,9 @@ End-to-end setup examples for each provider are in
 | `zai` | Z.ai / BigModel chat models | `https://open.bigmodel.cn/api/paas/v4`; `ZAI_API_KEY` |
 | `deepseek` | DeepSeek chat models | `https://api.deepseek.com`; `DEEPSEEK_API_KEY` |
 | `openrouter` | OpenRouter model routing | `https://openrouter.ai/api/v1`; `OPENROUTER_API_KEY` |
+| `databricks` | Databricks Model Serving and Unity AI Gateway chat endpoints | Set `BASE_URL` or `DATABRICKS_HOST`; `DATABRICKS_TOKEN` |
+| `snowflake` | Snowflake Cortex REST Chat Completions API | Set `BASE_URL`, `SNOWFLAKE_ACCOUNT_URL`, or `SNOWFLAKE_ACCOUNT`; `SNOWFLAKE_PAT` |
+| `openai_privacy_filter` | OpenAI Privacy Filter PII redaction service | `http://localhost:8080`; optional `OPENAI_PRIVACY_FILTER_API_KEY` |
 | `openai_compatible` / `local` | vLLM, LM Studio, LiteLLM, Ollama `/v1`, or another gateway | Set `BASE_URL`; optional `OPENAI_COMPATIBLE_API_KEY` |
 
 You can configure providers three ways:
@@ -299,6 +306,7 @@ You can configure providers three ways:
 -- Session defaults.
 SET duckdb_ai_provider = 'openai';
 SET duckdb_ai_model = 'gpt-4o-mini';
+SET duckdb_ai_embedding_model = 'text-embedding-3-small';
 SET duckdb_ai_timeout_seconds = 120;
 
 -- Per-call overrides.
@@ -322,9 +330,22 @@ SELECT ai_complete('hello', secret := 'local_llm');
 ```
 
 Provider-specific environment variables such as `OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, and `GEMINI_API_KEY` are also supported. Generic overrides
-include `DUCKDB_AI_PROVIDER`, `DUCKDB_AI_MODEL`, `DUCKDB_AI_BASE_URL`, and
+`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `DATABRICKS_TOKEN`, `SNOWFLAKE_PAT`, and
+`OPENAI_PRIVACY_FILTER_API_KEY` are also supported. Generic overrides include
+`DUCKDB_AI_PROVIDER`, `DUCKDB_AI_MODEL`, `DUCKDB_AI_BASE_URL`, and
 `DUCKDB_AI_API_KEY`.
+
+Use family-specific model settings when different function groups should default
+to different models. These override `duckdb_ai_model`, and per-call `model := ...`
+still overrides both:
+
+```sql
+SET duckdb_ai_completion_model = 'gpt-4o-mini';
+SET duckdb_ai_task_model = 'gpt-4o-mini';
+SET duckdb_ai_aggregate_model = 'gpt-4o-mini';
+SET duckdb_ai_sql_model = 'gpt-4o';
+SET duckdb_ai_embedding_model = 'text-embedding-3-small';
+```
 
 ## Structured Output
 
@@ -431,6 +452,8 @@ These controls apply to completion and embedding calls.
 - [`docs/functions.md`](docs/functions.md): complete SQL function reference.
 - [`docs/provider-guides.md`](docs/provider-guides.md): end-to-end examples for
   every supported provider.
+- [`docs/best-practices.md`](docs/best-practices.md): provider selection,
+  secrets, defaults, privacy, logging, throughput, and validation guidance.
 - [`docs/SMOKE_TESTING.md`](docs/SMOKE_TESTING.md): local mock-provider, Ollama,
   and remote-provider smoke checks.
 - [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md): release and distribution notes.

--- a/docs/SMOKE_TESTING.md
+++ b/docs/SMOKE_TESTING.md
@@ -13,7 +13,8 @@ python3 test/smoke/mock_provider_smoke.py
 ```
 
 The mock smoke covers OpenAI-compatible chat and embeddings, Ollama chat,
-Claude messages, usage logging, retries, and provider-error redaction without
+Claude messages, Databricks chat, Snowflake Cortex REST chat, OpenAI Privacy
+Filter redaction, usage logging, retries, and provider-error redaction without
 external network calls.
 
 ## Local Ollama
@@ -65,8 +66,63 @@ SELECT ai_embed('DuckDB vector smoke', secret := 'openai_ai')[1];
 "
 ```
 
-For OpenRouter, Gemini, Mistral, Zai, or DeepSeek, change `PROVIDER`,
-`MODEL`, and the corresponding environment variable.
+For OpenRouter, Gemini, Mistral, Zai, DeepSeek, Databricks, or Snowflake,
+change `PROVIDER`, `MODEL`, and the corresponding environment variable.
+
+## Databricks
+
+```sh
+DATABRICKS_TOKEN='...' \
+DATABRICKS_HOST='https://<workspace>.cloud.databricks.com' \
+./build/release/duckdb -c "
+LOAD duckdb_ai;
+CREATE OR REPLACE SECRET databricks_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'databricks',
+    MODEL 'databricks-llama-4-maverick'
+);
+SELECT ai_complete('Say hello from Databricks Model Serving.', secret := 'databricks_ai');
+"
+```
+
+Use the serving endpoint name as the model. Set `BASE_URL` or
+`DATABRICKS_BASE_URL` when you need a full `/serving-endpoints`,
+`/ai-gateway/mlflow/v1`, or `/chat/completions` URL.
+
+## Snowflake Cortex REST
+
+```sh
+SNOWFLAKE_PAT='...' \
+SNOWFLAKE_ACCOUNT_URL='https://<account-identifier>.snowflakecomputing.com' \
+./build/release/duckdb -c "
+LOAD duckdb_ai;
+CREATE OR REPLACE SECRET snowflake_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'snowflake',
+    MODEL 'snowflake-llama-3.3-70b'
+);
+SELECT ai_complete('Say hello from Snowflake Cortex REST.', secret := 'snowflake_ai');
+"
+```
+
+The authenticated user default role must be allowed to call Cortex REST.
+
+## OpenAI Privacy Filter
+
+Start a local wrapper around the OpenAI Privacy Filter package that exposes
+`POST /redact`, then run:
+
+```sh
+./build/release/duckdb -c "
+LOAD duckdb_ai;
+CREATE OR REPLACE SECRET privacy_filter_local (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai_privacy_filter',
+    BASE_URL 'http://localhost:8080'
+);
+SELECT ai_redact('email alice@example.com token fake-token', secret := 'privacy_filter_local');
+"
+```
 
 ## Claude
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -27,7 +27,7 @@ Result:
 
 - Release build passed and linked `extension/duckdb_ai/duckdb_ai.duckdb_extension`.
 - Format check passed after running the repository formatter.
-- SQLLogic tests passed with 122 assertions.
+- SQLLogic tests passed with 136 assertions.
 - Mock provider smoke passed.
 
 Coverage:
@@ -36,10 +36,17 @@ Coverage:
   SQLLogic load path.
 - Canonical `TYPE duckdb_ai` secret support through the common `AI_PROVIDER`
   secret parameter, redacted discovery through `ai_secrets()`, and aliases for
-  Anthropic, GCP/Gemini, Azure, and local/OpenAI-compatible providers.
+  Anthropic, GCP/Gemini, Azure, Databricks, OpenAI Privacy Filter, and
+  local/OpenAI-compatible providers.
 - The existing broad SQL function catalog, including request builders, provider
   metadata helpers, task wrappers, SQL-assistant helpers, embeddings,
   aggregates, usage, and model metadata.
+- Family-specific default model settings for completion, task, aggregate, SQL
+  assistant, and embedding function groups.
+- Mock HTTP coverage for OpenAI-compatible completions/embeddings/logging,
+  Ollama chat, Claude messages, Databricks chat, Snowflake Cortex REST chat,
+  OpenAI Privacy Filter redaction, retries, usage events, and provider error
+  redaction.
 
 Not covered:
 

--- a/docs/WORKPLAN.md
+++ b/docs/WORKPLAN.md
@@ -18,11 +18,15 @@ The local corpus is intentionally ignored by Git.
 - [x] Add a `libcurl` HTTP execution path.
 - [x] Support local Ollama chat requests.
 - [x] Support OpenAI-compatible chat-completions providers: OpenAI, Gemini,
-  Mistral, Zai, DeepSeek, and OpenRouter.
+  Mistral, Zai, DeepSeek, OpenRouter, Databricks Model Serving, and Snowflake
+  Cortex REST.
 - [x] Support Claude through Anthropic's messages API.
+- [x] Support OpenAI Privacy Filter through a dedicated redaction endpoint for
+  local or cloud-hosted PII masking.
 - [x] Keep API keys out of SQL by resolving them from environment variables.
 - [x] Add privacy-minimized usage logging to an optional HTTP endpoint.
-- [x] Add DuckDB settings for provider, model, base URL, timeout, and logging
+- [x] Add DuckDB settings for provider, global model, family-specific model
+  defaults, base URL, timeout, reliability controls, cost controls, and logging
   endpoint once the target DuckDB settings API is verified against the pinned
   submodule.
 - [x] Add DuckDB Secret support for provider credentials.
@@ -106,7 +110,8 @@ The local corpus is intentionally ignored by Git.
   resolution.
 - [x] Add a mock HTTP server smoke test for OpenAI-compatible completion and log
   endpoint paths.
-- [x] Add mock HTTP server tests for Ollama and Claude paths.
+- [x] Add mock HTTP server tests for Ollama, Claude, Databricks, Snowflake, and
+  OpenAI Privacy Filter paths.
 - [x] Add live smoke-test documentation for local Ollama and credentialed remote
   providers.
 - [x] Validate build and tests against the pinned DuckDB submodule on macOS.

--- a/docs/assets/duckdb-ai-logo.svg
+++ b/docs/assets/duckdb-ai-logo.svg
@@ -1,14 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 180" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 140" role="img" aria-labelledby="title desc">
   <title id="title">duckdb_ai logo proposal</title>
-  <desc id="desc">A lemon yellow badge with black AI sparkle marks and the duckdb_ai wordmark.</desc>
-  <rect width="720" height="180" fill="#ffffff"/>
-  <g transform="translate(32 20)">
-    <circle cx="70" cy="70" r="70" fill="#fff100"/>
+  <desc id="desc">The duckdb_ai wordmark with a small black sparkle above the i.</desc>
+  <rect width="720" height="140" fill="#ffffff"/>
+  <g transform="translate(488 16) scale(0.18)">
     <path d="M67 22C78 51 89 62 118 73C89 84 78 95 67 124C56 95 45 84 16 73C45 62 56 51 67 22Z" fill="#0d0d0d"/>
     <path d="M108 18C113 33 119 39 134 44C119 49 113 55 108 70C103 55 97 49 82 44C97 39 103 33 108 18Z" fill="#0d0d0d"/>
   </g>
-  <g transform="translate(205 49)" fill="#0d0d0d">
-    <text x="0" y="55" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="64" font-weight="760" letter-spacing="0">duckdb_ai</text>
-    <text x="3" y="91" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="19" font-weight="600" fill="#626262">model-backed analytics in DuckDB SQL</text>
-  </g>
+  <text x="360" y="94" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="64" font-weight="760" letter-spacing="0" fill="#0d0d0d">duckdb_ai</text>
 </svg>

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,297 @@
+---
+sidebar_position: 4
+---
+
+# Best practices
+
+Use this page as the operating guide for running `duckdb_ai` in notebooks,
+batch jobs, local workflows, and managed environments.
+
+## Choose the right provider path
+
+Use the most constrained provider that fits the job:
+
+| Workload | Recommended path | Why |
+| --- | --- | --- |
+| Local development without hosted credentials | `ollama` | Keeps prompts local and avoids provider costs. |
+| Production chat, extraction, classification, and SQL assistant calls | A managed LLM provider such as `openai`, `azure`, `databricks`, `snowflake`, `claude`, `gemini`, `mistral`, `deepseek`, `zai`, or `openrouter` | Gives managed reliability, model access, and governance controls. |
+| OpenAI-compatible gateways, vLLM, LM Studio, LiteLLM, or local Ollama `/v1` | `openai_compatible` or `local` | Uses the common chat-completions request shape. |
+| PII redaction where raw text should stay local | `openai_privacy_filter` with local hosting | Sends raw text to a dedicated redaction service instead of a general chat model. |
+| PII redaction shared across teams | `openai_privacy_filter` with a private cloud service | Centralizes deployment, auth, scaling, and audit controls while preserving the dedicated redaction contract. |
+
+`ai_redact` behaves differently for `openai_privacy_filter`: it sends the raw
+input text to `POST /redact`. With other completion providers, it uses the
+general task prompt for masking.
+
+## Configure credentials safely
+
+Prefer environment variables or DuckDB secrets. Avoid embedding API keys in SQL
+files, notebooks, CI logs, or shell history.
+
+```sql
+CREATE OR REPLACE SECRET openai_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai',
+    MODEL 'gpt-4o-mini'
+);
+
+SELECT ai_complete('hello', secret := 'openai_ai');
+```
+
+When a secret includes `API_KEY`, `ai_secrets()` reports only whether a key is
+present. It does not print the key value.
+
+Use provider-specific environment variables for local development:
+
+| Provider | Credential env var | Base URL env var |
+| --- | --- | --- |
+| `openai` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| `azure` | `AZURE_OPENAI_API_KEY` | `AZURE_OPENAI_BASE_URL` or `AZURE_OPENAI_ENDPOINT` |
+| `claude` / `anthropic` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | `CLAUDE_BASE_URL` |
+| `gemini` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| `mistral` | `MISTRAL_API_KEY` | `MISTRAL_BASE_URL` |
+| `zai` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| `deepseek` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| `openrouter` | `OPENROUTER_API_KEY` | `OPENROUTER_BASE_URL` |
+| `databricks` | `DATABRICKS_TOKEN` | `DATABRICKS_HOST` or `DATABRICKS_BASE_URL` |
+| `snowflake` | `SNOWFLAKE_PAT` or `SNOWFLAKE_TOKEN` | `SNOWFLAKE_ACCOUNT_URL`, `SNOWFLAKE_HOST`, `SNOWFLAKE_ACCOUNT`, or `SNOWFLAKE_BASE_URL` |
+| `openai_privacy_filter` | `OPENAI_PRIVACY_FILTER_API_KEY` | `OPENAI_PRIVACY_FILTER_BASE_URL` |
+| `openai_compatible` / `local` | `OPENAI_COMPATIBLE_API_KEY` | `OPENAI_COMPATIBLE_BASE_URL` |
+
+`DUCKDB_AI_API_KEY`, `DUCKDB_AI_BASE_URL`, and `DUCKDB_AI_MODEL` are generic
+fallbacks. Use them only when one process talks to one provider; provider-
+specific variables are clearer in mixed-provider environments.
+
+## Set defaults deliberately
+
+Use global defaults for short interactive sessions:
+
+```sql
+SET duckdb_ai_provider = 'openai';
+SET duckdb_ai_model = 'gpt-4o-mini';
+SET duckdb_ai_timeout_seconds = 120;
+```
+
+Use family-specific model settings when different function groups need different
+models:
+
+```sql
+SET duckdb_ai_completion_model = 'gpt-4o-mini';
+SET duckdb_ai_task_model = 'gpt-4o-mini';
+SET duckdb_ai_sql_model = 'gpt-4o';
+SET duckdb_ai_aggregate_model = 'gpt-4o-mini';
+SET duckdb_ai_embedding_model = 'text-embedding-3-small';
+```
+
+Precedence is:
+
+1. Per-call `model := ...`
+2. Function-family setting such as `duckdb_ai_embedding_model`
+3. `duckdb_ai_model`
+4. Provider default model
+
+For repeatable jobs, prefer secrets and explicit per-job settings over relying
+on ambient environment variables.
+
+## Preview requests before calling providers
+
+Use request-preview functions in tests, reviews, and provider debugging:
+
+```sql
+SELECT ai_request_json(
+    'Summarize this.',
+    provider := 'snowflake',
+    model := 'snowflake-llama-3.3-70b'
+);
+
+SELECT ai_embedding_request_json(
+    'DuckDB vector search',
+    provider := 'openai',
+    model := 'text-embedding-3-small'
+);
+```
+
+These functions do not make network calls. They are the safest way to confirm
+model selection, message structure, response-format hints, and provider aliases.
+
+## Prefer structured output for data pipelines
+
+For pipelines, avoid parsing prose. Use `ai_complete_json` or
+`ai_complete_record` with a JSON Schema:
+
+```sql
+SELECT *
+FROM ai_complete_record(
+    'Extract name and urgency from: customer says checkout is down',
+    '{
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "urgency": {"type": "string"}
+      },
+      "required": ["urgency"],
+      "additionalProperties": false
+    }',
+    provider := 'openai'
+);
+```
+
+Keep schemas narrow. Add `required`, `additionalProperties: false`, bounded
+strings, enum-like labels, and typed arrays when you need stable downstream
+columns.
+
+## Keep generated SQL bounded
+
+Use `ai_schema_prompt` to inspect exactly what table context the SQL assistant
+will see:
+
+```sql
+SELECT summary
+FROM ai_schema_prompt(
+    include_tables := ['main.support_tickets'],
+    sample_rows := 3
+);
+```
+
+Use `include_tables` and `exclude_tables` aggressively. Avoid sending an entire
+database catalog when the question only needs one schema or table.
+
+Generated SQL is validated as one read-only DuckDB `SELECT`, but you should
+still inspect generated queries before using them in important workflows:
+
+```sql
+WITH generated AS (
+    SELECT ai_sql(
+        'Count open tickets by priority',
+        include_tables := ['main.support_tickets']
+    ) AS sql
+)
+SELECT ai_validate_read_only_sql(sql)
+FROM generated;
+```
+
+## Treat redaction as a privacy control, not a proof
+
+Use `openai_privacy_filter` for dedicated PII masking when raw text should not
+be sent to a general chat model. Host it locally for the strongest data-boundary
+story:
+
+```sql
+CREATE OR REPLACE SECRET privacy_filter_local (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai_privacy_filter',
+    BASE_URL 'http://localhost:8080'
+);
+```
+
+For high-sensitivity domains, evaluate redaction output on representative data,
+keep human review paths, and avoid treating model redaction as a compliance
+certificate.
+
+## Control cost and throughput
+
+Provider calls happen per row unless you aggregate or pre-filter first. Reduce
+cost and latency by:
+
+- Filtering rows before AI calls.
+- Deduplicating repeated input text.
+- Using `ai_agg` or `ai_summarize_agg` when one grouped call is enough.
+- Persisting embeddings instead of recomputing pairwise similarity.
+- Setting lower `max_tokens` values for classification and extraction tasks.
+
+For batch workloads, set process-local concurrency and pacing:
+
+```sql
+SET duckdb_ai_max_concurrent_requests = 4;
+SET duckdb_ai_min_request_interval_ms = 100;
+```
+
+Retries are disabled by default. Enable small retry counts only for transient
+provider failures:
+
+```sql
+SELECT ai_complete(
+    'Summarize this.',
+    retry_count := 2,
+    retry_backoff_ms := 1000
+);
+```
+
+Use `fail_on_error := false` for exploratory enrichment where a missing output
+is acceptable:
+
+```sql
+SELECT ai_classify(
+    subject,
+    'billing, support, sales, other',
+    fail_on_error := false
+)
+FROM support_tickets;
+```
+
+## Log usage without leaking text
+
+`ai_usage()` keeps recent events in process:
+
+```sql
+SELECT provider, model, elapsed_ms, http_status, estimated_cost_usd
+FROM ai_usage()
+ORDER BY event_id DESC;
+```
+
+Outbound usage logs omit prompt, input, and response text by default:
+
+```sql
+SET duckdb_ai_log_endpoint = 'https://collector.example/ai-usage';
+SET duckdb_ai_log_format = 'generic_json';
+SET duckdb_ai_log_tags = 'app=support-triage,env=prod';
+SET duckdb_ai_log_sample_rate = 0.25;
+```
+
+Only enable text logging when you have a documented retention and access-control
+reason:
+
+```sql
+SET duckdb_ai_log_include_text = true;
+```
+
+Use `duckdb_ai_log_strict = true` only when losing a usage log must fail the SQL
+query. For most analytics workflows, keep strict logging off so the collector
+does not become a query dependency.
+
+## Estimate cost carefully
+
+Cost estimates are optional. Use explicit prices for a job, or opt into the
+built-in catalog when it covers your model:
+
+```sql
+SET duckdb_ai_use_builtin_model_prices = true;
+SELECT * FROM ai_models();
+```
+
+Treat `ai_models()` as a convenience catalog, not a billing source of truth.
+Provider pricing and regional availability change; verify prices with the
+provider before using estimates for chargeback or budgeting.
+
+## Validate before release
+
+Run the local deterministic checks after changes to SQL functions, provider
+request shapes, logging, settings, or docs:
+
+```sh
+PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
+GEN=ninja make release
+GEN=ninja make test
+python3 test/smoke/mock_provider_smoke.py
+```
+
+For docs changes, also run:
+
+```sh
+cd website
+npm run typecheck
+npm run build
+```
+
+Run live provider smoke tests only when you intentionally want to validate real
+credentials, provider account configuration, or provider-specific model access.

--- a/docs/cookbooks/support-ticket-enrichment.md
+++ b/docs/cookbooks/support-ticket-enrichment.md
@@ -109,7 +109,7 @@ WHERE language = 'en';
 After running provider calls, inspect recent usage events:
 
 ```sql
-SELECT provider, model, request_tokens_estimated, output_tokens_estimated, elapsed_ms
+SELECT provider, model, prompt_tokens, completion_tokens, total_tokens, elapsed_ms
 FROM ai_usage()
 ORDER BY event_id DESC
 LIMIT 10;

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -222,12 +222,20 @@ Result: `VARCHAR`
 #### `ai_redact(text[, model[, provider]])`
 
 Description: Masks direct personal data, credentials, secrets, and payment
-identifiers.
+identifiers. With provider `openai_privacy_filter`, sends the raw input text to
+a local or cloud-hosted OpenAI Privacy Filter service instead of wrapping it in a
+chat prompt.
 
 Example:
 
 ```sql
 SELECT ai_redact('email alice@example.com');
+
+SELECT ai_redact(
+    'email alice@example.com token fake-token',
+    provider := 'openai_privacy_filter',
+    base_url := 'http://localhost:8080'
+);
 ```
 
 Result: `VARCHAR`
@@ -579,8 +587,8 @@ not from direct API key arguments.
 | `log_format` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | `generic_json` or `otlp_json`. |
 | `log_tags` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Comma-separated tags copied into usage log payloads. |
 | `log_sample_rate` | `DOUBLE` | Completion, embedding, SQL assistant, aggregate | Stable sampling rate from 0 to 1. |
-| `log_include_text` | `BOOLEAN` | `ai_complete_record` | Include prompt/output text in outbound usage logs. Defaults to false. |
-| `log_strict` | `BOOLEAN` | `ai_complete_record` | Fail the SQL query when outbound usage logging fails. |
+| `log_include_text` | `BOOLEAN` | `ai_complete_record`; all families through `duckdb_ai_log_include_text` or `DUCKDB_AI_LOG_INCLUDE_TEXT` | Include prompt/output text in outbound usage logs. Defaults to false. |
+| `log_strict` | `BOOLEAN` | `ai_complete_record`; all families through `duckdb_ai_log_strict` or `DUCKDB_AI_LOG_STRICT` | Fail the SQL query when outbound usage logging fails. |
 
 SQL assistant table functions also accept:
 
@@ -602,14 +610,52 @@ Aggregate functions also accept:
 
 ## Provider settings and secrets
 
+Supported provider names and aliases are:
+
+| Provider | Aliases | Completion support | Embedding support | Default completion model |
+| --- | --- | --- | --- | --- |
+| `ollama` | none | Yes | Yes | `llama3.2` |
+| `openai` | none | Yes | Yes | `gpt-4o-mini` |
+| `azure` | `azure_openai`, `azure-openai` | Yes | Yes | `gpt-4o` |
+| `claude` | `anthropic` | Yes | No | `claude-3-5-haiku-latest` |
+| `gemini` | `gcp`, `google`, `google_gemini` | Yes | Yes | `gemini-2.5-flash` |
+| `mistral` | none | Yes | Yes | `mistral-small-latest` |
+| `zai` | `zhipu` | Yes | Yes | `glm-4-flash` |
+| `deepseek` | none | Yes | No | `deepseek-chat` |
+| `openrouter` | none | Yes | Yes | `openai/gpt-4o-mini` |
+| `databricks` | `mosaic`, `mosaic_ai`, `databricks_ai` | Yes | No | `databricks-llama-4-maverick` |
+| `snowflake` | none | Yes | No | `snowflake-llama-3.3-70b` |
+| `openai_privacy_filter` | `privacy_filter`, `pii_filter`, `opf` | Redaction only | No | `openai/privacy-filter` |
+| `openai_compatible` | `local`, `openai-compatible`, `local_openai`, `local-models`, `local_models` | Yes | Yes | `gpt-4o-mini` |
+
 Session defaults can be configured with DuckDB settings:
 
 ```sql
 SET duckdb_ai_provider = 'openai';
 SET duckdb_ai_model = 'gpt-4o-mini';
+SET duckdb_ai_embedding_model = 'text-embedding-3-small';
 SET duckdb_ai_base_url = 'https://api.openai.com/v1';
 SET duckdb_ai_timeout_seconds = 120;
 ```
+
+`duckdb_ai_model` is the global model fallback. Family-specific model settings
+override it for their function groups, while per-call `model := ...` still takes
+highest precedence:
+
+| Setting | Applies to |
+| --- | --- |
+| `duckdb_ai_completion_model` | `ai_complete`, `ai_complete_json`, `ai_complete_record`, `ai_request_json` |
+| `duckdb_ai_task_model` | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_extract`, `ai_filter` |
+| `duckdb_ai_aggregate_model` | `ai_agg`, `ai_summarize_agg` |
+| `duckdb_ai_sql_model` | `ai_sql`, `ai_query_data`, `ai_explain_sql`, `ai_fix_sql`, `ai_fix_sql_line` |
+| `duckdb_ai_embedding_model` | `ai_embed`, `ai_embedding_request_json`, `ai_similarity` |
+
+Model resolution order is:
+
+1. Per-call `model := ...`
+2. Matching function-family setting
+3. `duckdb_ai_model`
+4. Provider default model
 
 Credentials should use environment variables or DuckDB secrets:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,12 @@ SQL, usage logging, and local validation evidence.
 - [Cookbooks](cookbooks/index.md): practical workflows over local tables,
   including text enrichment, similarity, structured records, and SQL generation.
 - [Provider guides](provider-guides.md): end-to-end examples for Ollama, OpenAI,
-  Azure OpenAI, Claude, Gemini, Mistral, Z.ai, DeepSeek, OpenRouter, and local
+  Azure OpenAI, Claude, Gemini, Mistral, Z.ai, DeepSeek, OpenRouter,
+  Databricks, Snowflake Cortex REST, OpenAI Privacy Filter, and local
   OpenAI-compatible gateways.
+- [Best practices](best-practices.md): provider selection, secrets, model
+  defaults, structured output, SQL safety, redaction, logging, throughput, cost,
+  and release validation guidance.
 - [Validation](VALIDATION.md): local build, test, and smoke evidence for the
   pinned DuckDB extension build.
 - [Smoke testing](SMOKE_TESTING.md): deterministic mock-provider checks plus

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -27,6 +27,27 @@ ORDER BY event_id DESC
 LIMIT 1;
 ```
 
+## Provider matrix
+
+| Provider | Protocol | Default model | Credentials | Base URL behavior |
+| --- | --- | --- | --- | --- |
+| `ollama` | Ollama chat and embeddings | `llama3.2`; embeddings use `nomic-embed-text` | Optional `OLLAMA_API_KEY` | Defaults to `http://localhost:11434`; `OLLAMA_HOST` overrides it. |
+| `openai` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | `OPENAI_API_KEY` | Defaults to `https://api.openai.com/v1`. |
+| `azure` | OpenAI-compatible chat and embeddings | `gpt-4o`; embeddings use `text-embedding-3-small` | `AZURE_OPENAI_API_KEY` | Appends `/openai/v1` to `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, or secret `BASE_URL` when needed. |
+| `claude` / `anthropic` | Anthropic Messages | `claude-3-5-haiku-latest` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | Defaults to `https://api.anthropic.com/v1`. |
+| `gemini` / `gcp` / `google` | OpenAI-compatible chat and embeddings | `gemini-2.5-flash`; embeddings use `text-embedding-004` | `GEMINI_API_KEY` | Defaults to Google's OpenAI-compatible endpoint. |
+| `mistral` | OpenAI-compatible chat and embeddings | `mistral-small-latest`; embeddings use `mistral-embed` | `MISTRAL_API_KEY` | Defaults to `https://api.mistral.ai/v1`. |
+| `zai` / `zhipu` | OpenAI-compatible chat and embeddings | `glm-4-flash`; embeddings use `embedding-3` | `ZAI_API_KEY` | Defaults to `https://open.bigmodel.cn/api/paas/v4`. |
+| `deepseek` | OpenAI-compatible chat | `deepseek-chat` | `DEEPSEEK_API_KEY` | Defaults to `https://api.deepseek.com`. |
+| `openrouter` | OpenAI-compatible chat and embeddings | `openai/gpt-4o-mini`; embeddings use `openai/text-embedding-3-small` | `OPENROUTER_API_KEY` | Defaults to `https://openrouter.ai/api/v1`. |
+| `databricks` | OpenAI-compatible chat | `databricks-llama-4-maverick` | `DATABRICKS_TOKEN` | Derives `/serving-endpoints` from `DATABRICKS_HOST`, or accepts full Model Serving, AI Gateway, or chat-completions URLs. |
+| `snowflake` | OpenAI-compatible chat | `snowflake-llama-3.3-70b` | `SNOWFLAKE_PAT` or `SNOWFLAKE_TOKEN` | Derives `/api/v2/cortex/v1` from Snowflake account URL, host, or account id. |
+| `openai_privacy_filter` | Dedicated redaction endpoint | `openai/privacy-filter` | Optional `OPENAI_PRIVACY_FILTER_API_KEY` | Defaults to `http://localhost:8080` and calls `POST /redact`. |
+| `openai_compatible` / `local` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | Optional `OPENAI_COMPATIBLE_API_KEY` | Requires `BASE_URL` or `OPENAI_COMPATIBLE_BASE_URL`. |
+
+For guidance on choosing providers, credentials, logging, cost, throughput, and
+PII workflows, see [Best practices](best-practices.md).
+
 ## Ollama
 
 Use Ollama for local models without a hosted API key.
@@ -322,6 +343,148 @@ SELECT ai_embed(
 
 OpenRouter model names include the upstream provider prefix, for example
 `openai/gpt-4o-mini`.
+
+## Databricks
+
+Databricks Model Serving exposes chat endpoints through an OpenAI-compatible
+API. Use a Databricks personal access token or service-principal token, and set
+the model to the serving endpoint name.
+
+```sh
+export DATABRICKS_TOKEN='...'
+export DATABRICKS_HOST='https://<workspace>.cloud.databricks.com'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET databricks_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'databricks',
+    MODEL 'databricks-llama-4-maverick'
+);
+
+SELECT ai_complete(
+    'Explain Delta Lake in one sentence.',
+    secret := 'databricks_ai'
+) AS answer;
+```
+
+If `BASE_URL` is omitted, set `DATABRICKS_HOST`; the extension derives
+`https://<workspace>/serving-endpoints`. You can also set a secret `BASE_URL`,
+`DATABRICKS_BASE_URL`, or per-call `base_url := ...` to use a full
+`/serving-endpoints`, `/ai-gateway/mlflow/v1`, or `/chat/completions` endpoint.
+Aliases `mosaic`, `mosaic_ai`, and `databricks_ai` resolve to `databricks`.
+
+## Snowflake Cortex REST
+
+Snowflake Cortex REST exposes a Chat Completions API compatible with the OpenAI
+request shape. Use a Snowflake Programmatic Access Token, OAuth token, or JWT
+with a role that can call Cortex REST.
+
+```sh
+export SNOWFLAKE_PAT='...'
+export SNOWFLAKE_ACCOUNT_URL='https://<account-identifier>.snowflakecomputing.com'
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET snowflake_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'snowflake',
+    MODEL 'snowflake-llama-3.3-70b'
+);
+
+SELECT ai_complete(
+    'Summarize why governed model inference matters.',
+    secret := 'snowflake_ai'
+) AS answer;
+```
+
+If `BASE_URL` is omitted, set `SNOWFLAKE_ACCOUNT_URL`, `SNOWFLAKE_HOST`, or
+`SNOWFLAKE_ACCOUNT`; the extension derives
+`https://<account>.snowflakecomputing.com/api/v2/cortex/v1`. You can also set a
+secret `BASE_URL`, `SNOWFLAKE_BASE_URL`, or per-call `base_url := ...` to use a
+full `/api/v2/cortex/v1` or `/chat/completions` endpoint. Snowflake model IDs
+include values such as `snowflake-llama-3.3-70b`, `llama4-maverick`, and
+`openai-gpt-5.1`, depending on region and model access.
+
+## OpenAI Privacy Filter
+
+OpenAI Privacy Filter is an open-weight PII detection and masking model. The
+extension calls it through a small HTTP service so the model can run either on
+the same machine as DuckDB or in your own cloud deployment.
+
+Use local hosting when unredacted PII should not leave the machine running
+DuckDB:
+
+```sh
+# Host a wrapper around the openai/privacy-filter Python package.
+# The wrapper should expose POST /redact.
+export OPF_CHECKPOINT="$HOME/.opf/privacy_filter"
+./serve-privacy-filter --host 127.0.0.1 --port 8080
+./build/release/duckdb
+```
+
+```sql
+LOAD duckdb_ai;
+
+CREATE OR REPLACE SECRET privacy_filter_local (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai_privacy_filter',
+    BASE_URL 'http://localhost:8080'
+);
+
+SELECT ai_redact(
+    'email alice@example.com token fake-token',
+    secret := 'privacy_filter_local'
+) AS redacted_text;
+```
+
+Use cloud hosting when multiple DuckDB clients should share one managed Privacy
+Filter deployment:
+
+```sql
+CREATE OR REPLACE SECRET privacy_filter_cloud (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'openai_privacy_filter',
+    BASE_URL 'https://privacy-filter.example.com',
+    API_KEY '...'
+);
+
+SELECT ai_redact(
+    internal_note,
+    secret := 'privacy_filter_cloud'
+) AS redacted_note
+FROM support_tickets;
+```
+
+The service contract is intentionally small:
+
+```http
+POST /redact
+Content-Type: application/json
+Authorization: Bearer ...    # optional
+
+{"text":"email alice@example.com","model":"openai/privacy-filter"}
+```
+
+The response should include one of `redacted_text`, `masked_text`, `text`, or
+`output`:
+
+```json
+{"redacted_text":"email [PRIVATE_EMAIL]"}
+```
+
+Aliases `privacy_filter`, `pii_filter`, and `opf` resolve to
+`openai_privacy_filter`. The default base URL is `http://localhost:8080`; set
+`OPENAI_PRIVACY_FILTER_BASE_URL`, `DUCKDB_AI_BASE_URL`, a secret `BASE_URL`, or a
+per-call `base_url := ...` to point at a different local or cloud service. For
+cloud auth, use a secret `API_KEY`, `OPENAI_PRIVACY_FILTER_API_KEY`, or
+`DUCKDB_AI_API_KEY`.
 
 ## OpenAI-compatible / Local gateway
 

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -709,6 +709,26 @@ bool TryGetSetting(ClientContext &context, const std::string &name, Value &value
 	return context.TryGetCurrentSetting(name, value) && !value.IsNull();
 }
 
+enum class AiModelSettingKind { GENERIC, COMPLETION, TASK, AGGREGATE, EMBEDDING, SQL_ASSISTANT };
+
+std::string ModelSettingName(AiModelSettingKind kind) {
+	switch (kind) {
+	case AiModelSettingKind::COMPLETION:
+		return "duckdb_ai_completion_model";
+	case AiModelSettingKind::TASK:
+		return "duckdb_ai_task_model";
+	case AiModelSettingKind::AGGREGATE:
+		return "duckdb_ai_aggregate_model";
+	case AiModelSettingKind::EMBEDDING:
+		return "duckdb_ai_embedding_model";
+	case AiModelSettingKind::SQL_ASSISTANT:
+		return "duckdb_ai_sql_model";
+	case AiModelSettingKind::GENERIC:
+		break;
+	}
+	return "";
+}
+
 void ApplyStringSetting(ClientContext &context, const std::string &name, std::string &target) {
 	Value value;
 	if (!TryGetSetting(context, name, value)) {
@@ -840,8 +860,17 @@ void ApplySettingsWithPrefix(ClientContext &context, const std::string &prefix, 
 	ApplyTimeoutSetting(context, prefix + "_timeout_seconds", options);
 }
 
-void ApplySettings(ClientContext &context, duckdb_ai::CompletionOptions &options) {
+void ApplyModelSetting(ClientContext &context, AiModelSettingKind kind, duckdb_ai::CompletionOptions &options) {
+	auto setting_name = ModelSettingName(kind);
+	if (!setting_name.empty()) {
+		ApplyStringSetting(context, setting_name, options.model);
+	}
+}
+
+void ApplySettings(ClientContext &context, duckdb_ai::CompletionOptions &options,
+                   AiModelSettingKind kind = AiModelSettingKind::GENERIC) {
 	ApplySettingsWithPrefix(context, "duckdb_ai", options);
+	ApplyModelSetting(context, kind, options);
 	if (!options.response_format.empty()) {
 		options.response_format = NormalizeResponseFormatValue(options.response_format, "AI setting");
 	}
@@ -952,7 +981,7 @@ unique_ptr<FunctionData> AiCompletionBindInternal(ClientContext &context, Scalar
                                                   vector<unique_ptr<Expression>> &arguments,
                                                   bool validate_json_output = false) {
 	auto bind_data = make_uniq<AiCompletionBindData>(false, validate_json_output);
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::COMPLETION);
 	if (arguments.empty()) {
 		throw BinderException("%s requires a prompt argument", bound_function.name);
 	}
@@ -1321,7 +1350,7 @@ unique_ptr<FunctionData> AiRecordBind(ClientContext &context, TableFunctionBindI
 		throw BinderException("ai_complete_record expects prompt, response_schema, optional model, optional provider");
 	}
 	auto bind_data = make_uniq<AiRecordBindData>();
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::COMPLETION);
 	bind_data->prompt = RequiredRecordStringInput(input, 0, "prompt");
 	bind_data->response_schema = RequiredRecordStringInput(input, 1, "response_schema");
 	ValidateResponseSchemaValue(bind_data->response_schema, "ai_complete_record");
@@ -1407,7 +1436,7 @@ bool IsEmbeddingOption(const std::string &name) {
 unique_ptr<FunctionData> AiEmbeddingBindInternal(ClientContext &context, ScalarFunction &bound_function,
                                                  vector<unique_ptr<Expression>> &arguments, bool request_json) {
 	auto bind_data = make_uniq<AiCompletionBindData>(request_json);
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::EMBEDDING);
 	if (arguments.empty()) {
 		throw BinderException("%s requires an input argument", bound_function.name);
 	}
@@ -1460,7 +1489,7 @@ unique_ptr<FunctionData> AiEmbeddingRequestJsonBind(ClientContext &context, Scal
 unique_ptr<FunctionData> AiSimilarityBind(ClientContext &context, ScalarFunction &bound_function,
                                           vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = make_uniq<AiCompletionBindData>(false);
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::EMBEDDING);
 	if (arguments.size() < 2) {
 		throw BinderException("%s requires two text arguments", bound_function.name);
 	}
@@ -1651,7 +1680,7 @@ unique_ptr<FunctionData> AiTaskBindInternal(ClientContext &context, ScalarFuncti
                                             vector<unique_ptr<Expression>> &arguments, AiTaskKind task,
                                             idx_t required_args) {
 	auto bind_data = make_uniq<AiTaskBindData>(task, required_args);
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::TASK);
 	if (arguments.size() < required_args) {
 		throw BinderException("%s requires %llu argument(s)", bound_function.name, required_args);
 	}
@@ -1727,7 +1756,7 @@ unique_ptr<FunctionData> AiFilterBind(ClientContext &context, ScalarFunction &bo
 unique_ptr<FunctionData> AiPromptSqlBind(ClientContext &context, ScalarFunction &bound_function,
                                          vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = make_uniq<AiPromptSqlBindData>();
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::SQL_ASSISTANT);
 	if (arguments.empty()) {
 		throw BinderException("%s requires a question argument", bound_function.name);
 	}
@@ -1797,7 +1826,7 @@ std::string EvaluateConstantString(ClientContext &context, Expression &expr, con
 unique_ptr<FunctionData> AiAggregateBindInternal(ClientContext &context, AggregateFunction &function,
                                                  vector<unique_ptr<Expression>> &arguments, AiAggregateKind kind) {
 	auto bind_data = make_uniq<AiAggregateBindData>(kind);
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::AGGREGATE);
 	if (arguments.empty()) {
 		throw BinderException("%s requires an input text argument", function.name);
 	}
@@ -2469,8 +2498,14 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 
 		try {
 			ApplyAiProviderSecret(state.GetContext(), options);
-			auto prompt = BuildTaskPrompt(bind_data.task, input, parameter);
-			auto output = duckdb_ai::Complete(prompt, options).text;
+			std::string output;
+			if (bind_data.task == AiTaskKind::MASK &&
+			    duckdb_ai::ResolveProvider(options).protocol == "privacy_filter") {
+				output = duckdb_ai::Redact(input, options).text;
+			} else {
+				auto prompt = BuildTaskPrompt(bind_data.task, input, parameter);
+				output = duckdb_ai::Complete(prompt, options).text;
+			}
 			result_data[row] = StringVector::AddString(result, output);
 		} catch (std::exception &ex) {
 			if (options.fail_on_error) {
@@ -2772,7 +2807,7 @@ unique_ptr<TableRef> EmptyPromptQueryResult(const ParserOptions &options) {
 
 unique_ptr<TableRef> PromptQueryBindReplace(ClientContext &context, TableFunctionBindInput &input) {
 	auto options = duckdb_ai::CompletionOptions();
-	ApplySettings(context, options);
+	ApplySettings(context, options, AiModelSettingKind::SQL_ASSISTANT);
 	auto question = RequiredTableStringInput(input, 0, "question");
 	auto schema_context = OptionalTableStringInput(input, 1);
 	PromptSchemaOptions schema_options;
@@ -3022,7 +3057,7 @@ unique_ptr<FunctionData> PromptAssistantBindInternal(ClientContext &context, Tab
                                                      vector<LogicalType> &return_types, vector<string> &names,
                                                      PromptAssistantKind kind, const std::string &function_name) {
 	auto bind_data = make_uniq<PromptAssistantBindData>(kind);
-	ApplySettings(context, bind_data->options);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::SQL_ASSISTANT);
 	auto max_positional_args = kind == PromptAssistantKind::FIX_LINE ? 2 : 1;
 	if (input.inputs.empty() || input.inputs.size() > max_positional_args) {
 		throw BinderException("%s expects %s", function_name,
@@ -3477,6 +3512,16 @@ void RegisterSettingsForPrefix(DBConfig &config, const std::string &prefix, cons
 void RegisterSettings(ExtensionLoader &loader) {
 	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
 	RegisterSettingsForPrefix(config, "duckdb_ai", "duckdb_ai");
+	AddSetting(config, "duckdb_ai_completion_model", "Default AI model for completion functions", LogicalType::VARCHAR,
+	           Value(""));
+	AddSetting(config, "duckdb_ai_task_model", "Default AI model for text task functions", LogicalType::VARCHAR,
+	           Value(""));
+	AddSetting(config, "duckdb_ai_aggregate_model", "Default AI model for aggregate functions", LogicalType::VARCHAR,
+	           Value(""));
+	AddSetting(config, "duckdb_ai_embedding_model", "Default AI model for embedding functions", LogicalType::VARCHAR,
+	           Value(""));
+	AddSetting(config, "duckdb_ai_sql_model", "Default AI model for SQL assistant functions", LogicalType::VARCHAR,
+	           Value(""));
 }
 
 void RegisterAiProviderSecretType(ExtensionLoader &loader, const std::string &type_name) {

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -62,6 +62,13 @@ std::string NormalizeProviderNameInternal(const std::string &provider_input) {
 	if (provider == "azure_openai" || provider == "azure-openai") {
 		return "azure";
 	}
+	if (provider == "mosaic" || provider == "mosaic_ai" || provider == "databricks_ai") {
+		return "databricks";
+	}
+	if (provider == "privacy_filter" || provider == "openai_privacy_filter" || provider == "pii_filter" ||
+	    provider == "opf") {
+		return "openai_privacy_filter";
+	}
 	if (provider == "openai-compatible" || provider == "openai_compatible" || provider == "local" ||
 	    provider == "local_openai" || provider == "local-models" || provider == "local_models") {
 		return "openai_compatible";
@@ -85,12 +92,60 @@ bool EndsWith(const std::string &value, const std::string &suffix) {
 	return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
+bool StartsWith(const std::string &value, const std::string &prefix) {
+	return value.size() >= prefix.size() && value.compare(0, prefix.size(), prefix) == 0;
+}
+
+bool HasHttpScheme(const std::string &value) {
+	return StartsWith(value, "https://") || StartsWith(value, "http://");
+}
+
 std::string AzureOpenAIBaseUrl(std::string value) {
 	value = TrimTrailingSlash(std::move(value));
 	if (value.empty() || EndsWith(value, "/openai/v1")) {
 		return value;
 	}
 	return value + "/openai/v1";
+}
+
+std::string DatabricksBaseUrl(std::string value) {
+	value = TrimTrailingSlash(std::move(value));
+	if (value.empty()) {
+		return value;
+	}
+	if (!HasHttpScheme(value)) {
+		value = "https://" + value;
+	}
+	if (EndsWith(value, "/serving-endpoints") || EndsWith(value, "/ai-gateway/mlflow/v1") ||
+	    EndsWith(value, "/chat/completions")) {
+		return value;
+	}
+	return value + "/serving-endpoints";
+}
+
+std::string SnowflakeCortexBaseUrl(std::string value) {
+	value = TrimTrailingSlash(std::move(value));
+	if (value.empty()) {
+		return value;
+	}
+	if (!HasHttpScheme(value)) {
+		value = "https://" + value;
+	}
+	if (EndsWith(value, "/api/v2/cortex/v1") || EndsWith(value, "/chat/completions")) {
+		return value;
+	}
+	return value + "/api/v2/cortex/v1";
+}
+
+std::string SnowflakeAccountBaseUrl(std::string account) {
+	account = TrimTrailingSlash(std::move(account));
+	if (account.empty()) {
+		return account;
+	}
+	if (HasHttpScheme(account) || account.find(".snowflakecomputing.") != std::string::npos) {
+		return SnowflakeCortexBaseUrl(account);
+	}
+	return SnowflakeCortexBaseUrl(account + ".snowflakecomputing.com");
 }
 
 std::string CurrentTimestamp() {
@@ -1679,6 +1734,22 @@ ProviderConfig ProviderDefaults(const std::string &provider_input) {
 		return {provider, "openai_chat", "openai/gpt-4o-mini", "", "https://openrouter.ai/api/v1", "OPENROUTER_API_KEY",
 		        "",       true};
 	}
+	if (provider == "databricks") {
+		return {provider, "openai_chat", "databricks-llama-4-maverick", "", "", "DATABRICKS_TOKEN", "", true};
+	}
+	if (provider == "snowflake") {
+		return {provider, "openai_chat", "snowflake-llama-3.3-70b", "", "", "SNOWFLAKE_PAT", "", true};
+	}
+	if (provider == "openai_privacy_filter") {
+		return {provider,
+		        "privacy_filter",
+		        "openai/privacy-filter",
+		        "",
+		        "http://localhost:8080",
+		        "OPENAI_PRIVACY_FILTER_API_KEY",
+		        "",
+		        false};
+	}
 	if (provider == "openai_compatible") {
 		return {provider, "openai_chat", "gpt-4o-mini", "", "", "OPENAI_COMPATIBLE_API_KEY", "", false};
 	}
@@ -1721,7 +1792,8 @@ ProviderConfig ProviderDefaults(const std::string &provider_input) {
 	}
 
 	throw InvalidInputException("Unsupported AI provider \"%s\". Supported providers: ollama, openai, azure, claude, "
-	                            "anthropic, gemini, gcp, mistral, zai, deepseek, openrouter, openai_compatible, local",
+	                            "anthropic, databricks, gemini, gcp, mistral, snowflake, zai, deepseek, openrouter, "
+	                            "openai_privacy_filter, openai_compatible, local",
 	                            provider_input);
 }
 
@@ -1740,11 +1812,36 @@ std::string ResolveBaseUrl(const ProviderConfig &config) {
 		}
 	}
 	if (!provider_base_url.empty()) {
-		return config.provider == "azure" ? AzureOpenAIBaseUrl(provider_base_url)
-		                                  : TrimTrailingSlash(provider_base_url);
+		return config.provider == "azure"        ? AzureOpenAIBaseUrl(provider_base_url)
+		       : config.provider == "databricks" ? DatabricksBaseUrl(provider_base_url)
+		       : config.provider == "snowflake"  ? SnowflakeCortexBaseUrl(provider_base_url)
+		                                         : TrimTrailingSlash(provider_base_url);
 	}
 	if (!generic_base_url.empty()) {
-		return config.provider == "azure" ? AzureOpenAIBaseUrl(generic_base_url) : TrimTrailingSlash(generic_base_url);
+		return config.provider == "azure"        ? AzureOpenAIBaseUrl(generic_base_url)
+		       : config.provider == "databricks" ? DatabricksBaseUrl(generic_base_url)
+		       : config.provider == "snowflake"  ? SnowflakeCortexBaseUrl(generic_base_url)
+		                                         : TrimTrailingSlash(generic_base_url);
+	}
+	if (config.provider == "databricks") {
+		auto databricks_host = GetEnv("DATABRICKS_HOST");
+		if (!databricks_host.empty()) {
+			return DatabricksBaseUrl(databricks_host);
+		}
+	}
+	if (config.provider == "snowflake") {
+		auto snowflake_account_url = GetEnv("SNOWFLAKE_ACCOUNT_URL");
+		if (!snowflake_account_url.empty()) {
+			return SnowflakeCortexBaseUrl(snowflake_account_url);
+		}
+		auto snowflake_host = GetEnv("SNOWFLAKE_HOST");
+		if (!snowflake_host.empty()) {
+			return SnowflakeCortexBaseUrl(snowflake_host);
+		}
+		auto snowflake_account = GetEnv("SNOWFLAKE_ACCOUNT");
+		if (!snowflake_account.empty()) {
+			return SnowflakeAccountBaseUrl(snowflake_account);
+		}
 	}
 	if (config.provider == "ollama") {
 		auto ollama_host = GetEnv("OLLAMA_HOST");
@@ -1775,6 +1872,22 @@ std::string ResolveApiKey(const ProviderConfig &config) {
 		auto claude_key = GetEnv("CLAUDE_API_KEY");
 		if (!claude_key.empty()) {
 			return claude_key;
+		}
+	}
+	if (config.provider == "databricks") {
+		auto databricks_token = GetEnv("DATABRICKS_TOKEN");
+		if (!databricks_token.empty()) {
+			return databricks_token;
+		}
+	}
+	if (config.provider == "snowflake") {
+		auto snowflake_pat = GetEnv("SNOWFLAKE_PAT");
+		if (!snowflake_pat.empty()) {
+			return snowflake_pat;
+		}
+		auto snowflake_token = GetEnv("SNOWFLAKE_TOKEN");
+		if (!snowflake_token.empty()) {
+			return snowflake_token;
 		}
 	}
 	return GetEnv(config.api_key_env);
@@ -1808,24 +1921,45 @@ std::string ResolveModel(const ProviderConfig &config, const std::string &model_
 
 ProviderConfig ResolveProviderConfig(const CompletionOptions &options, bool require_api_key) {
 	auto config = ProviderDefaults(options.provider);
-	config.base_url = options.base_url.empty() ? ResolveBaseUrl(config)
-	                                           : (config.provider == "azure" ? AzureOpenAIBaseUrl(options.base_url)
-	                                                                         : TrimTrailingSlash(options.base_url));
+	config.base_url = options.base_url.empty()          ? ResolveBaseUrl(config)
+	                  : config.provider == "azure"      ? AzureOpenAIBaseUrl(options.base_url)
+	                  : config.provider == "databricks" ? DatabricksBaseUrl(options.base_url)
+	                  : config.provider == "snowflake"  ? SnowflakeCortexBaseUrl(options.base_url)
+	                                                    : TrimTrailingSlash(options.base_url);
 	config.api_key = options.api_key.empty() ? ResolveApiKey(config) : options.api_key;
 	config.model = ResolveModel(config, options.model);
 	if (require_api_key && config.requires_api_key && config.api_key.empty()) {
 		throw InvalidInputException("AI provider \"%s\" requires an API key. Set %s or DUCKDB_AI_API_KEY.",
 		                            config.provider, config.api_key_env);
 	}
+	if (require_api_key && config.provider == "databricks" && config.base_url.empty()) {
+		throw InvalidInputException(
+		    "AI provider \"databricks\" requires a base URL. Set duckdb_ai_base_url, DATABRICKS_BASE_URL, or "
+		    "DATABRICKS_HOST.");
+	}
+	if (require_api_key && config.provider == "snowflake" && config.base_url.empty()) {
+		throw InvalidInputException("AI provider \"snowflake\" requires a base URL. Set duckdb_ai_base_url, "
+		                            "SNOWFLAKE_BASE_URL, SNOWFLAKE_ACCOUNT_URL, SNOWFLAKE_HOST, or "
+		                            "SNOWFLAKE_ACCOUNT.");
+	}
 	return config;
 }
 
 std::string RequestEndpoint(const ProviderConfig &config) {
+	if (config.protocol == "privacy_filter") {
+		if (EndsWith(config.base_url, "/redact")) {
+			return config.base_url;
+		}
+		return config.base_url + "/redact";
+	}
 	if (config.protocol == "ollama_chat") {
 		return config.base_url + "/api/chat";
 	}
 	if (config.protocol == "anthropic_messages") {
 		return config.base_url + "/messages";
+	}
+	if (EndsWith(config.base_url, "/chat/completions")) {
+		return config.base_url;
 	}
 	return config.base_url + "/chat/completions";
 }
@@ -1914,6 +2048,9 @@ std::string OllamaFormatJson(const CompletionOptions &options) {
 
 std::string RequestPayload(const ProviderConfig &config, const std::string &prompt, const CompletionOptions &options) {
 	auto escaped_model = JsonEscape(config.model);
+	if (config.protocol == "privacy_filter") {
+		return "{\"text\":\"" + JsonEscape(prompt) + "\",\"model\":\"" + escaped_model + "\"}";
+	}
 	if (config.protocol == "anthropic_messages") {
 		ValidateResponseSchema(options);
 		auto format = NormalizeResponseFormat(options);
@@ -2006,9 +2143,9 @@ ProviderConfig ResolveEmbeddingProviderConfig(const CompletionOptions &options, 
 	auto config = ProviderDefaults(options.provider);
 	config.default_model = EmbeddingDefaultModel(config.provider);
 	config.protocol = config.provider == "ollama" ? "ollama_embed" : "openai_embeddings";
-	config.base_url = options.base_url.empty() ? ResolveBaseUrl(config)
-	                                           : (config.provider == "azure" ? AzureOpenAIBaseUrl(options.base_url)
-	                                                                         : TrimTrailingSlash(options.base_url));
+	config.base_url = options.base_url.empty()     ? ResolveBaseUrl(config)
+	                  : config.provider == "azure" ? AzureOpenAIBaseUrl(options.base_url)
+	                                               : TrimTrailingSlash(options.base_url);
 	config.api_key = options.api_key.empty() ? ResolveApiKey(config) : options.api_key;
 	config.model = ResolveModel(config, options.model);
 	if (require_api_key && config.requires_api_key && config.api_key.empty()) {
@@ -2154,7 +2291,12 @@ std::vector<std::string> RequestHeaders(const ProviderConfig &config) {
 
 std::string ExtractCompletionText(const ProviderConfig &config, const std::string &body) {
 	std::string value;
-	if (config.protocol == "anthropic_messages") {
+	if (config.protocol == "privacy_filter") {
+		if (FindJsonStringValue(body, "redacted_text", value) || FindJsonStringValue(body, "masked_text", value) ||
+		    FindJsonStringValue(body, "text", value) || FindJsonStringValue(body, "output", value)) {
+			return value;
+		}
+	} else if (config.protocol == "anthropic_messages") {
 		if (FindJsonStringValue(body, "text", value)) {
 			return value;
 		}
@@ -2597,6 +2739,27 @@ CompletionResult Complete(const std::string &prompt, const CompletionOptions &op
 	auto result = ParseCompletionResult(config, response);
 	RecordUsageEvent(config, prompt, result, options);
 	MaybePostUsageLog(config, prompt, result, options);
+	return result;
+}
+
+CompletionResult Redact(const std::string &text, const CompletionOptions &options) {
+	if (text.empty()) {
+		throw InvalidInputException("ai_redact text must not be empty");
+	}
+	auto config = ResolveProvider(options);
+	if (config.protocol != "privacy_filter") {
+		throw InvalidInputException("AI provider \"%s\" does not support dedicated Privacy Filter redaction.",
+		                            config.provider);
+	}
+	auto response = [&]() {
+		ProviderRequestGuard request_guard(options);
+		return HttpPost(RequestEndpoint(config), RequestPayload(config, text, options), RequestHeaders(config),
+		                TimeoutSeconds(options), false, RetryCount(options), RetryBackoffMs(options));
+	}();
+	ThrowIfProviderHttpError(config, response);
+	auto result = ParseCompletionResult(config, response);
+	RecordUsageEvent(config, text, result, options);
+	MaybePostUsageLog(config, text, result, options);
 	return result;
 }
 

--- a/src/include/duckdb_ai_provider.hpp
+++ b/src/include/duckdb_ai_provider.hpp
@@ -158,6 +158,8 @@ std::string BuildRequestJson(const std::string &prompt, const CompletionOptions 
 CompletionResult Complete(const std::string &prompt, const std::string &model, const std::string &provider);
 //! Execute a completion request from a full option set.
 CompletionResult Complete(const std::string &prompt, const CompletionOptions &options);
+//! Execute a dedicated PII redaction request from a full option set.
+CompletionResult Redact(const std::string &text, const CompletionOptions &options);
 //! Build an embedding request payload without making a network call.
 std::string BuildEmbeddingRequestJson(const std::string &input, const std::string &model, const std::string &provider);
 //! Build an embedding request payload from a full option set.

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -11,6 +11,7 @@ from pathlib import Path
 class MockProviderHandler(BaseHTTPRequestHandler):
     completion_requests = []
     embedding_requests = []
+    privacy_filter_requests = []
     ollama_requests = []
     claude_requests = []
     log_requests = []
@@ -23,7 +24,7 @@ class MockProviderHandler(BaseHTTPRequestHandler):
         length = int(self.headers.get("content-length", "0"))
         body = self.rfile.read(length).decode("utf-8")
 
-        if self.path == "/chat/completions":
+        if self.path.endswith("/chat/completions"):
             self.authorization_headers.append(self.headers.get("authorization"))
             request = json.loads(body)
             self.completion_requests.append(request)
@@ -109,6 +110,13 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             self._send_json(payload)
             return
 
+        if self.path == "/redact":
+            self.authorization_headers.append(self.headers.get("authorization"))
+            request = json.loads(body)
+            self.privacy_filter_requests.append(request)
+            self._send_json({"redacted_text": "email [PRIVATE_EMAIL] token [SECRET]"})
+            return
+
         if self.path == "/api/chat":
             self.ollama_requests.append(json.loads(body))
             payload = {
@@ -162,6 +170,11 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
         SELECT * FROM ai_clear_usage();
         SET duckdb_ai_provider = 'openai';
         SET duckdb_ai_model = 'mock-model';
+        SET duckdb_ai_completion_model = 'mock-completion-model';
+        SET duckdb_ai_task_model = 'mock-task-model';
+        SET duckdb_ai_aggregate_model = 'mock-aggregate-model';
+        SET duckdb_ai_embedding_model = 'mock-embedding-default';
+        SET duckdb_ai_sql_model = 'mock-sql-model';
         SET duckdb_ai_base_url = '{base_url}';
         SET duckdb_ai_log_endpoint = '{base_url}/log';
         SET duckdb_ai_timeout_seconds = 5;
@@ -169,6 +182,27 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             TYPE duckdb_ai,
             API_KEY 'test-key',
             AI_PROVIDER 'openai'
+        );
+        CREATE OR REPLACE SECRET smoke_privacy_filter_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'openai_privacy_filter',
+            BASE_URL '{base_url}',
+            MODEL 'openai/privacy-filter'
+        );
+        CREATE OR REPLACE SECRET smoke_databricks_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'databricks',
+            BASE_URL '{base_url}',
+            MODEL 'databricks-llama-4-maverick'
+        );
+        CREATE OR REPLACE SECRET smoke_snowflake_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'snowflake',
+            BASE_URL '{base_url}',
+            MODEL 'snowflake-llama-3.3-70b'
         );
         SELECT ai_complete(
             'hello from smoke',
@@ -279,8 +313,26 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             model := 'gpt-5.4-mini',
             use_builtin_model_prices := true
         ) AS builtin_priced_completion;
-        SELECT ai_embed('embed smoke', model := 'mock-embedding-model')[1] AS first_embedding_value;
-        SELECT round(ai_similarity('same left', 'same right', model := 'mock-embedding-model'), 6) AS similarity;
+        SELECT ai_complete(
+            'hello databricks',
+            secret := 'smoke_databricks_ai',
+            provider := 'databricks',
+            model := 'databricks-llama-4-maverick'
+        ) AS databricks_completion;
+        SELECT ai_complete(
+            'hello snowflake',
+            secret := 'smoke_snowflake_ai',
+            provider := 'snowflake',
+            model := 'snowflake-llama-3.3-70b'
+        ) AS snowflake_completion;
+        SELECT ai_redact(
+            'email alice@example.com token fake-token',
+            secret := 'smoke_privacy_filter_ai',
+            provider := 'openai_privacy_filter',
+            model := 'openai/privacy-filter'
+        ) AS privacy_filter_redaction;
+        SELECT ai_embed('embed smoke')[1] AS first_embedding_value;
+        SELECT round(ai_similarity('same left', 'same right'), 6) AS similarity;
         SELECT event, provider, protocol, model, prompt_chars, response_chars, input_chars,
                dimensions, prompt_tokens, completion_tokens, total_tokens, http_status,
                estimated_cost_usd
@@ -374,7 +426,18 @@ def assert_smoke_result(output: str):
         "openai",
         "openai_chat",
         "openai_embeddings",
-        "mock-model",
+        "mock-completion-model",
+        "mock-task-model",
+        "mock-sql-model",
+        "mock-aggregate-model",
+        "mock-embedding-default",
+        "openai_privacy_filter",
+        "privacy_filter",
+        "databricks",
+        "snowflake",
+        "databricks-llama-4-maverick",
+        "snowflake-llama-3.3-70b",
+        "email [PRIVATE_EMAIL] token [SECRET]",
         "0.25",
         "1.0",
         "16",
@@ -388,16 +451,28 @@ def assert_smoke_result(output: str):
     if missing:
         raise AssertionError(f"duckdb output missing {missing}\n{output}")
 
-    if len(MockProviderHandler.completion_requests) != 28:
-        raise AssertionError(f"expected 28 completion requests, got {len(MockProviderHandler.completion_requests)}")
-    if len(MockProviderHandler.authorization_headers) != 31:
-        raise AssertionError(f"expected 31 auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if len(MockProviderHandler.completion_requests) != 30:
+        raise AssertionError(f"expected 30 completion requests, got {len(MockProviderHandler.completion_requests)}")
+    if len(MockProviderHandler.authorization_headers) != 34:
+        raise AssertionError(f"expected 34 auth headers, got {len(MockProviderHandler.authorization_headers)}")
     for header in MockProviderHandler.authorization_headers:
         if header != "Bearer test-key":
             raise AssertionError(f"unexpected authorization header: {header}")
 
+    completion_models = [request["model"] for request in MockProviderHandler.completion_requests]
+    if completion_models[0:9] != ["mock-completion-model"] * 9:
+        raise AssertionError(f"unexpected completion default models: {completion_models[0:9]}")
+    if completion_models[9:16] != ["mock-task-model"] * 7:
+        raise AssertionError(f"unexpected task default models: {completion_models[9:16]}")
+    if completion_models[16:21] != ["mock-sql-model"] * 5:
+        raise AssertionError(f"unexpected SQL assistant default models: {completion_models[16:21]}")
+    if completion_models[21:23] != ["mock-aggregate-model"] * 2:
+        raise AssertionError(f"unexpected aggregate default models: {completion_models[21:23]}")
+    if completion_models[23:27] != ["mock-completion-model"] * 4:
+        raise AssertionError(f"unexpected later completion default models: {completion_models[23:27]}")
+
     completion_request = MockProviderHandler.completion_requests[0]
-    if completion_request["model"] != "mock-model":
+    if completion_request["model"] != "mock-completion-model":
         raise AssertionError(f"unexpected completion model: {completion_request}")
     if completion_request["messages"][0] != {"role": "system", "content": "answer briefly"}:
         raise AssertionError(f"unexpected completion system prompt: {completion_request}")
@@ -506,6 +581,26 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"unexpected builtin pricing model: {builtin_price_request}")
     if builtin_price_request["messages"][-1]["content"] != "builtin pricing smoke":
         raise AssertionError(f"unexpected builtin pricing prompt: {builtin_price_request}")
+    databricks_request = MockProviderHandler.completion_requests[28]
+    if databricks_request.get("model") != "databricks-llama-4-maverick":
+        raise AssertionError(f"unexpected Databricks model: {databricks_request}")
+    if databricks_request["messages"][-1]["content"] != "hello databricks":
+        raise AssertionError(f"unexpected Databricks prompt: {databricks_request}")
+    snowflake_request = MockProviderHandler.completion_requests[29]
+    if snowflake_request.get("model") != "snowflake-llama-3.3-70b":
+        raise AssertionError(f"unexpected Snowflake model: {snowflake_request}")
+    if snowflake_request["messages"][-1]["content"] != "hello snowflake":
+        raise AssertionError(f"unexpected Snowflake prompt: {snowflake_request}")
+    if len(MockProviderHandler.privacy_filter_requests) != 1:
+        raise AssertionError(
+            f"expected 1 Privacy Filter request, got {len(MockProviderHandler.privacy_filter_requests)}"
+        )
+    privacy_filter_request = MockProviderHandler.privacy_filter_requests[0]
+    if privacy_filter_request != {
+        "text": "email alice@example.com token fake-token",
+        "model": "openai/privacy-filter",
+    }:
+        raise AssertionError(f"unexpected Privacy Filter request: {privacy_filter_request}")
 
     if len(MockProviderHandler.ollama_requests) != 1:
         raise AssertionError(f"expected 1 Ollama request, got {len(MockProviderHandler.ollama_requests)}")
@@ -540,27 +635,32 @@ def assert_smoke_result(output: str):
     if len(MockProviderHandler.embedding_requests) != 3:
         raise AssertionError(f"expected 3 embedding requests, got {len(MockProviderHandler.embedding_requests)}")
     embedding_request = MockProviderHandler.embedding_requests[0]
-    if embedding_request["model"] != "mock-embedding-model":
+    if embedding_request["model"] != "mock-embedding-default":
         raise AssertionError(f"unexpected embedding model: {embedding_request}")
     if embedding_request["input"] != "embed smoke":
         raise AssertionError(f"unexpected embedding input: {embedding_request}")
     similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[1:]]
     if similarity_inputs != ["same left", "same right"]:
         raise AssertionError(f"unexpected similarity embedding inputs: {similarity_inputs}")
+    similarity_models = [request["model"] for request in MockProviderHandler.embedding_requests[1:]]
+    if similarity_models != ["mock-embedding-default", "mock-embedding-default"]:
+        raise AssertionError(f"unexpected similarity embedding models: {similarity_models}")
 
-    if len(MockProviderHandler.log_requests) != 31:
-        raise AssertionError(f"expected 31 log requests, got {len(MockProviderHandler.log_requests)}")
+    if len(MockProviderHandler.log_requests) != 34:
+        raise AssertionError(f"expected 34 log requests, got {len(MockProviderHandler.log_requests)}")
     completion_logs = [
         request for request in MockProviderHandler.log_requests if request.get("event") == "ai_completion"
     ]
     embedding_logs = [request for request in MockProviderHandler.log_requests if request.get("event") == "ai_embedding"]
     otlp_logs = [request for request in MockProviderHandler.log_requests if "resourceLogs" in request]
-    if len(completion_logs) != 27 or len(embedding_logs) != 3:
+    if len(completion_logs) != 30 or len(embedding_logs) != 3:
         raise AssertionError(f"unexpected log events: {MockProviderHandler.log_requests}")
     if len(otlp_logs) != 1:
         raise AssertionError(f"expected 1 OTLP log request, got {otlp_logs}")
     logged_providers = {request.get("provider") for request in completion_logs}
-    if not {"openai", "ollama", "claude"}.issubset(logged_providers):
+    if not {"openai", "ollama", "claude", "databricks", "snowflake", "openai_privacy_filter"}.issubset(
+        logged_providers
+    ):
         raise AssertionError(f"missing provider logs: {completion_logs}")
 
     otlp_log = otlp_logs[0]
@@ -582,7 +682,7 @@ def assert_smoke_result(output: str):
         "ai.event": "ai_completion",
         "ai.provider": "openai",
         "ai.protocol": "openai_chat",
-        "ai.model": "mock-model",
+        "ai.model": "mock-completion-model",
         "ai.tags": "otlp-smoke",
         "ai.prompt_chars": "14",
         "ai.response_chars": "15",
@@ -601,7 +701,7 @@ def assert_smoke_result(output: str):
         "event": "ai_completion",
         "provider": "openai",
         "protocol": "openai_chat",
-        "model": "mock-model",
+        "model": "mock-completion-model",
         "tags": "smoke-run",
         "prompt_chars": 16,
         "response_chars": 15,
@@ -623,6 +723,21 @@ def assert_smoke_result(output: str):
     builtin_estimated_cost = builtin_price_log.get("estimated_cost_usd")
     if builtin_estimated_cost is None or abs(builtin_estimated_cost - 0.00001875) > 0.000000001:
         raise AssertionError(f"unexpected builtin pricing cost: {builtin_price_log}")
+    databricks_log = next(
+        (request for request in completion_logs if request.get("model") == "databricks-llama-4-maverick"), None
+    )
+    if databricks_log is None or databricks_log.get("provider") != "databricks":
+        raise AssertionError(f"missing Databricks completion log: {completion_logs}")
+    snowflake_log = next(
+        (request for request in completion_logs if request.get("model") == "snowflake-llama-3.3-70b"), None
+    )
+    if snowflake_log is None or snowflake_log.get("provider") != "snowflake":
+        raise AssertionError(f"missing Snowflake completion log: {completion_logs}")
+    privacy_filter_log = next(
+        (request for request in completion_logs if request.get("model") == "openai/privacy-filter"), None
+    )
+    if privacy_filter_log is None or privacy_filter_log.get("provider") != "openai_privacy_filter":
+        raise AssertionError(f"missing Privacy Filter redaction log: {completion_logs}")
     for completion_log in completion_logs:
         if "prompt" in completion_log or "response" in completion_log:
             raise AssertionError(f"log request unexpectedly included prompt/response text: {completion_log}")
@@ -633,7 +748,7 @@ def assert_smoke_result(output: str):
         "event": "ai_embedding",
         "provider": "openai",
         "protocol": "openai_embeddings",
-        "model": "mock-embedding-model",
+        "model": "mock-embedding-default",
         "input_chars": 11,
         "dimensions": 3,
         "prompt_tokens": 2,

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -53,6 +53,16 @@ SELECT ai_provider_protocol('anthropic'), ai_provider_protocol('gcp'), ai_provid
 anthropic_messages	openai_chat	openai_chat	openai_chat
 
 query I
+SELECT ai_provider_protocol('openai_privacy_filter');
+----
+privacy_filter
+
+query II
+SELECT ai_provider_protocol('databricks'), ai_provider_protocol('snowflake');
+----
+openai_chat	openai_chat
+
+query I
 SELECT ai_provider_protocol('gemini') || '@' || ai_provider_base_url('gemini') || '|' || ai_provider_protocol('mistral') || '@' || ai_provider_base_url('mistral') || '|' || ai_provider_protocol('zai') || '@' || ai_provider_base_url('zai') || '|' || ai_provider_protocol('deepseek') || '@' || ai_provider_base_url('deepseek') || '|' || ai_provider_protocol('openrouter') || '@' || ai_provider_base_url('openrouter');
 ----
 openai_chat@https://generativelanguage.googleapis.com/v1beta/openai|openai_chat@https://api.mistral.ai/v1|openai_chat@https://open.bigmodel.cn/api/paas/v4|openai_chat@https://api.deepseek.com|openai_chat@https://openrouter.ai/api/v1
@@ -191,6 +201,21 @@ SELECT contains(ai_request_json('json please', 'llama3', 'ollama', response_form
 ----
 true
 
+query I
+SELECT ai_request_json('redact email alice@example.com', provider := 'openai_privacy_filter');
+----
+{"text":"redact email alice@example.com","model":"openai/privacy-filter"}
+
+query I
+SELECT ai_request_json('hello databricks', provider := 'databricks');
+----
+{"model":"databricks-llama-4-maverick","messages":[{"role":"user","content":"hello databricks"}],"temperature":0.1}
+
+query I
+SELECT ai_request_json('hello snowflake', provider := 'snowflake');
+----
+{"model":"snowflake-llama-3.3-70b","messages":[{"role":"user","content":"hello snowflake"}],"temperature":0.1}
+
 statement ok
 SET duckdb_ai_provider = 'openai';
 
@@ -203,10 +228,42 @@ SELECT contains(ai_request_json('hello from settings'), '"model":"settings-model
 true
 
 statement ok
+SET duckdb_ai_completion_model = 'completion-settings-model';
+
+query I
+SELECT contains(ai_request_json('hello from completion settings'), '"model":"completion-settings-model"');
+----
+true
+
+query I
+SELECT contains(ai_request_json('hello with explicit model', model := 'explicit-model'), '"model":"explicit-model"');
+----
+true
+
+statement ok
+SET duckdb_ai_embedding_model = 'embedding-settings-model';
+
+query I
+SELECT ai_embedding_request_json('duck', provider := 'openai') = '{"model":"embedding-settings-model","input":"duck"}';
+----
+true
+
+query I
+SELECT ai_embedding_request_json('duck', provider := 'openai', model := 'explicit-embedding-model') = '{"model":"explicit-embedding-model","input":"duck"}';
+----
+true
+
+statement ok
 RESET duckdb_ai_provider;
 
 statement ok
 RESET duckdb_ai_model;
+
+statement ok
+RESET duckdb_ai_completion_model;
+
+statement ok
+RESET duckdb_ai_embedding_model;
 
 statement ok
 CREATE OR REPLACE SECRET ai_test_openai (TYPE duckdb_ai, AI_PROVIDER 'openai', API_KEY 'secret-key', MODEL 'secret-model');

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
     },
     'functions',
     'provider-guides',
+    'best-practices',
     'VALIDATION',
     'SMOKE_TESTING',
     'DISTRIBUTION',


### PR DESCRIPTION
Adds managed provider support and documentation for Databricks Model Serving, Snowflake Cortex REST, and OpenAI Privacy Filter while adding function-family default model settings.

### Codex description

- add Databricks, Snowflake, and OpenAI Privacy Filter provider support with deterministic request and smoke coverage
- add family-specific default model settings for completion, task, aggregate, SQL assistant, and embedding functions
- expand provider, best-practices, smoke-testing, validation, and README docs