### PR TITLE
feat: add ai batch controls

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,6 +19,9 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     defaults:
       run:
         working-directory: website
@@ -41,6 +44,10 @@ jobs:
 
       - name: Build website
         run: npm run build
+
+      - name: Configure Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !github.event.repository.private
+        uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ These are the main functions most users should start with:
 
 | Function | Use it for |
 | --- | --- |
-| `ai_complete` | General prompt-to-text completions from SQL. |
+| `ai_complete` / `ai_try_complete` | General prompt-to-text completions from SQL, with optional row-level error capture. |
 | `ai_summarize` / `ai_summarize_agg` | Summarizing one text value or a grouped set of rows. |
 | `ai_classify` | Assigning one label from a controlled list. |
 | `ai_filter` | Filtering rows with a natural-language predicate. |
@@ -267,7 +267,7 @@ These are the main functions most users should start with:
 
 | Need | Functions |
 | --- | --- |
-| Completion text | `ai_complete`, `ai_request_json` |
+| Completion text | `ai_complete`, `ai_try_complete`, `ai_request_json` |
 | Structured output | `ai_complete_json`, `ai_complete_record` |
 | Text tasks | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_extract`, `ai_filter` |
 | Aggregates | `ai_summarize_agg`, `ai_agg` |
@@ -276,7 +276,7 @@ These are the main functions most users should start with:
 | SQL safety checks | `ai_is_read_only_sql`, `ai_validate_read_only_sql` |
 | Provider metadata | `ai_provider_base_url`, `ai_provider_protocol`, `ai_models` |
 | Usage and secrets | `ai_usage`, `ai_clear_usage`, `ai_secrets` |
-| Local utility | `ai_count_tokens` |
+| Local utility | `ai_count_tokens`, `ai_recommended_batch_size` |
 
 The full SQL reference is in [`docs/functions.md`](docs/functions.md).
 End-to-end setup examples for each provider are in
@@ -284,21 +284,28 @@ End-to-end setup examples for each provider are in
 
 ## Providers
 
+### Local or self-hosted providers
+
 | Provider | Use it with | Default base URL / key |
 | --- | --- | --- |
 | `ollama` | Local Ollama chat and embedding models | `http://localhost:11434`; optional `OLLAMA_API_KEY` |
-| `openai` | OpenAI chat and embedding models | `https://api.openai.com/v1`; `OPENAI_API_KEY` |
+| `openai_compatible` / `local` | vLLM, LM Studio, LiteLLM, Ollama `/v1`, or another gateway | Set `BASE_URL`; optional `OPENAI_COMPATIBLE_API_KEY` |
+| `openai_privacy_filter` | OpenAI Privacy Filter PII redaction service | `http://localhost:8080`; optional `OPENAI_PRIVACY_FILTER_API_KEY` |
+
+### Remote providers
+
+| Provider | Use it with | Default base URL / key |
+| --- | --- | --- |
 | `azure` | Azure OpenAI deployments | Set `BASE_URL` or `AZURE_OPENAI_BASE_URL`; `AZURE_OPENAI_API_KEY` |
 | `claude` / `anthropic` | Anthropic Claude models | `https://api.anthropic.com/v1`; `ANTHROPIC_API_KEY` |
+| `databricks` | Databricks Model Serving and Unity AI Gateway chat endpoints | Set `BASE_URL` or `DATABRICKS_HOST`; `DATABRICKS_TOKEN` |
+| `deepseek` | DeepSeek chat models | `https://api.deepseek.com`; `DEEPSEEK_API_KEY` |
 | `gemini` / `gcp` / `google` | Gemini through the OpenAI-compatible endpoint | `GEMINI_API_KEY` |
 | `mistral` | Mistral chat models | `https://api.mistral.ai/v1`; `MISTRAL_API_KEY` |
-| `zai` | Z.ai / BigModel chat models | `https://open.bigmodel.cn/api/paas/v4`; `ZAI_API_KEY` |
-| `deepseek` | DeepSeek chat models | `https://api.deepseek.com`; `DEEPSEEK_API_KEY` |
+| `openai` | OpenAI chat and embedding models | `https://api.openai.com/v1`; `OPENAI_API_KEY` |
 | `openrouter` | OpenRouter model routing | `https://openrouter.ai/api/v1`; `OPENROUTER_API_KEY` |
-| `databricks` | Databricks Model Serving and Unity AI Gateway chat endpoints | Set `BASE_URL` or `DATABRICKS_HOST`; `DATABRICKS_TOKEN` |
 | `snowflake` | Snowflake Cortex REST Chat Completions API | Set `BASE_URL`, `SNOWFLAKE_ACCOUNT_URL`, or `SNOWFLAKE_ACCOUNT`; `SNOWFLAKE_PAT` |
-| `openai_privacy_filter` | OpenAI Privacy Filter PII redaction service | `http://localhost:8080`; optional `OPENAI_PRIVACY_FILTER_API_KEY` |
-| `openai_compatible` / `local` | vLLM, LM Studio, LiteLLM, Ollama `/v1`, or another gateway | Set `BASE_URL`; optional `OPENAI_COMPATIBLE_API_KEY` |
+| `zai` | Z.ai / BigModel chat models | `https://open.bigmodel.cn/api/paas/v4`; `ZAI_API_KEY` |
 
 You can configure providers three ways:
 
@@ -443,9 +450,69 @@ For batch workloads, cap provider concurrency and rate:
 ```sql
 SET duckdb_ai_max_concurrent_requests = 4;
 SET duckdb_ai_min_request_interval_ms = 100;
+SET duckdb_ai_token_limit_per_minute = 200000;
 ```
 
-These controls apply to completion and embedding calls.
+These controls apply to completion and embedding calls. The token limit uses the
+local `ai_count_tokens` estimate plus `max_tokens` when present, or a conservative
+default output estimate otherwise. Set `max_tokens` for large jobs so the runtime
+can pace requests against your provider's current tokens-per-minute limit.
+
+Use `ai_recommended_batch_size` with a small provider-limit table to pick a
+starting batch size before running a large enrichment:
+
+```sql
+CREATE OR REPLACE TABLE ai_provider_limits AS
+SELECT
+    'openai' AS provider,
+    'gpt-4o-mini' AS model,
+    200000::BIGINT AS token_limit_per_minute,
+    500::BIGINT AS request_limit_per_minute;
+
+WITH prompt_stats AS (
+    SELECT avg(ai_count_tokens(subject || ': ' || body)) AS input_tokens_per_row
+    FROM support_tickets
+)
+SELECT ai_recommended_batch_size(
+    input_tokens_per_row,
+    200, -- planned max_tokens per row
+    token_limit_per_minute,
+    request_limit_per_minute
+) AS recommended_rows_per_minute
+FROM prompt_stats, ai_provider_limits
+WHERE provider = 'openai' AND model = 'gpt-4o-mini';
+```
+
+For production row enrichment, use `ai_try_complete` when one bad row should not
+fail the full query. It returns a `STRUCT(response VARCHAR, error VARCHAR)`, so
+successful rows and rejected rows can be written separately:
+
+```sql
+CREATE TEMP TABLE ticket_ai_attempts AS
+SELECT
+    ticket_id,
+    ai_try_complete(
+        subject || ': ' || body,
+        provider := 'openai',
+        model := 'gpt-4o-mini',
+        max_tokens := 200,
+        token_limit_per_minute := 200000
+    ) AS result
+FROM support_tickets;
+
+CREATE OR REPLACE TABLE ticket_summaries AS
+SELECT ticket_id, result.response AS summary
+FROM ticket_ai_attempts
+WHERE result.error IS NULL;
+
+CREATE OR REPLACE TABLE ticket_ai_failed_rows AS
+SELECT ticket_id, result.error AS error_reason, current_timestamp AS failed_at
+FROM ticket_ai_attempts
+WHERE result.error IS NOT NULL;
+```
+
+Use the same rejected-row `SELECT` inside `COPY (...) TO 'failed_rows.parquet'`
+or an `s3://...` target when failures should live outside the DuckDB database.
 
 ## Learn More
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -204,6 +204,33 @@ For batch workloads, set process-local concurrency and pacing:
 ```sql
 SET duckdb_ai_max_concurrent_requests = 4;
 SET duckdb_ai_min_request_interval_ms = 100;
+SET duckdb_ai_token_limit_per_minute = 200000;
+```
+
+Use `ai_count_tokens` and `ai_recommended_batch_size` before large jobs. Keep
+provider limits in a small table so the numbers are easy to update when your
+account tier changes:
+
+```sql
+CREATE OR REPLACE TABLE ai_provider_limits AS
+SELECT
+    'openai' AS provider,
+    'gpt-4o-mini' AS model,
+    200000::BIGINT AS token_limit_per_minute,
+    500::BIGINT AS request_limit_per_minute;
+
+WITH prompt_stats AS (
+    SELECT avg(ai_count_tokens(subject || ': ' || body)) AS input_tokens_per_row
+    FROM support_tickets
+)
+SELECT ai_recommended_batch_size(
+    input_tokens_per_row,
+    200,
+    token_limit_per_minute,
+    request_limit_per_minute
+) AS recommended_rows_per_minute
+FROM prompt_stats, ai_provider_limits
+WHERE provider = 'openai' AND model = 'gpt-4o-mini';
 ```
 
 Retries are disabled by default. Enable small retry counts only for transient
@@ -228,6 +255,36 @@ SELECT ai_classify(
 )
 FROM support_tickets;
 ```
+
+For production enrichment, prefer `ai_try_complete` so failed rows keep their
+error reason:
+
+```sql
+CREATE TEMP TABLE ticket_ai_attempts AS
+SELECT
+    ticket_id,
+    ai_try_complete(
+        subject || ': ' || body,
+        provider := 'openai',
+        model := 'gpt-4o-mini',
+        max_tokens := 200,
+        token_limit_per_minute := 200000
+    ) AS result
+FROM support_tickets;
+
+CREATE OR REPLACE TABLE ticket_summaries AS
+SELECT ticket_id, result.response AS summary
+FROM ticket_ai_attempts
+WHERE result.error IS NULL;
+
+CREATE OR REPLACE TABLE ticket_ai_failed_rows AS
+SELECT ticket_id, result.error AS error_reason, current_timestamp AS failed_at
+FROM ticket_ai_attempts
+WHERE result.error IS NOT NULL;
+```
+
+Use the same rejected-row `SELECT` inside `COPY (...) TO 'failed_rows.parquet'`
+or an `s3://...` target when failures should live outside the DuckDB database.
 
 ## Log usage without leaking text
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -21,6 +21,7 @@ FROM ai_usage();
 | Function | Type | Description |
 | --- | --- | --- |
 | `ai_complete(prompt[, model[, provider]])` | Scalar | Calls a completion model and returns text. |
+| `ai_try_complete(prompt[, model[, provider]])` | Scalar | Calls a completion model and returns `STRUCT(response, error)` for row-level failure capture. |
 | `ai_complete_json(prompt[, model[, provider]])` | Scalar | Calls a completion model and validates the response as a JSON object or array. |
 | `ai_complete_record(prompt, response_schema[, model[, provider]])` | Table | Calls a completion model and projects a JSON object into typed columns from a JSON Schema. |
 | `ai_request_json(prompt[, model[, provider]])` | Scalar | Returns the completion request JSON without making a network call. |
@@ -46,6 +47,7 @@ FROM ai_usage();
 | `ai_is_read_only_sql(sql)` | Scalar | Returns whether SQL is one parser-valid read-only `SELECT`. |
 | `ai_validate_read_only_sql(sql)` | Scalar | Returns normalized SQL or raises if it is not one read-only `SELECT`. |
 | `ai_count_tokens(text[, model[, provider]])` | Scalar | Returns a local approximate token count. |
+| `ai_recommended_batch_size(input_tokens_per_row, max_output_tokens_per_row, token_limit_per_minute[, request_limit_per_minute[, safety_factor]])` | Scalar | Returns a conservative row batch size for rate-limited AI jobs. |
 | `ai_provider_base_url(provider)` | Scalar | Returns the default base URL for a supported provider. |
 | `ai_provider_protocol(provider)` | Scalar | Returns the internal provider protocol. |
 | `ai_usage()` | Table | Returns recent in-process AI usage events. |
@@ -71,6 +73,28 @@ SELECT ai_complete(
 ```
 
 Result: `VARCHAR`
+
+#### `ai_try_complete(prompt[, model[, provider]])`
+
+Description: Calls a configured completion provider and returns a
+`STRUCT(response VARCHAR, error VARCHAR)`. Successful rows have `error = NULL`;
+failed rows have `response = NULL` and the provider or validation error text.
+Use this for batch enrichment when one bad row should be written to a rejected
+rows table instead of failing the whole query.
+
+Example:
+
+```sql
+WITH attempts AS (
+    SELECT id, ai_try_complete(prompt, provider := 'openai') AS result
+    FROM prompts
+)
+SELECT id, result.response
+FROM attempts
+WHERE result.error IS NULL;
+```
+
+Result: `STRUCT(response VARCHAR, error VARCHAR)`
 
 #### `ai_complete_json(prompt[, model[, provider]])`
 
@@ -466,6 +490,21 @@ SELECT ai_count_tokens('DuckDB local analytics');
 
 Result: `BIGINT`
 
+#### `ai_recommended_batch_size(input_tokens_per_row, max_output_tokens_per_row, token_limit_per_minute[, request_limit_per_minute[, safety_factor]])`
+
+Description: Returns a conservative number of rows to process per batch or
+minute for a rate-limited AI job. `input_tokens_per_row` can come from
+`avg(ai_count_tokens(prompt))`, `max_output_tokens_per_row` should match the
+planned `max_tokens`, and `safety_factor` defaults to `0.8`.
+
+Example:
+
+```sql
+SELECT ai_recommended_batch_size(100, 200, 200000, 500);
+```
+
+Result: `BIGINT`
+
 ## Provider metadata functions
 
 #### `ai_provider_base_url(provider)`
@@ -578,6 +617,7 @@ not from direct API key arguments.
 | `retry_backoff_ms` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Base retry backoff from 0 to 60000 milliseconds. |
 | `max_concurrent_requests` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Process-local request concurrency cap from 0 to 1024. |
 | `min_request_interval_ms` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Process-local minimum interval between provider request starts. |
+| `token_limit_per_minute` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Process-local estimated token cap per rolling minute. `0` disables the token cap. |
 | `fail_on_error` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | If false, supported functions return `NULL` or an empty result instead of raising provider errors. |
 | `response_format` | `VARCHAR` | Completion and SQL assistant | `text`, `json_object`, or `json_schema`. |
 | `response_schema`, `json_schema` | `VARCHAR` | Completion and SQL assistant | JSON Schema object for structured output hints and validation. |

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -40,6 +40,8 @@ namespace duckdb {
 
 namespace {
 
+constexpr int64_t MAX_TOKEN_LIMIT_PER_MINUTE = 10000000000LL;
+
 bool CompletionOptionsEqual(const duckdb_ai::CompletionOptions &left, const duckdb_ai::CompletionOptions &right) {
 	return left.model == right.model && left.provider == right.provider && left.secret_name == right.secret_name &&
 	       left.system_prompt == right.system_prompt && left.base_url == right.base_url &&
@@ -53,6 +55,8 @@ bool CompletionOptionsEqual(const duckdb_ai::CompletionOptions &left, const duck
 	       left.max_concurrent_requests == right.max_concurrent_requests &&
 	       left.has_min_request_interval_ms == right.has_min_request_interval_ms &&
 	       left.min_request_interval_ms == right.min_request_interval_ms &&
+	       left.has_token_limit_per_minute == right.has_token_limit_per_minute &&
+	       left.token_limit_per_minute == right.token_limit_per_minute &&
 	       left.has_input_token_price_per_million == right.has_input_token_price_per_million &&
 	       left.input_token_price_per_million == right.input_token_price_per_million &&
 	       left.has_output_token_price_per_million == right.has_output_token_price_per_million &&
@@ -429,7 +433,7 @@ bool TryGetOptionType(const std::string &name, LogicalType &type) {
 		return true;
 	}
 	if (name == "max_tokens" || name == "retry_count" || name == "retry_backoff_ms" ||
-	    name == "max_concurrent_requests" || name == "min_request_interval_ms") {
+	    name == "max_concurrent_requests" || name == "min_request_interval_ms" || name == "token_limit_per_minute") {
 		type = LogicalType::BIGINT;
 		return true;
 	}
@@ -451,9 +455,10 @@ LogicalType OptionType(const std::string &name) {
 	}
 	throw BinderException("Unsupported AI option \"%s\". Supported options: model, provider, temperature, "
 	                      "system_prompt, max_tokens, base_url, timeout_seconds, retry_count, retry_backoff_ms, "
-	                      "max_concurrent_requests, min_request_interval_ms, input_token_price_per_million, "
-	                      "output_token_price_per_million, use_builtin_model_prices, fail_on_error, profile, secret, "
-	                      "response_format, response_schema, json_schema, log_format, log_tags, log_sample_rate",
+	                      "max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, "
+	                      "input_token_price_per_million, output_token_price_per_million, use_builtin_model_prices, "
+	                      "fail_on_error, profile, secret, response_format, response_schema, json_schema, log_format, "
+	                      "log_tags, log_sample_rate",
 	                      name);
 }
 
@@ -639,6 +644,15 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 			throw BinderException("%s option \"min_request_interval_ms\" must be between 0 and 60000", function_name);
 		}
 		options.has_min_request_interval_ms = true;
+		return true;
+	}
+	if (name == "token_limit_per_minute") {
+		options.token_limit_per_minute = OptionBigIntValue(value, function_name, name);
+		if (options.token_limit_per_minute < 0 || options.token_limit_per_minute > MAX_TOKEN_LIMIT_PER_MINUTE) {
+			throw BinderException("%s option \"token_limit_per_minute\" must be between 0 and %lld", function_name,
+			                      static_cast<long long>(MAX_TOKEN_LIMIT_PER_MINUTE));
+		}
+		options.has_token_limit_per_minute = true;
 		return true;
 	}
 	if (name == "timeout_seconds") {
@@ -851,6 +865,8 @@ void ApplySettingsWithPrefix(ClientContext &context, const std::string &prefix, 
 	                                options.has_max_concurrent_requests, 0, 1024);
 	ApplyOptionalBigIntRangeSetting(context, prefix + "_min_request_interval_ms", options.min_request_interval_ms,
 	                                options.has_min_request_interval_ms, 0, 60000);
+	ApplyOptionalBigIntRangeSetting(context, prefix + "_token_limit_per_minute", options.token_limit_per_minute,
+	                                options.has_token_limit_per_minute, 0, MAX_TOKEN_LIMIT_PER_MINUTE);
 	ApplyNonNegativeDoubleSetting(context, prefix + "_input_token_price_per_million",
 	                              options.input_token_price_per_million, options.has_input_token_price_per_million);
 	ApplyNonNegativeDoubleSetting(context, prefix + "_output_token_price_per_million",
@@ -1171,6 +1187,69 @@ void AiCompletionFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	}
 }
 
+LogicalType AiTryCompleteReturnType() {
+	child_list_t<LogicalType> children;
+	children.emplace_back("response", LogicalType::VARCHAR);
+	children.emplace_back("error", LogicalType::VARCHAR);
+	return LogicalType::STRUCT(std::move(children));
+}
+
+unique_ptr<FunctionData> AiTryCompleteBind(ClientContext &context, ScalarFunction &bound_function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = AiCompletionBindInternal(context, bound_function, arguments);
+	bound_function.SetReturnType(AiTryCompleteReturnType());
+	return bind_data;
+}
+
+Value AiTryCompleteValue(const LogicalType &result_type, const std::string &response, bool has_error,
+                         const std::string &error) {
+	vector<Value> children;
+	children.reserve(2);
+	if (has_error) {
+		children.emplace_back(LogicalType::VARCHAR);
+		children.emplace_back(error);
+	} else {
+		children.emplace_back(response);
+		children.emplace_back(LogicalType::VARCHAR);
+	}
+	return Value::STRUCT(result_type, std::move(children));
+}
+
+void AiTryCompleteFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &bind_data = func_expr.bind_info->Cast<AiCompletionBindData>();
+	auto result_type = AiTryCompleteReturnType();
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader prompt_reader(args, bind_data.prompt_index);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
+
+	for (idx_t row = 0; row < args.size(); row++) {
+		std::string prompt;
+		if (!prompt_reader.Read(row, prompt)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		try {
+			ApplyAiProviderSecret(state.GetContext(), options);
+			auto output = duckdb_ai::Complete(prompt, options).text;
+			result.SetValue(row, AiTryCompleteValue(result_type, output, false, ""));
+		} catch (std::exception &ex) {
+			result.SetValue(row, AiTryCompleteValue(result_type, "", true, ex.what()));
+		}
+	}
+}
+
 std::string RequiredRecordStringInput(const TableFunctionBindInput &input, idx_t index, const std::string &name) {
 	if (index >= input.inputs.size()) {
 		throw BinderException("ai_complete_record requires a %s argument", name);
@@ -1427,7 +1506,7 @@ void AiRecordFunction(ClientContext &context, TableFunctionInput &input, DataChu
 bool IsEmbeddingOption(const std::string &name) {
 	return name == "model" || name == "provider" || name == "profile" || name == "secret" || name == "secret_name" ||
 	       name == "base_url" || name == "timeout_seconds" || name == "retry_count" || name == "retry_backoff_ms" ||
-	       name == "max_concurrent_requests" || name == "min_request_interval_ms" ||
+	       name == "max_concurrent_requests" || name == "min_request_interval_ms" || name == "token_limit_per_minute" ||
 	       name == "input_token_price_per_million" || name == "output_token_price_per_million" ||
 	       name == "use_builtin_model_prices" || name == "fail_on_error" || name == "log_format" ||
 	       name == "log_tags" || name == "log_sample_rate";
@@ -1464,7 +1543,7 @@ unique_ptr<FunctionData> AiEmbeddingBindInternal(ClientContext &context, ScalarF
 			throw BinderException(
 			    "Unsupported AI embedding option \"%s\". Supported options: model, provider, "
 			    "profile, secret, base_url, timeout_seconds, retry_count, retry_backoff_ms, fail_on_error, "
-			    "max_concurrent_requests, min_request_interval_ms, "
+			    "max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, "
 			    "input_token_price_per_million, output_token_price_per_million, "
 			    "use_builtin_model_prices, log_format, log_tags, log_sample_rate",
 			    alias);
@@ -1517,7 +1596,7 @@ unique_ptr<FunctionData> AiSimilarityBind(ClientContext &context, ScalarFunction
 			throw BinderException(
 			    "Unsupported AI similarity option \"%s\". Supported options: model, provider, "
 			    "profile, secret, base_url, timeout_seconds, retry_count, retry_backoff_ms, fail_on_error, "
-			    "max_concurrent_requests, min_request_interval_ms, "
+			    "max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, "
 			    "input_token_price_per_million, output_token_price_per_million, "
 			    "use_builtin_model_prices, log_format, log_tags, log_sample_rate",
 			    alias);
@@ -2584,13 +2663,6 @@ unique_ptr<FunctionData> AiCountTokensBind(ClientContext &context, ScalarFunctio
 	return bind_data;
 }
 
-int64_t EstimateTokenCount(const std::string &input) {
-	if (input.empty()) {
-		return 0;
-	}
-	return static_cast<int64_t>((input.size() + 3) / 4);
-}
-
 void AiCountTokensFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &bind_data = func_expr.bind_info->Cast<AiCompletionBindData>();
@@ -2606,7 +2678,80 @@ void AiCountTokensFunction(DataChunk &args, ExpressionState &state, Vector &resu
 			result_validity.SetInvalid(row);
 			continue;
 		}
-		result_data[row] = EstimateTokenCount(input);
+		result_data[row] = duckdb_ai::EstimateTokenCount(input);
+	}
+}
+
+double NumericArgValue(DataChunk &args, idx_t column, idx_t row, bool &is_null) {
+	auto value = args.data[column].GetValue(row);
+	if (value.IsNull()) {
+		is_null = true;
+		return 0;
+	}
+	return DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
+}
+
+int64_t RecommendedBatchSize(double input_tokens_per_row, double max_output_tokens_per_row,
+                             double token_limit_per_minute, double request_limit_per_minute, double safety_factor) {
+	if (!std::isfinite(input_tokens_per_row) || input_tokens_per_row < 0) {
+		throw InvalidInputException(
+		    "ai_recommended_batch_size input_tokens_per_row must be greater than or equal to 0");
+	}
+	if (!std::isfinite(max_output_tokens_per_row) || max_output_tokens_per_row < 0) {
+		throw InvalidInputException(
+		    "ai_recommended_batch_size max_output_tokens_per_row must be greater than or equal to 0");
+	}
+	if (!std::isfinite(token_limit_per_minute) || token_limit_per_minute < 0) {
+		throw InvalidInputException(
+		    "ai_recommended_batch_size token_limit_per_minute must be greater than or equal to 0");
+	}
+	if (!std::isfinite(request_limit_per_minute) || request_limit_per_minute < 0) {
+		throw InvalidInputException(
+		    "ai_recommended_batch_size request_limit_per_minute must be greater than or equal to 0");
+	}
+	if (!std::isfinite(safety_factor) || safety_factor <= 0 || safety_factor > 1) {
+		throw InvalidInputException("ai_recommended_batch_size safety_factor must be greater than 0 and at most 1");
+	}
+	if (token_limit_per_minute <= 0 && request_limit_per_minute <= 0) {
+		throw InvalidInputException("ai_recommended_batch_size requires token_limit_per_minute or "
+		                            "request_limit_per_minute to be greater than 0");
+	}
+
+	auto tokens_per_row = std::max(1.0, input_tokens_per_row + max_output_tokens_per_row);
+	auto token_rows = std::numeric_limits<double>::infinity();
+	if (token_limit_per_minute > 0) {
+		token_rows = std::floor((token_limit_per_minute * safety_factor) / tokens_per_row);
+	}
+	auto request_rows = std::numeric_limits<double>::infinity();
+	if (request_limit_per_minute > 0) {
+		request_rows = std::floor(request_limit_per_minute * safety_factor);
+	}
+	auto recommended = std::min(token_rows, request_rows);
+	if (!std::isfinite(recommended)) {
+		throw InvalidInputException("ai_recommended_batch_size requires token_limit_per_minute or "
+		                            "request_limit_per_minute to be greater than 0");
+	}
+	return std::max<int64_t>(1, static_cast<int64_t>(recommended));
+}
+
+void AiRecommendedBatchSizeFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<int64_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t row = 0; row < args.size(); row++) {
+		bool is_null = false;
+		auto input_tokens_per_row = NumericArgValue(args, 0, row, is_null);
+		auto max_output_tokens_per_row = NumericArgValue(args, 1, row, is_null);
+		auto token_limit_per_minute = NumericArgValue(args, 2, row, is_null);
+		auto request_limit_per_minute = args.ColumnCount() >= 4 ? NumericArgValue(args, 3, row, is_null) : 0;
+		auto safety_factor = args.ColumnCount() >= 5 ? NumericArgValue(args, 4, row, is_null) : 0.8;
+		if (is_null) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+		result_data[row] = RecommendedBatchSize(input_tokens_per_row, max_output_tokens_per_row, token_limit_per_minute,
+		                                        request_limit_per_minute, safety_factor);
 	}
 }
 
@@ -3486,6 +3631,10 @@ void RegisterSettingsForPrefix(DBConfig &config, const std::string &prefix, cons
 	AddSetting(config, prefix + "_min_request_interval_ms",
 	           "Minimum milliseconds between AI provider request starts between 0 and 60000; -1 uses default",
 	           LogicalType::BIGINT, Value::BIGINT(-1));
+	AddSetting(config, prefix + "_token_limit_per_minute",
+	           "Maximum estimated AI provider tokens per rolling minute between 0 and 10000000000; 0 disables the "
+	           "limit, -1 uses default",
+	           LogicalType::BIGINT, Value::BIGINT(-1));
 	AddSetting(config, prefix + "_input_token_price_per_million",
 	           "Input token price per million tokens for estimated AI usage cost; -1 disables cost estimates",
 	           LogicalType::DOUBLE, Value::DOUBLE(-1));
@@ -3560,6 +3709,16 @@ void RegisterTaskFunction(ExtensionLoader &loader, const std::string &name, vect
 
 void RegisterCompletionFunction(ExtensionLoader &loader, const std::string &name, bind_scalar_function_t bind) {
 	auto function = ScalarFunction(name, {LogicalType::VARCHAR}, LogicalType::VARCHAR, AiCompletionFunction, bind);
+	function.varargs = LogicalType::ANY;
+	function.SetFallible();
+	function.SetVolatile();
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	loader.RegisterFunction(function);
+}
+
+void RegisterTryCompletionFunction(ExtensionLoader &loader) {
+	auto function = ScalarFunction("ai_try_complete", {LogicalType::VARCHAR}, AiTryCompleteReturnType(),
+	                               AiTryCompleteFunction, AiTryCompleteBind);
 	function.varargs = LogicalType::ANY;
 	function.SetFallible();
 	function.SetVolatile();
@@ -3642,6 +3801,7 @@ void AddCompletionNamedParameters(TableFunction &function, bool include_response
 	                                           "retry_backoff_ms",
 	                                           "max_concurrent_requests",
 	                                           "min_request_interval_ms",
+	                                           "token_limit_per_minute",
 	                                           "input_token_price_per_million",
 	                                           "output_token_price_per_million",
 	                                           "use_builtin_model_prices",
@@ -3770,6 +3930,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterAiProviderSecret(loader);
 
 	RegisterCompletionFunction(loader, "ai_complete", AiCompleteBind);
+	RegisterTryCompletionFunction(loader);
 	RegisterCompletionFunction(loader, "ai_request_json", AiRequestJsonBind);
 
 	auto ai_complete_json = ScalarFunction("ai_complete_json", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
@@ -3834,6 +3995,19 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ai_count_tokens.varargs = LogicalType::ANY;
 	ai_count_tokens.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	loader.RegisterFunction(ai_count_tokens);
+
+	ScalarFunctionSet ai_recommended_batch_size("ai_recommended_batch_size");
+	for (idx_t argument_count = 3; argument_count <= 5; argument_count++) {
+		vector<LogicalType> arguments;
+		for (idx_t i = 0; i < argument_count; i++) {
+			arguments.emplace_back(LogicalType::DOUBLE);
+		}
+		auto function = ScalarFunction(std::move(arguments), LogicalType::BIGINT, AiRecommendedBatchSizeFunction);
+		function.SetFallible();
+		function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+		ai_recommended_batch_size.AddFunction(std::move(function));
+	}
+	loader.RegisterFunction(std::move(ai_recommended_batch_size));
 
 	loader.RegisterFunction(TableFunction("ai_usage", {}, AiUsageFunction, AiUsageBind, AiUsageInit));
 	loader.RegisterFunction(

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <curl/curl.h>
+#include <deque>
 #include <exception>
 #include <initializer_list>
 #include <iomanip>
@@ -36,11 +37,15 @@ std::mutex usage_mutex;
 std::vector<UsageEvent> usage_events;
 uint64_t next_usage_event_id = 1;
 const size_t MAX_USAGE_EVENTS = 1024;
+constexpr int64_t MAX_TOKEN_LIMIT_PER_MINUTE = 10000000000LL;
+constexpr int64_t DEFAULT_COMPLETION_OUTPUT_TOKEN_ESTIMATE = 512;
 std::mutex provider_control_mutex;
 std::condition_variable provider_control_cv;
 int64_t active_provider_requests = 0;
 bool has_last_provider_request_start = false;
 std::chrono::steady_clock::time_point last_provider_request_start;
+std::deque<std::pair<std::chrono::steady_clock::time_point, int64_t>> provider_token_window;
+int64_t provider_token_window_tokens = 0;
 
 std::string LowerAscii(std::string input) {
 	std::transform(input.begin(), input.end(), input.begin(),
@@ -1539,35 +1544,107 @@ int64_t MinRequestIntervalMs(const CompletionOptions &options) {
 	}
 }
 
+int64_t TokenLimitPerMinute(const CompletionOptions &options) {
+	if (options.has_token_limit_per_minute) {
+		return options.token_limit_per_minute;
+	}
+	auto configured = GetEnv("DUCKDB_AI_TOKEN_LIMIT_PER_MINUTE");
+	if (configured.empty()) {
+		return 0;
+	}
+	try {
+		auto token_limit_per_minute = std::stoll(configured);
+		if (token_limit_per_minute < 0 || token_limit_per_minute > MAX_TOKEN_LIMIT_PER_MINUTE) {
+			throw InvalidInputException("DUCKDB_AI_TOKEN_LIMIT_PER_MINUTE must be between 0 and %lld",
+			                            static_cast<long long>(MAX_TOKEN_LIMIT_PER_MINUTE));
+		}
+		return token_limit_per_minute;
+	} catch (InvalidInputException &) {
+		throw;
+	} catch (...) {
+		throw InvalidInputException("DUCKDB_AI_TOKEN_LIMIT_PER_MINUTE must be an integer between 0 and %lld",
+		                            static_cast<long long>(MAX_TOKEN_LIMIT_PER_MINUTE));
+	}
+}
+
+void PruneProviderTokenWindow(std::chrono::steady_clock::time_point now) {
+	auto cutoff = now - std::chrono::minutes(1);
+	while (!provider_token_window.empty() && provider_token_window.front().first <= cutoff) {
+		provider_token_window_tokens -= provider_token_window.front().second;
+		provider_token_window.pop_front();
+	}
+	if (provider_token_window_tokens < 0) {
+		provider_token_window_tokens = 0;
+	}
+}
+
+int64_t EstimatedCompletionTokens(const std::string &prompt, const CompletionOptions &options) {
+	auto output_estimate = options.has_max_tokens ? options.max_tokens : DEFAULT_COMPLETION_OUTPUT_TOKEN_ESTIMATE;
+	return EstimateTokenCount(prompt) + output_estimate;
+}
+
+int64_t TokenReservation(int64_t estimated_tokens, int64_t token_limit_per_minute) {
+	if (estimated_tokens <= 0 || token_limit_per_minute <= 0) {
+		return 0;
+	}
+	return std::min(estimated_tokens, token_limit_per_minute);
+}
+
 class ProviderRequestGuard {
 public:
-	explicit ProviderRequestGuard(const CompletionOptions &options)
+	explicit ProviderRequestGuard(const CompletionOptions &options, int64_t estimated_tokens)
 	    : max_concurrent_requests(MaxConcurrentRequests(options)),
-	      min_request_interval_ms(MinRequestIntervalMs(options)) {
-		if (max_concurrent_requests <= 0 && min_request_interval_ms <= 0) {
+	      min_request_interval_ms(MinRequestIntervalMs(options)), token_limit_per_minute(TokenLimitPerMinute(options)),
+	      request_tokens(TokenReservation(estimated_tokens, token_limit_per_minute)) {
+		if (max_concurrent_requests <= 0 && min_request_interval_ms <= 0 && token_limit_per_minute <= 0) {
 			return;
 		}
 
 		std::unique_lock<std::mutex> lock(provider_control_mutex);
 		while (true) {
-			auto concurrency_ready = max_concurrent_requests <= 0 || active_provider_requests < max_concurrent_requests;
 			auto now = std::chrono::steady_clock::now();
+			PruneProviderTokenWindow(now);
+			auto concurrency_ready = max_concurrent_requests <= 0 || active_provider_requests < max_concurrent_requests;
 			auto rate_ready = min_request_interval_ms <= 0 || !has_last_provider_request_start ||
 			                  now >= last_provider_request_start + std::chrono::milliseconds(min_request_interval_ms);
-			if (concurrency_ready && rate_ready) {
+			auto token_ready =
+			    token_limit_per_minute <= 0 || provider_token_window_tokens + request_tokens <= token_limit_per_minute;
+			if (concurrency_ready && rate_ready && token_ready) {
 				break;
 			}
 			if (!concurrency_ready) {
 				provider_control_cv.wait(lock);
 			} else {
-				provider_control_cv.wait_until(lock, last_provider_request_start +
-				                                         std::chrono::milliseconds(min_request_interval_ms));
+				std::chrono::steady_clock::time_point wake_at;
+				bool has_wake_at = false;
+				auto set_wake_at = [&](std::chrono::steady_clock::time_point candidate) {
+					if (!has_wake_at || candidate < wake_at) {
+						wake_at = candidate;
+						has_wake_at = true;
+					}
+				};
+				if (!rate_ready) {
+					set_wake_at(last_provider_request_start + std::chrono::milliseconds(min_request_interval_ms));
+				}
+				if (!token_ready && !provider_token_window.empty()) {
+					set_wake_at(provider_token_window.front().first + std::chrono::minutes(1));
+				}
+				if (has_wake_at) {
+					provider_control_cv.wait_until(lock, wake_at);
+				} else {
+					provider_control_cv.wait(lock);
+				}
 			}
 		}
 		active_provider_requests++;
+		auto request_start = std::chrono::steady_clock::now();
 		if (min_request_interval_ms > 0) {
-			last_provider_request_start = std::chrono::steady_clock::now();
+			last_provider_request_start = request_start;
 			has_last_provider_request_start = true;
+		}
+		if (token_limit_per_minute > 0 && request_tokens > 0) {
+			provider_token_window.emplace_back(request_start, request_tokens);
+			provider_token_window_tokens += request_tokens;
 		}
 		acquired = true;
 	}
@@ -1584,6 +1661,8 @@ public:
 private:
 	int64_t max_concurrent_requests;
 	int64_t min_request_interval_ms;
+	int64_t token_limit_per_minute;
+	int64_t request_tokens;
 	bool acquired = false;
 };
 
@@ -2706,6 +2785,13 @@ std::string ProviderProtocol(const std::string &provider) {
 	return ProviderDefaults(provider).protocol;
 }
 
+int64_t EstimateTokenCount(const std::string &input) {
+	if (input.empty()) {
+		return 0;
+	}
+	return static_cast<int64_t>((input.size() + 3) / 4);
+}
+
 std::string BuildRequestJson(const std::string &prompt, const std::string &model, const std::string &provider) {
 	CompletionOptions options;
 	options.model = model;
@@ -2731,7 +2817,7 @@ CompletionResult Complete(const std::string &prompt, const CompletionOptions &op
 	}
 	auto config = ResolveProvider(options);
 	auto response = [&]() {
-		ProviderRequestGuard request_guard(options);
+		ProviderRequestGuard request_guard(options, EstimatedCompletionTokens(prompt, options));
 		return HttpPost(RequestEndpoint(config), RequestPayload(config, prompt, options), RequestHeaders(config),
 		                TimeoutSeconds(options), false, RetryCount(options), RetryBackoffMs(options));
 	}();
@@ -2752,7 +2838,7 @@ CompletionResult Redact(const std::string &text, const CompletionOptions &option
 		                            config.provider);
 	}
 	auto response = [&]() {
-		ProviderRequestGuard request_guard(options);
+		ProviderRequestGuard request_guard(options, EstimateTokenCount(text));
 		return HttpPost(RequestEndpoint(config), RequestPayload(config, text, options), RequestHeaders(config),
 		                TimeoutSeconds(options), false, RetryCount(options), RetryBackoffMs(options));
 	}();
@@ -2788,7 +2874,7 @@ EmbeddingResult Embed(const std::string &input, const CompletionOptions &options
 	}
 	auto config = ResolveEmbeddingProviderConfig(options, true);
 	auto response = [&]() {
-		ProviderRequestGuard request_guard(options);
+		ProviderRequestGuard request_guard(options, EstimateTokenCount(input));
 		return HttpPost(EmbeddingEndpoint(config), EmbeddingPayload(config, input), RequestHeaders(config),
 		                TimeoutSeconds(options), false, RetryCount(options), RetryBackoffMs(options));
 	}();

--- a/src/include/duckdb_ai_provider.hpp
+++ b/src/include/duckdb_ai_provider.hpp
@@ -41,6 +41,8 @@ struct CompletionOptions {
 	int64_t max_concurrent_requests = 0;
 	bool has_min_request_interval_ms = false;
 	int64_t min_request_interval_ms = 0;
+	bool has_token_limit_per_minute = false;
+	int64_t token_limit_per_minute = 0;
 	bool has_input_token_price_per_million = false;
 	double input_token_price_per_million = 0;
 	bool has_output_token_price_per_million = false;
@@ -150,6 +152,8 @@ std::string NormalizeProviderName(const std::string &provider);
 std::string ProviderBaseUrl(const std::string &provider);
 //! Return the provider protocol used for request/response shaping.
 std::string ProviderProtocol(const std::string &provider);
+//! Return a local approximate token count used by ai_count_tokens() and token-aware pacing.
+int64_t EstimateTokenCount(const std::string &input);
 //! Build a completion request payload without making a network call.
 std::string BuildRequestJson(const std::string &prompt, const std::string &model, const std::string &provider);
 //! Build a completion request payload from a full option set.

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -325,6 +325,8 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             provider := 'snowflake',
             model := 'snowflake-llama-3.3-70b'
         ) AS snowflake_completion;
+        SELECT result.response, result.error IS NULL
+        FROM (SELECT ai_try_complete('try complete smoke', max_tokens := 5) AS result);
         SELECT ai_redact(
             'email alice@example.com token fake-token',
             secret := 'smoke_privacy_filter_ai',
@@ -451,10 +453,10 @@ def assert_smoke_result(output: str):
     if missing:
         raise AssertionError(f"duckdb output missing {missing}\n{output}")
 
-    if len(MockProviderHandler.completion_requests) != 30:
-        raise AssertionError(f"expected 30 completion requests, got {len(MockProviderHandler.completion_requests)}")
-    if len(MockProviderHandler.authorization_headers) != 34:
-        raise AssertionError(f"expected 34 auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if len(MockProviderHandler.completion_requests) != 31:
+        raise AssertionError(f"expected 31 completion requests, got {len(MockProviderHandler.completion_requests)}")
+    if len(MockProviderHandler.authorization_headers) != 35:
+        raise AssertionError(f"expected 35 auth headers, got {len(MockProviderHandler.authorization_headers)}")
     for header in MockProviderHandler.authorization_headers:
         if header != "Bearer test-key":
             raise AssertionError(f"unexpected authorization header: {header}")
@@ -591,6 +593,11 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"unexpected Snowflake model: {snowflake_request}")
     if snowflake_request["messages"][-1]["content"] != "hello snowflake":
         raise AssertionError(f"unexpected Snowflake prompt: {snowflake_request}")
+    try_complete_request = MockProviderHandler.completion_requests[30]
+    if try_complete_request["messages"][-1]["content"] != "try complete smoke":
+        raise AssertionError(f"unexpected try completion prompt: {try_complete_request}")
+    if try_complete_request.get("max_tokens") != 5:
+        raise AssertionError(f"unexpected try completion max tokens: {try_complete_request}")
     if len(MockProviderHandler.privacy_filter_requests) != 1:
         raise AssertionError(
             f"expected 1 Privacy Filter request, got {len(MockProviderHandler.privacy_filter_requests)}"
@@ -646,14 +653,14 @@ def assert_smoke_result(output: str):
     if similarity_models != ["mock-embedding-default", "mock-embedding-default"]:
         raise AssertionError(f"unexpected similarity embedding models: {similarity_models}")
 
-    if len(MockProviderHandler.log_requests) != 34:
-        raise AssertionError(f"expected 34 log requests, got {len(MockProviderHandler.log_requests)}")
+    if len(MockProviderHandler.log_requests) != 35:
+        raise AssertionError(f"expected 35 log requests, got {len(MockProviderHandler.log_requests)}")
     completion_logs = [
         request for request in MockProviderHandler.log_requests if request.get("event") == "ai_completion"
     ]
     embedding_logs = [request for request in MockProviderHandler.log_requests if request.get("event") == "ai_embedding"]
     otlp_logs = [request for request in MockProviderHandler.log_requests if "resourceLogs" in request]
-    if len(completion_logs) != 30 or len(embedding_logs) != 3:
+    if len(completion_logs) != 31 or len(embedding_logs) != 3:
         raise AssertionError(f"unexpected log events: {MockProviderHandler.log_requests}")
     if len(otlp_logs) != 1:
         raise AssertionError(f"expected 1 OTLP log request, got {otlp_logs}")

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -57,6 +57,26 @@ SELECT ai_provider_protocol('openai_privacy_filter');
 ----
 privacy_filter
 
+query I
+SELECT ai_recommended_batch_size(100, 50, 6000);
+----
+32
+
+query I
+SELECT ai_recommended_batch_size(100, 50, 6000, 20);
+----
+16
+
+query I
+SELECT ai_recommended_batch_size(100, 50, 6000, 20, 0.5);
+----
+10
+
+query I
+SELECT ai_recommended_batch_size(NULL, 50, 6000) IS NULL;
+----
+true
+
 query II
 SELECT ai_provider_protocol('databricks'), ai_provider_protocol('snowflake');
 ----
@@ -326,6 +346,11 @@ SELECT ai_complete('hello', provider := 'not-a-provider', fail_on_error := false
 ----
 true
 
+query II
+SELECT result.response IS NULL, contains(result.error, 'Unsupported AI provider') FROM (SELECT ai_try_complete('hello', provider := 'not-a-provider') AS result);
+----
+true	true
+
 query I
 SELECT ai_complete_json('hello', provider := 'not-a-provider', fail_on_error := false) IS NULL;
 ----
@@ -457,6 +482,16 @@ SELECT ai_request_json('hello', provider := 'openai', min_request_interval_ms :=
 Binder Error: AI option "min_request_interval_ms" must be between 0 and 60000
 
 statement error
+SELECT ai_request_json('hello', provider := 'openai', token_limit_per_minute := -1);
+----
+Binder Error: AI option "token_limit_per_minute" must be between 0 and 10000000000
+
+statement error
+SELECT ai_request_json('hello', provider := 'openai', token_limit_per_minute := 10000000001);
+----
+Binder Error: AI option "token_limit_per_minute" must be between 0 and 10000000000
+
+statement error
 SELECT ai_request_json('hello', provider := 'openai', input_token_price_per_million := -0.1);
 ----
 Binder Error: AI option "input_token_price_per_million" must be greater than or equal to 0
@@ -520,6 +555,17 @@ Binder Error: Setting duckdb_ai_min_request_interval_ms must be between 0 and 60
 
 statement ok
 RESET duckdb_ai_min_request_interval_ms;
+
+statement ok
+SET duckdb_ai_token_limit_per_minute = 10000000001;
+
+statement error
+SELECT ai_request_json('hello', provider := 'openai');
+----
+Binder Error: Setting duckdb_ai_token_limit_per_minute must be between 0 and 10000000000, or -1 to disable
+
+statement ok
+RESET duckdb_ai_token_limit_per_minute;
 
 statement ok
 SET duckdb_ai_input_token_price_per_million = -2.0;


### PR DESCRIPTION
Adds row-level completion error capture and token-aware batch controls so production enrichment jobs can pace provider calls and preserve failed rows instead of aborting a full query.

### Codex description

- adds ai_try_complete with STRUCT(response, error) results for row-level completion failure capture
- adds token_limit_per_minute pacing and ai_recommended_batch_size for batch planning
- updates docs, SQLLogic coverage, mock-provider smoke coverage, and public Pages deployment setup