### PR TITLE
ci: enable pages workflow setup

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !github.event.repository.private
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Allows the main-branch docs deploy workflow to enable and configure GitHub Pages now that the repository is public.

### Codex description

- sets configure-pages enablement to true for public main-branch deploys
- preserves the existing pull request docs build behavior