### PR TITLE
docs: update pages branding

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Best practices
 
-Use this page as the operating guide for running `duckdb_ai` in notebooks,
+Use this page as the operating guide for running duckdb-ai in notebooks,
 batch jobs, local workflows, and managed environments.
 
 ## Choose the right provider path

--- a/docs/cookbooks/index.md
+++ b/docs/cookbooks/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Cookbooks
 
-These cookbooks show practical `duckdb_ai` workflows over local DuckDB tables.
+These cookbooks show practical duckdb-ai workflows over local DuckDB tables.
 They use the same `support_tickets` sample data so you can move from one example
 to the next without changing context.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ sidebar_position: 1
 slug: /
 ---
 
-# duckdb_ai documentation
+# duckdb-ai documentation
 
-`duckdb_ai` is a DuckDB extension that lets SQL call AI model providers. It
+duckdb-ai is a DuckDB extension that lets SQL call AI model providers. It
 currently focuses on deterministic request shaping, provider metadata,
 completion and embedding calls, structured JSON validation, generated read-only
 SQL, usage logging, and local validation evidence.

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# duckdb_ai docs site
+# duckdb-ai docs site
 
-This directory contains the Docusaurus site shell for the `duckdb_ai`
+This directory contains the Docusaurus site shell for the duckdb-ai
 documentation. The published docs content is sourced from the repository-level
 `docs/` directory.
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
-  title: 'duckdb_ai',
+  title: 'duckdb-ai',
   tagline: 'AI provider functions for DuckDB SQL',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -64,7 +64,7 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: 'duckdb_ai',
+      title: 'duckdb-ai',
       items: [
         {
           type: 'docSidebar',
@@ -122,7 +122,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} duckdb_ai contributors. Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} duckdb-ai contributors. Built with Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -52,9 +52,9 @@ function DocsSummary(): ReactNode {
           <article>
             <Heading as="h2">What it covers</Heading>
             <p>
-              <code>duckdb_ai</code> adds SQL functions for completion models,
-              structured JSON output, embeddings, generated read-only SQL,
-              usage logging, and provider metadata.
+              duckdb-ai adds SQL functions for completion models, structured
+              JSON output, embeddings, generated read-only SQL, usage logging,
+              and provider metadata.
             </p>
             <div className={styles.chips}>
               {functionGroups.map((name) => (
@@ -96,7 +96,7 @@ export default function Home(): ReactNode {
   return (
     <Layout
       title={siteConfig.title}
-      description="Documentation for the duckdb_ai DuckDB extension">
+      description="Documentation for the duckdb-ai DuckDB extension">
       <HomepageHeader />
       <main>
         <DocsSummary />


### PR DESCRIPTION
Updates the public Docusaurus site branding to duckdb-ai so GitHub Pages matches the public repository name, while leaving SQL extension identifiers unchanged.

### Codex description

- changes Docusaurus title, navbar title, homepage metadata, hero, and footer to duckdb-ai
- updates public docs overview and cookbook/best-practices prose to use duckdb-ai display branding