### PR TITLE
docs: remove readme status note

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ DuckDB `SELECT` before returning or executing it.
 - Inspect local usage events and optionally send privacy-minimized usage logs to
   your own collector.
 
-## Status
-
-This is a preview extension available through the DuckDB community extension
-repository. The SQL surface is still expected to evolve while the extension
-settles.
-
 ## Quick Start
 
 Install and load the extension from DuckDB:


### PR DESCRIPTION
## Summary\n\nRemoves the README status section that described duckdb-ai as a preview community extension.\n\n## Verification\n\n- Searched for the removed wording with rg\n- Ran git diff --check