### PR TITLE
docs: update readme branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="docs/assets/duckdb-ai-logo.svg" alt="duckdb_ai logo proposal" width="520">
+  <img src="docs/assets/duckdb-ai-logo.svg" alt="duckdb-ai logo" width="520">
 </p>
 
-# duckdb_ai
+# duckdb-ai
 
-`duckdb_ai` is a DuckDB extension for model-backed analytical workflows inside
+duckdb-ai is a DuckDB extension for model-backed analytical workflows inside
 SQL. It adds functions for completions, structured JSON extraction, embeddings,
 natural-language filters, read-only SQL generation, and usage tracking.
 

--- a/docs/assets/duckdb-ai-logo.svg
+++ b/docs/assets/duckdb-ai-logo.svg
@@ -1,10 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 140" role="img" aria-labelledby="title desc">
-  <title id="title">duckdb_ai logo proposal</title>
-  <desc id="desc">The duckdb_ai wordmark with a small black sparkle above the i.</desc>
+  <title id="title">duckdb-ai logo</title>
+  <desc id="desc">The duckdb-ai wordmark.</desc>
   <rect width="720" height="140" fill="#ffffff"/>
-  <g transform="translate(488 16) scale(0.18)">
-    <path d="M67 22C78 51 89 62 118 73C89 84 78 95 67 124C56 95 45 84 16 73C45 62 56 51 67 22Z" fill="#0d0d0d"/>
-    <path d="M108 18C113 33 119 39 134 44C119 49 113 55 108 70C103 55 97 49 82 44C97 39 103 33 108 18Z" fill="#0d0d0d"/>
-  </g>
-  <text x="360" y="94" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="64" font-weight="760" letter-spacing="0" fill="#0d0d0d">duckdb_ai</text>
+  <text x="360" y="94" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="64" font-weight="760" letter-spacing="0" fill="#0d0d0d">duckdb-ai</text>
 </svg>


### PR DESCRIPTION
Updates the README-facing project name and logo asset now that the public repository uses duckdb-ai branding, while preserving the SQL extension identifier.

### Codex description

- changes the README heading, image alt text, and opening sentence to duckdb-ai
- removes the sparkle mark from the SVG logo and changes the wordmark to duckdb-ai