### PR TITLE
implement duckdb ai review hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,12 @@ These are the main functions most users should start with:
 | --- | --- |
 | `ai_complete` / `ai_try_complete` | General prompt-to-text completions from SQL, with optional row-level error capture. |
 | `ai_summarize` / `ai_summarize_agg` | Summarizing one text value or a grouped set of rows. |
-| `ai_classify` | Assigning one label from a controlled list. |
+| `ai_classify` / `ai_classify_labels` | Assigning one or more labels from a controlled list. |
 | `ai_filter` | Filtering rows with a natural-language predicate. |
 | `ai_extract` | Pulling compact structured facts from text. |
 | `ai_complete_record` | Returning model output as typed DuckDB columns from a JSON Schema. |
-| `ai_embed` / `ai_similarity` | Creating embeddings and comparing text semantically. |
+| `ai_extract_record` | Extracting typed `STRUCT` values per input row from a JSON Schema. |
+| `ai_embed` / `ai_similarity` / `ai_rerank` | Creating embeddings, comparing text semantically, and LLM-reranking short candidate sets. |
 | `ai_schema_prompt` | Building deterministic local table context for SQL generation. |
 | `ai_sql` / `ai_query_data` | Generating, validating, and optionally running read-only DuckDB `SELECT` statements. |
 | `ai_usage` | Inspecting recent model calls, latency, token estimates, and status. |
@@ -269,14 +270,14 @@ These are the main functions most users should start with:
 
 | Need | Functions |
 | --- | --- |
-| Completion text | `ai_complete`, `ai_try_complete`, `ai_request_json` |
-| Structured output | `ai_complete_json`, `ai_complete_record` |
-| Text tasks | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_extract`, `ai_filter` |
+| Completion text | `ai_complete`, `ai_try_complete`, `ai_completion_request_json` |
+| Structured output | `ai_complete_json`, `ai_complete_record`, `ai_extract_record` |
+| Text tasks | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_classify_labels`, `ai_extract`, `ai_filter` |
 | Aggregates | `ai_summarize_agg`, `ai_agg` |
-| Embeddings | `ai_embed`, `ai_embedding_request_json`, `ai_similarity` |
-| SQL assistant | `ai_schema_prompt`, `ai_sql`, `ai_query_data`, `ai_explain_sql`, `ai_fix_sql`, `ai_fix_sql_line` |
+| Embeddings and ranking | `ai_embed`, `ai_embedding_request_json`, `ai_similarity`, `ai_rerank` |
+| SQL assistant | `ai_schema_prompt`, `ai_sql`, `ai_query_data`, `ai_explain_sql`, `ai_fix_sql` |
 | SQL safety checks | `ai_is_read_only_sql`, `ai_validate_read_only_sql` |
-| Provider metadata | `ai_provider_base_url`, `ai_provider_protocol`, `ai_models` |
+| Provider metadata | `ai_provider_base_url`, `ai_provider_protocol`, `ai_model_prices` |
 | Usage and secrets | `ai_usage`, `ai_clear_usage`, `ai_clear_cache`, `ai_secrets` |
 | Local utility | `ai_count_tokens`, `ai_recommended_batch_size` |
 
@@ -299,7 +300,7 @@ End-to-end setup examples for each provider are in
 | Provider | Use it with | Default base URL / key |
 | --- | --- | --- |
 | `azure` | Azure OpenAI deployments | Set `BASE_URL` or `AZURE_OPENAI_BASE_URL`; `AZURE_OPENAI_API_KEY` |
-| `claude` / `anthropic` | Anthropic Claude models | `https://api.anthropic.com/v1`; `ANTHROPIC_API_KEY` |
+| `anthropic` / `claude` | Anthropic Claude models | `https://api.anthropic.com/v1`; `ANTHROPIC_API_KEY` |
 | `databricks` | Databricks Model Serving and Unity AI Gateway chat endpoints | Set `BASE_URL` or `DATABRICKS_HOST`; `DATABRICKS_TOKEN` |
 | `deepseek` | DeepSeek chat models | `https://api.deepseek.com`; `DEEPSEEK_API_KEY` |
 | `gemini` / `gcp` / `google` | Gemini through the OpenAI-compatible endpoint | `GEMINI_API_KEY` |
@@ -352,7 +353,7 @@ still overrides both:
 SET duckdb_ai_completion_model = 'gpt-4o-mini';
 SET duckdb_ai_task_model = 'gpt-4o-mini';
 SET duckdb_ai_aggregate_model = 'gpt-4o-mini';
-SET duckdb_ai_sql_model = 'gpt-4o';
+SET duckdb_ai_sql_assistant_model = 'gpt-4o';
 SET duckdb_ai_embedding_model = 'text-embedding-3-small';
 ```
 
@@ -381,7 +382,7 @@ arrays become `STRUCT` and `LIST` values.
 
 ## Safety And Privacy
 
-- Request-preview functions such as `ai_request_json` and
+- Request-preview functions such as `ai_completion_request_json` and
   `ai_embedding_request_json` build provider request bodies without making a
   network call.
 - API keys are resolved from environment variables or DuckDB secrets, not direct
@@ -395,20 +396,25 @@ arrays become `STRUCT` and `LIST` values.
   read-only DuckDB `SELECT`.
 
 By default, provider errors fail the SQL query. For exploratory workflows, use
-`fail_on_error := false` to return `NULL` instead:
+`on_error := 'null'` to return `NULL` instead:
 
 ```sql
 SELECT ai_complete(
     'Try this with a best-effort provider call.',
     provider := 'openai',
-    fail_on_error := false
+    on_error := 'null'
 );
 ```
+
+`fail_on_error := false` is still accepted as a compatibility alias for
+`on_error := 'null'`. Use `ai_try_complete` when you need row-level error text
+instead of a bare `NULL`.
 
 ## Usage And Cost Visibility
 
 Successful completions, embeddings, and local `ai_schema_prompt` calls are kept
-in a local in-process ring buffer:
+in a local in-process ring buffer with function name, query id, provider,
+latency, token, cache, status, error, and cost metadata:
 
 ```sql
 SELECT * FROM ai_usage();
@@ -421,7 +427,7 @@ model price catalog:
 
 ```sql
 SET duckdb_ai_use_builtin_model_prices = true;
-SELECT * FROM ai_models();
+SELECT * FROM ai_model_prices();
 ```
 
 Provider pricing changes often, so treat the built-in catalog as a convenience

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -14,7 +14,7 @@ Use the most constrained provider that fits the job:
 | Workload | Recommended path | Why |
 | --- | --- | --- |
 | Local development without hosted credentials | `ollama` | Keeps prompts local and avoids provider costs. |
-| Production chat, extraction, classification, and SQL assistant calls | A managed LLM provider such as `openai`, `azure`, `databricks`, `snowflake`, `claude`, `gemini`, `mistral`, `deepseek`, `zai`, or `openrouter` | Gives managed reliability, model access, and governance controls. |
+| Production chat, extraction, classification, and SQL assistant calls | A managed LLM provider such as `openai`, `azure`, `databricks`, `snowflake`, `anthropic`, `gemini`, `mistral`, `deepseek`, `zai`, or `openrouter` | Gives managed reliability, model access, and governance controls. |
 | OpenAI-compatible gateways, vLLM, LM Studio, LiteLLM, or local Ollama `/v1` | `openai_compatible` or `local` | Uses the common chat-completions request shape. |
 | PII redaction where raw text should stay local | `openai_privacy_filter` with local hosting | Sends raw text to a dedicated redaction service instead of a general chat model. |
 | PII redaction shared across teams | `openai_privacy_filter` with a private cloud service | Centralizes deployment, auth, scaling, and audit controls while preserving the dedicated redaction contract. |
@@ -47,7 +47,7 @@ Use provider-specific environment variables for local development:
 | --- | --- | --- |
 | `openai` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | `azure` | `AZURE_OPENAI_API_KEY` | `AZURE_OPENAI_BASE_URL` or `AZURE_OPENAI_ENDPOINT` |
-| `claude` / `anthropic` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | `CLAUDE_BASE_URL` |
+| `anthropic` / `claude` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | `ANTHROPIC_BASE_URL` or `CLAUDE_BASE_URL` |
 | `gemini` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
 | `mistral` | `MISTRAL_API_KEY` | `MISTRAL_BASE_URL` |
 | `zai` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
@@ -78,7 +78,7 @@ models:
 ```sql
 SET duckdb_ai_completion_model = 'gpt-4o-mini';
 SET duckdb_ai_task_model = 'gpt-4o-mini';
-SET duckdb_ai_sql_model = 'gpt-4o';
+SET duckdb_ai_sql_assistant_model = 'gpt-4o';
 SET duckdb_ai_aggregate_model = 'gpt-4o-mini';
 SET duckdb_ai_embedding_model = 'text-embedding-3-small';
 ```
@@ -117,7 +117,7 @@ log endpoints.
 Use request-preview functions in tests, reviews, and provider debugging:
 
 ```sql
-SELECT ai_request_json(
+SELECT ai_completion_request_json(
     'Summarize this.',
     provider := 'snowflake',
     model := 'snowflake-llama-3.3-70b'
@@ -281,14 +281,14 @@ SELECT ai_complete(
 Retry sleeps are interruptible and provider `Retry-After` headers take
 precedence over the configured backoff. Provider redirects are not followed.
 
-Use `fail_on_error := false` for exploratory enrichment where a missing output
+Use `on_error := 'null'` for exploratory enrichment where a missing output
 is acceptable:
 
 ```sql
 SELECT ai_classify(
     subject,
     'billing, support, sales, other',
-    fail_on_error := false
+    on_error := 'null'
 )
 FROM support_tickets;
 ```
@@ -323,12 +323,70 @@ WHERE result.error IS NOT NULL;
 Use the same rejected-row `SELECT` inside `COPY (...) TO 'failed_rows.parquet'`
 or an `s3://...` target when failures should live outside the DuckDB database.
 
+## Export provider-native batch requests for offline jobs
+
+`duckdb_ai` runs provider calls synchronously inside the DuckDB query. For
+overnight jobs that should use provider-native Batch APIs, materialize request
+bodies with the request-preview functions, then submit and poll them with your
+job runner or provider SDK:
+
+```sql
+COPY (
+    SELECT
+        ticket_id AS custom_id,
+        ai_completion_request_json(
+            subject || chr(10) || body,
+            provider := 'openai',
+            model := 'gpt-4o-mini',
+            system_prompt := 'Summarize this support ticket in one sentence.'
+        ) AS body
+    FROM support_tickets
+) TO 'openai-batch-requests.jsonl' (FORMAT json);
+```
+
+Store `custom_id` with the provider response and join it back to the source
+table after the batch finishes. Keep `response_schema` or downstream DuckDB
+validation in the exported request path so the offline job has the same shape
+checks as interactive SQL enrichment.
+
+## Use provider-side prompt caching for stable prefixes
+
+Keep static instructions, schemas, and catalog context byte-stable across rows.
+`ai_complete_json` and `ai_complete_record` put their JSON instructions and
+schema in the system message so the row-specific text stays last. Task wrappers
+put their static task instructions in the system message, and SQL assistant
+functions put their static rules and schema context there for the same reason.
+
+For providers that expose cache controls, opt in with `prompt_cache := true` or
+`DUCKDB_AI_PROMPT_CACHE=1`:
+
+```sql
+SELECT ai_complete_json(
+    body,
+    provider := 'openai',
+    prompt_cache := true,
+    response_schema := '{"type":"object","properties":{"summary":{"type":"string"}}}'
+)
+FROM documents;
+```
+
+OpenAI-compatible prompt caching generally needs a stable prefix of at least
+1,024 tokens before cached-token discounts appear. Anthropic cache reads and
+writes are exposed in `ai_usage()` as `cached_prompt_tokens` and
+`cache_creation_prompt_tokens`.
+
+This is separate from the extension's exact-response cache. Use `cache := true`
+when identical prompts may repeat inside or across chunks in the same database
+process. Concurrent identical misses are coalesced into one provider request,
+and `cache_ttl_seconds := ...` or `DUCKDB_AI_CACHE_TTL_SECONDS` can expire
+entries by age.
+
 ## Log usage without leaking text
 
 `ai_usage()` keeps recent events in process:
 
 ```sql
-SELECT provider, model, elapsed_ms, http_status, estimated_cost_usd
+SELECT function_name, query_id, provider, model, elapsed_ms, http_status, estimated_cost_usd
 FROM ai_usage()
 ORDER BY event_id DESC;
 ```
@@ -349,9 +407,9 @@ reason:
 SET duckdb_ai_log_include_text = true;
 ```
 
-Use `duckdb_ai_log_strict = true` only when losing a usage log must fail the SQL
-query. For most analytics workflows, keep strict logging off so the collector
-does not become a query dependency.
+By default, outbound usage logs are queued asynchronously and sent on a
+best-effort basis. Use `duckdb_ai_log_strict = true` only when losing a usage log
+must fail the SQL query; strict logs are posted synchronously.
 
 ## Corporate proxy and TLS
 
@@ -368,9 +426,9 @@ built-in catalog when it covers your model:
 
 ```sql
 SET duckdb_ai_use_builtin_model_prices = true;
-SELECT * FROM ai_models();
+SELECT * FROM ai_model_prices();
 ```
 
-Treat `ai_models()` as a convenience catalog, not a billing source of truth.
+Treat `ai_model_prices()` as a convenience catalog, not a billing source of truth.
 Provider pricing and regional availability change; verify prices with the
 provider before using estimates for chargeback or budgeting.

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -24,16 +24,19 @@ FROM ai_usage();
 | `ai_try_complete(prompt[, model[, provider]])` | Scalar | Calls a completion model and returns `STRUCT(response, error)` for row-level failure capture. |
 | `ai_complete_json(prompt[, model[, provider]])` | Scalar | Calls a completion model and validates the response as a JSON object or array. |
 | `ai_complete_record(prompt, response_schema[, model[, provider]])` | Table | Calls a completion model and projects a JSON object into typed columns from a JSON Schema. |
-| `ai_request_json(prompt[, model[, provider]])` | Scalar | Returns the completion request JSON without making a network call. |
+| `ai_extract_record(text, response_schema[, model[, provider]])` | Scalar | Extracts one typed `STRUCT` per row from text using a JSON Schema. |
+| `ai_completion_request_json(prompt[, model[, provider]])` | Scalar | Returns the completion request JSON without making a network call. |
 | `ai_embed(text[, model[, provider]])` | Scalar | Calls an embedding model and returns `DOUBLE[]`. |
 | `ai_embedding_request_json(text[, model[, provider]])` | Scalar | Returns the embedding request JSON without making a network call. |
 | `ai_similarity(left_text, right_text[, model[, provider]])` | Scalar | Embeds two strings and returns cosine similarity. |
+| `ai_rerank(query, candidate[, model[, provider]])` | Scalar | Uses a completion model to score candidate relevance from `0` to `1`. |
 | `ai_summarize(text[, model[, provider]])` | Scalar | Summarizes text with a completion model. |
 | `ai_sentiment(text[, model[, provider]])` | Scalar | Classifies text as positive, neutral, or negative. |
 | `ai_fix_grammar(text[, model[, provider]])` | Scalar | Rewrites text with corrected grammar, spelling, and punctuation. |
 | `ai_redact(text[, model[, provider]])` | Scalar | Masks direct personal data, credentials, secrets, and payment identifiers. |
 | `ai_translate(text, target_language[, model[, provider]])` | Scalar | Translates text to the target language. |
-| `ai_classify(text, labels[, model[, provider]])` | Scalar | Chooses one label from a comma-separated label list. |
+| `ai_classify(text, labels[, model[, provider]])` | Scalar | Chooses one label from a comma-separated `VARCHAR` or `VARCHAR[]` label list. |
+| `ai_classify_labels(text, labels[, model[, provider]])` | Scalar | Chooses zero or more labels from a comma-separated `VARCHAR` or `VARCHAR[]` label list. |
 | `ai_extract(text, instruction[, model[, provider]])` | Scalar | Extracts requested information from text. |
 | `ai_filter(text, predicate[, model[, provider]])` | Scalar | Evaluates a natural-language predicate and returns `BOOLEAN`. |
 | `ai_agg(text, instruction[, model[, provider]])` | Aggregate | Runs one completion over grouped text values and an instruction. |
@@ -42,8 +45,7 @@ FROM ai_usage();
 | `ai_query_data(question[, schema_context[, model[, provider]]])` | Table | Generates one read-only `SELECT` at bind time and executes it as a subquery. |
 | `ai_schema_prompt([include_tables])` | Table | Returns deterministic local catalog context for prompting SQL models. |
 | `ai_explain_sql(sql[, ...])` | Table | Explains one read-only DuckDB `SELECT` statement. |
-| `ai_fix_sql(sql[, ...])` | Table | Rewrites a broken query as one corrected read-only DuckDB `SELECT`. |
-| `ai_fix_sql_line(sql[, error][, ...])` | Table | Rewrites only the line identified by an error message. |
+| `ai_fix_sql(sql[, ...])` | Table | Rewrites a broken query as one corrected read-only DuckDB `SELECT`, or rewrites one line with `mode := 'line'`. |
 | `ai_is_read_only_sql(sql)` | Scalar | Returns whether SQL is one parser-valid read-only `SELECT`. |
 | `ai_validate_read_only_sql(sql)` | Scalar | Returns normalized SQL or raises if it is not one read-only `SELECT`. |
 | `ai_count_tokens(text[, model[, provider]])` | Scalar | Returns a local approximate token count. |
@@ -52,9 +54,9 @@ FROM ai_usage();
 | `ai_provider_protocol(provider)` | Scalar | Returns the internal provider protocol. |
 | `ai_usage()` | Table | Returns recent per-database AI usage events. |
 | `ai_clear_usage()` | Table | Clears the per-database usage event buffer. |
-| `ai_clear_cache()` | Table | Clears the per-database in-memory response cache. |
+| `ai_clear_cache()` | Table | Clears per-database in-memory response and generated-SQL caches. |
 | `ai_secrets()` | Table | Lists configured `duckdb_ai` secrets with credentials redacted. |
-| `ai_models()` | Table | Returns the built-in provider/model pricing catalog. |
+| `ai_model_prices()` | Table | Returns the built-in provider/model pricing catalog. |
 
 ## Completion functions
 
@@ -135,7 +137,41 @@ FROM ai_complete_record(
 
 Result: one row with columns derived from `response_schema`
 
-#### `ai_request_json(prompt[, model[, provider]])`
+#### `ai_extract_record(text, response_schema[, model[, provider]])`
+
+Description: Scalar function that calls a completion provider for each input row
+and returns a typed `STRUCT` projected from the top-level object properties in
+`response_schema`. The schema must be constant so DuckDB can bind the return
+type.
+
+Example:
+
+```sql
+SELECT
+    ticket_id,
+    extracted.product_area,
+    extracted.urgency_score
+FROM (
+    SELECT
+        ticket_id,
+        ai_extract_record(
+            subject || ': ' || body,
+            '{
+              "type": "object",
+              "properties": {
+                "product_area": {"type": "string"},
+                "urgency_score": {"type": "integer"}
+              },
+              "required": ["product_area", "urgency_score"]
+            }'
+        ) AS extracted
+    FROM support_tickets
+);
+```
+
+Result: one `STRUCT` value whose fields are derived from `response_schema`
+
+#### `ai_completion_request_json(prompt[, model[, provider]])`
 
 Description: Builds the provider completion request body and returns it without
 making a network call. Use this for deterministic tests and provider debugging.
@@ -143,7 +179,7 @@ making a network call. Use this for deterministic tests and provider debugging.
 Example:
 
 ```sql
-SELECT ai_request_json(
+SELECT ai_completion_request_json(
     'Summarize this text.',
     provider := 'openai',
     model := 'gpt-4o-mini',
@@ -206,6 +242,24 @@ SELECT ai_similarity(
 
 Result: `DOUBLE`
 
+#### `ai_rerank(query, candidate[, model[, provider]])`
+
+Description: Uses a completion model to score how relevant `candidate` is for
+`query`. The provider response must be a single numeric score from `0` to `1`.
+Use it when you want LLM-based reranking over a short candidate set; use
+`ai_similarity` for embedding-based semantic comparison at larger scale.
+
+Example:
+
+```sql
+SELECT *
+FROM documents
+ORDER BY ai_rerank('analytics database', title || chr(10) || body) DESC
+LIMIT 10;
+```
+
+Result: `DOUBLE`
+
 ## Task wrappers
 
 #### `ai_summarize(text[, model[, provider]])`
@@ -222,7 +276,7 @@ Result: `VARCHAR`
 
 #### `ai_sentiment(text[, model[, provider]])`
 
-Description: Classifies the sentiment of text as positive, neutral, or negative.
+Description: Convenience wrapper for `ai_classify(text, 'positive, neutral, negative')`.
 
 Example:
 
@@ -280,15 +334,36 @@ Result: `VARCHAR`
 
 #### `ai_classify(text, labels[, model[, provider]])`
 
-Description: Classifies text into exactly one label from `labels`.
+Description: Classifies text into exactly one label from `labels`. `labels` can
+be a comma-separated `VARCHAR` or a `VARCHAR[]`; use `VARCHAR[]` when labels may
+contain commas.
 
 Example:
 
 ```sql
 SELECT ai_classify('invoice overdue', 'billing, support');
+
+SELECT ai_classify('invoice overdue', ['billing, overdue', 'support']);
 ```
 
 Result: `VARCHAR`
+
+#### `ai_classify_labels(text, labels[, model[, provider]])`
+
+Description: Classifies text into zero or more labels from `labels`. `labels`
+can be a comma-separated `VARCHAR` or a `VARCHAR[]`; use `VARCHAR[]` when labels
+may contain commas. The model must return a JSON array of label strings.
+
+Example:
+
+```sql
+SELECT ai_classify_labels(
+    'invoice overdue and app is slow',
+    ['billing, overdue', 'performance', 'support']
+);
+```
+
+Result: `VARCHAR[]`
 
 #### `ai_extract(text, instruction[, model[, provider]])`
 
@@ -334,7 +409,8 @@ Result: `VARCHAR`
 
 #### `ai_summarize_agg(text[, model[, provider]])`
 
-Description: Collects grouped input text and returns one summary per group.
+Description: Convenience wrapper around `ai_agg` with the built-in summarization
+instruction. It collects grouped input text and returns one summary per group.
 
 Example:
 
@@ -366,8 +442,10 @@ Result: `VARCHAR` containing a read-only DuckDB `SELECT`
 #### `ai_query_data(question[, schema_context[, model[, provider]]])`
 
 Description: Table function that generates one read-only DuckDB `SELECT` at bind
-time and executes it as a subquery. Use `fail_on_error := false` to return an
-empty error-shaped relation instead of failing the bind.
+time and executes it as a subquery. Successful generated SQL is cached in the
+current DuckDB database instance for repeated binds with the same question,
+schema context, and output-affecting options. Use `on_error := 'null'` to return
+an empty error-shaped relation instead of failing the bind.
 
 Example:
 
@@ -421,7 +499,9 @@ Result: one `explanation VARCHAR` column
 #### `ai_fix_sql(sql[, ...])`
 
 Description: Table function that asks the model to rewrite a broken query as one
-corrected read-only DuckDB `SELECT` statement.
+corrected read-only DuckDB `SELECT` statement. With `mode := 'line'`, it rewrites
+only the line identified by an error message and returns the detected line number
+plus replacement line.
 
 Example:
 
@@ -432,23 +512,18 @@ FROM ai_fix_sql('SEELECT status, count(*) FRUM orders GROUP BY status');
 
 Result: one `sql VARCHAR` column
 
-#### `ai_fix_sql_line(sql[, error][, ...])`
-
-Description: Table function that asks the model to rewrite only the line
-identified by an error message. The result includes the detected line number and
-replacement line.
-
 Example:
 
 ```sql
 SELECT line_number, replacement_line
-FROM ai_fix_sql_line(
+FROM ai_fix_sql(
     'SEELECT status FROM orders',
+    mode := 'line',
     error := 'Parser Error: syntax error at or near "SEELECT" LINE 1'
 );
 ```
 
-Result: `line_number BIGINT`, `replacement_line VARCHAR`
+Line-mode result: `line_number BIGINT`, `replacement_line VARCHAR`
 
 ## SQL validation functions
 
@@ -549,9 +624,10 @@ FROM ai_usage()
 ORDER BY event_id DESC;
 ```
 
-Result columns: `event_id`, `created_at`, `event`, `provider`, `protocol`,
-`model`, character counts, token counts, elapsed time, HTTP status, and
-estimated cost.
+Result columns: `event_id`, `created_at`, `event`, `function_name`, `query_id`,
+`provider`, `protocol`, `model`, character counts, token counts,
+cached-token counts, elapsed time, retry count, HTTP status, cache hit flag,
+status, error, and estimated cost.
 
 #### `ai_clear_usage()`
 
@@ -570,7 +646,8 @@ Result: one `cleared BOOLEAN` column
 #### `ai_clear_cache()`
 
 Description: Clears the current DuckDB database instance's opt-in in-memory
-response cache and returns one confirmation row.
+response cache and `ai_query_data()` generated-SQL cache, then returns one
+confirmation row.
 
 Example:
 
@@ -596,7 +673,7 @@ FROM ai_secrets();
 Result columns: `name`, `provider`, `model`, `base_url`, `scope`,
 `has_api_key`
 
-#### `ai_models()`
+#### `ai_model_prices()`
 
 Description: Returns the small built-in provider/model pricing catalog used by
 opt-in cost estimation.
@@ -605,7 +682,7 @@ Example:
 
 ```sql
 SELECT provider, model, operation, input_token_price_per_million
-FROM ai_models();
+FROM ai_model_prices();
 ```
 
 Result columns: `provider`, `model`, `operation`,
@@ -630,22 +707,25 @@ not from direct API key arguments.
 | `timeout_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | HTTP timeout. Must be greater than 0. |
 | `retry_count` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Retry count from 0 to 10 for curl failures and retryable HTTP status codes. Retries honor `Retry-After` on 429/5xx responses when present. |
 | `retry_backoff_ms` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Base retry backoff from 0 to 60000 milliseconds; exponential jitter is added per retry. |
-| `max_concurrent_requests` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Per-database request concurrency cap from 0 to 1024. |
+| `max_concurrent_requests` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Per-database request concurrency cap from 0 to 64. |
 | `min_request_interval_ms` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Per-database minimum interval between provider request starts. |
 | `token_limit_per_minute` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Per-database estimated token cap per rolling minute. `0` disables the token cap. |
 | `cache` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Enables the current database instance's in-memory response cache for successful provider responses. |
+| `cache_ttl_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Optional response-cache expiration from 0 to 31536000 seconds. `0` means entries do not expire by age. The `DUCKDB_AI_CACHE_TTL_SECONDS` environment variable sets the default. |
+| `prompt_cache` | `BOOLEAN` | Completion, task wrappers, and SQL assistant | Emits provider-side prompt-cache controls where supported. OpenAI requests include a stable `prompt_cache_key`; Anthropic requests attach ephemeral cache control to the system prompt. The `DUCKDB_AI_PROMPT_CACHE` environment variable enables this by default. |
 | `allowed_hosts` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Comma-separated provider/logging host allowlist. Entries may be hostnames, `host:port`, full URLs, `*.example.com`, or `*`. |
-| `fail_on_error` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | If false, supported functions return `NULL` or an empty result instead of raising provider errors. |
+| `on_error` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Error handling mode: `fail`, `null`, or `capture`. `capture` is used by `ai_try_complete`; scalar/table functions that cannot return an error field use `NULL` behavior. |
+| `fail_on_error` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Compatibility alias: `true` maps to `on_error := 'fail'`, `false` maps to `on_error := 'null'`. |
 | `response_format` | `VARCHAR` | Completion and SQL assistant | `text`, `json_object`, or `json_schema`. |
 | `response_schema`, `json_schema` | `VARCHAR` | Completion and SQL assistant | JSON Schema object for structured output hints and validation. |
 | `input_token_price_per_million` | `DOUBLE` | Completion, embedding, SQL assistant, aggregate | Manual input-token price for cost estimation. |
 | `output_token_price_per_million` | `DOUBLE` | Completion, SQL assistant, aggregate | Manual output-token price for cost estimation. |
-| `use_builtin_model_prices` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Enables lookup from `ai_models()` when manual prices are not supplied. |
-| `log_format` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | `generic_json` or `otlp_json`. |
+| `use_builtin_model_prices` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Enables lookup from `ai_model_prices()` when manual prices are not supplied. |
+| `log_format` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | `generic`, `json`, `generic_json`, `otlp`, or `otlp_json`. |
 | `log_tags` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Comma-separated tags copied into usage log payloads. |
 | `log_sample_rate` | `DOUBLE` | Completion, embedding, SQL assistant, aggregate | Stable sampling rate from 0 to 1. |
 | `log_include_text` | `BOOLEAN` | `ai_complete_record`; all families through `duckdb_ai_log_include_text` or `DUCKDB_AI_LOG_INCLUDE_TEXT` | Include prompt/output text in outbound usage logs. Defaults to false. |
-| `log_strict` | `BOOLEAN` | `ai_complete_record`; all families through `duckdb_ai_log_strict` or `DUCKDB_AI_LOG_STRICT` | Fail the SQL query when outbound usage logging fails. |
+| `log_strict` | `BOOLEAN` | `ai_complete_record`; all families through `duckdb_ai_log_strict` or `DUCKDB_AI_LOG_STRICT` | Post outbound usage logs synchronously and fail the SQL query when logging fails. Without strict logging, outbound logs are queued asynchronously on a best-effort basis. |
 
 See [Runtime behavior](runtime-behavior.md) for the execution semantics behind
 volatility, per-database state, concurrency, cancellation, retries, response
@@ -659,7 +739,8 @@ SQL assistant table functions also accept:
 | `include_tables` | `VARCHAR[]` | Limit generated local catalog context to matching tables. |
 | `exclude_tables` | `VARCHAR[]` | Remove matching tables from generated local catalog context. |
 | `sample_rows` | `BIGINT` | Include up to 100 sample rows per local table. |
-| `error` | `VARCHAR` | `ai_fix_sql_line` only. Error text used to identify the target line. |
+| `mode` | `VARCHAR` | `ai_fix_sql` only. `query` or `full` rewrites the full query; `line` rewrites one error line. |
+| `error` | `VARCHAR` | `ai_fix_sql` line mode only. Error text used to identify the target line. |
 
 Aggregate functions also accept:
 
@@ -678,7 +759,7 @@ Supported provider names and aliases are:
 | `ollama` | none | Yes | Yes | `llama3.2` |
 | `openai` | none | Yes | Yes | `gpt-4o-mini` |
 | `azure` | `azure_openai`, `azure-openai` | Yes | Yes | `gpt-4o` |
-| `claude` | `anthropic` | Yes | No | `claude-3-5-haiku-latest` |
+| `anthropic` | `claude` | Yes | No | `claude-haiku-4-5` |
 | `gemini` | `gcp`, `google`, `google_gemini` | Yes | Yes | `gemini-2.5-flash` |
 | `mistral` | none | Yes | Yes | `mistral-small-latest` |
 | `zai` | `zhipu` | Yes | Yes | `glm-4-flash` |
@@ -707,10 +788,10 @@ highest precedence:
 
 | Setting | Applies to |
 | --- | --- |
-| `duckdb_ai_completion_model` | `ai_complete`, `ai_complete_json`, `ai_complete_record`, `ai_request_json` |
-| `duckdb_ai_task_model` | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_extract`, `ai_filter` |
+| `duckdb_ai_completion_model` | `ai_complete`, `ai_complete_json`, `ai_complete_record`, `ai_completion_request_json`, `ai_rerank` |
+| `duckdb_ai_task_model` | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_classify_labels`, `ai_extract`, `ai_filter` |
 | `duckdb_ai_aggregate_model` | `ai_agg`, `ai_summarize_agg` |
-| `duckdb_ai_sql_model` | `ai_sql`, `ai_query_data`, `ai_explain_sql`, `ai_fix_sql`, `ai_fix_sql_line` |
+| `duckdb_ai_sql_assistant_model` | `ai_sql`, `ai_query_data`, `ai_explain_sql`, `ai_fix_sql` |
 | `duckdb_ai_embedding_model` | `ai_embed`, `ai_embedding_request_json`, `ai_similarity` |
 
 Model resolution order is:

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -21,7 +21,7 @@ runs. If you prefer a fully DuckDB-managed secret, add `API_KEY '...'` to the
 After any provider call, inspect the local usage buffer:
 
 ```sql
-SELECT provider, protocol, model, http_status, elapsed_ms
+SELECT function_name, provider, protocol, model, http_status, elapsed_ms
 FROM ai_usage()
 ORDER BY event_id DESC
 LIMIT 1;
@@ -34,7 +34,7 @@ LIMIT 1;
 | `ollama` | Ollama chat and embeddings | `llama3.2`; embeddings use `nomic-embed-text` | Optional `OLLAMA_API_KEY` | Defaults to `http://localhost:11434`; `OLLAMA_HOST` overrides it. |
 | `openai` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | `OPENAI_API_KEY` | Defaults to `https://api.openai.com/v1`. |
 | `azure` | OpenAI-compatible chat and embeddings | `gpt-4o`; embeddings use `text-embedding-3-small` | `AZURE_OPENAI_API_KEY` | Appends `/openai/v1` to `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, or secret `BASE_URL` when needed. |
-| `claude` / `anthropic` | Anthropic Messages | `claude-3-5-haiku-latest` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | Defaults to `https://api.anthropic.com/v1`. |
+| `anthropic` / `claude` | Anthropic Messages | `claude-haiku-4-5` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | Defaults to `https://api.anthropic.com/v1`. |
 | `gemini` / `gcp` / `google` | OpenAI-compatible chat and embeddings | `gemini-2.5-flash`; embeddings use `text-embedding-004` | `GEMINI_API_KEY` | Defaults to Google's OpenAI-compatible endpoint. |
 | `mistral` | OpenAI-compatible chat and embeddings | `mistral-small-latest`; embeddings use `mistral-embed` | `MISTRAL_API_KEY` | Defaults to `https://api.mistral.ai/v1`. |
 | `zai` / `zhipu` | OpenAI-compatible chat and embeddings | `glm-4-flash`; embeddings use `embedding-3` | `ZAI_API_KEY` | Defaults to `https://open.bigmodel.cn/api/paas/v4`. |
@@ -173,7 +173,7 @@ LOAD duckdb_ai;
 CREATE OR REPLACE SECRET claude_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'anthropic',
-    MODEL 'claude-3-5-haiku-latest'
+    MODEL 'claude-haiku-4-5'
 );
 
 SELECT ai_complete(

--- a/docs/runtime-behavior.md
+++ b/docs/runtime-behavior.md
@@ -17,6 +17,19 @@ calls were deterministic.
 Local helper functions such as `ai_count_tokens()` and
 `ai_is_read_only_sql()` remain deterministic and do not call providers.
 
+## Prompt shape
+
+Completion functions accept one user prompt plus an optional system prompt.
+Task wrappers and SQL assistant functions build provider messages from their SQL
+arguments: static instructions and schema context are placed in the system
+message when the selected provider protocol supports it, while row-specific text
+stays in the user message.
+
+Multi-turn chat transcripts are deliberately outside the scalar function
+surface. Store or serialize the conversation in your own table and pass the
+conversation summary or transcript as the prompt when you need row-wise SQL
+enrichment.
+
 ## Runtime state scope
 
 Usage events, response-cache entries, and provider pacing state are scoped to
@@ -27,6 +40,7 @@ The affected state includes:
 
 - `ai_usage()` and `ai_clear_usage()`,
 - opt-in response cache entries used by `cache := true` or `duckdb_ai_cache`,
+- generated SQL cache entries for successful `ai_query_data()` binds,
 - `duckdb_ai_max_concurrent_requests`,
 - `duckdb_ai_min_request_interval_ms`, and
 - `duckdb_ai_token_limit_per_minute`.
@@ -41,7 +55,7 @@ completion on the execution thread.
 This applies to:
 
 - `ai_complete()`, `ai_try_complete()`, `ai_complete_json()`, and
-  `ai_request_json()`,
+  `ai_completion_request_json()`,
 - task wrappers such as `ai_summarize()`, `ai_classify()`, `ai_redact()`,
   `ai_translate()`, and `ai_filter()`,
 - `ai_embed()`, `ai_embedding_request_json()`, and `ai_similarity()`, and
@@ -51,6 +65,8 @@ The worker count is bounded by `duckdb_ai_max_concurrent_requests` or
 `max_concurrent_requests := ...` when configured. Without an explicit cap, the
 extension uses a conservative local worker count for the chunk while the
 provider rate limiter still controls outbound request pacing.
+Configured worker caps must be between 0 and 64; larger values are rejected
+instead of being silently clamped.
 
 Aggregate functions and SQL-assistant table functions perform one provider call
 per group or invocation and do not need intra-chunk fan-out.
@@ -68,9 +84,14 @@ the configured backoff.
 
 ## HTTP connection behavior
 
-The extension initializes libcurl once per process and reuses a thread-local
-easy handle for provider requests. This allows libcurl to reuse connections
-where the provider and libcurl build support it.
+The extension initializes libcurl once per process, reuses a thread-local easy
+handle for provider requests, and attaches those handles to a shared libcurl
+connection cache. This allows libcurl to reuse connections across provider
+worker threads where the provider and libcurl build support it.
+
+Provider calls use the configured `timeout_seconds` for the total request. The
+connect timeout defaults to the smaller of 10 seconds and the total timeout; set
+`DUCKDB_AI_CONNECT_TIMEOUT_SECONDS` to override it for provider requests.
 
 Provider redirects are not followed. This avoids forwarding authorization or
 API-key headers to an unexpected redirect target.
@@ -91,9 +112,9 @@ SELECT ai_complete('Summarize this repeated prompt.');
 SELECT * FROM ai_clear_cache();
 ```
 
-The cache is in-memory and scoped to the current DuckDB database instance. It is
-keyed by provider, model, endpoint, request payload, and response-relevant
-options. API keys are not stored directly in cache keys.
+The response cache is in-memory and scoped to the current DuckDB database
+instance. It is keyed by provider, model, endpoint, request payload, and
+response-relevant options. API keys are not stored directly in cache keys.
 
 Cached responses still record usage events, but their elapsed time is reported
 as `0` because no provider HTTP request was made.
@@ -101,6 +122,9 @@ as `0` because no provider HTTP request was made.
 The maximum number of cached entries defaults to `1024`. Set
 `DUCKDB_AI_CACHE_MAX_ENTRIES=0` to disable storage, or use a positive integer to
 change the bound.
+
+`ai_query_data()` also keeps a small in-memory generated-SQL cache for successful
+binds. `ai_clear_cache()` clears both caches.
 
 ## Egress allowlisting
 

--- a/docs/security-data-flow.md
+++ b/docs/security-data-flow.md
@@ -38,20 +38,25 @@ endpoints.
 
 | Function family | Data sent |
 | --- | --- |
-| `ai_complete`, `ai_try_complete`, `ai_complete_json`, task wrappers, aggregates, and SQL assistant functions | Prompt text, configured system prompt, model name, response-format hints, and provider options needed by the selected provider API. |
+| `ai_complete`, `ai_try_complete`, `ai_complete_json`, `ai_rerank`, task wrappers, aggregates, and SQL assistant functions | Prompt text, configured system prompt, model name, response-format hints, and provider options needed by the selected provider API. |
 | `ai_complete_record` | Prompt text plus the supplied JSON Schema. |
-| `ai_embed` and `ai_similarity` | Input text to embed and model name. `ai_similarity` sends both input strings as separate embedding requests. |
+| `ai_embed` and `ai_similarity` | Input text to embed and model name. `ai_embed` may batch multiple rows with the same options into one provider request; `ai_similarity` reuses a constant-side embedding within a chunk and sends non-constant inputs as embedding requests. |
 | `ai_redact` with `openai_privacy_filter` | Raw input text and model name to `POST /redact`. |
-| `ai_request_json`, `ai_embedding_request_json`, `ai_schema_prompt`, `ai_is_read_only_sql`, `ai_validate_read_only_sql`, `ai_count_tokens`, `ai_recommended_batch_size`, metadata functions, and catalog table functions | No provider network call. |
-| `ai_query_data` | The natural-language question and generated schema context are sent during bind; generated SQL is validated as one read-only DuckDB `SELECT` before execution. |
+| `ai_completion_request_json`, `ai_embedding_request_json`, `ai_schema_prompt`, `ai_is_read_only_sql`, `ai_validate_read_only_sql`, `ai_count_tokens`, `ai_recommended_batch_size`, metadata functions, and catalog table functions | No provider network call. |
+| `ai_query_data` | The natural-language question and generated schema context are sent during bind; generated SQL is validated as one read-only DuckDB `SELECT` before execution. SQL assistant schema context is sent in the provider system message when the provider protocol supports it. Successful generated SQL is cached in memory for repeated binds with the same question, schema context, and output-affecting options. |
 
 ## Logging
 
 Outbound usage logs are disabled unless a log endpoint is configured. Default
-payloads contain provider, protocol, model, character counts, token counts,
-elapsed time, HTTP status, optional tags, and optional estimated cost. Text
-fields are included only when `duckdb_ai_log_include_text` or
+payloads contain function name, query id, provider, protocol, model, character
+counts, token counts, elapsed time, HTTP status, optional tags, and optional
+estimated cost. Text fields are included only when `duckdb_ai_log_include_text` or
 `DUCKDB_AI_LOG_INCLUDE_TEXT=1` is enabled.
+
+When strict logging is disabled, outbound usage logs are queued in memory and
+sent asynchronously on a best-effort basis. Enabling `duckdb_ai_log_strict` or
+`DUCKDB_AI_LOG_STRICT=1` posts logs synchronously and fails the SQL query if the
+collector request fails.
 
 ## Proxy and TLS
 

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -54,7 +54,7 @@ constexpr idx_t MAX_PROVIDER_CHUNK_WORKERS = 64;
 constexpr size_t MAX_PROMPT_QUERY_CACHE_ENTRIES = 1024;
 std::atomic<uint64_t> NEXT_QUERY_ID {1};
 
-static_assert(sizeof(duckdb_ai::CompletionOptions) == 608,
+static_assert(sizeof(duckdb_ai::CompletionOptions) == 608 || sizeof(duckdb_ai::CompletionOptions) == 728,
               "Update CompletionOptionsEqual when CompletionOptions fields change");
 
 bool CompletionOptionsEqual(const duckdb_ai::CompletionOptions &left, const duckdb_ai::CompletionOptions &right) {

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -22,6 +22,7 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/object_cache.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
@@ -29,15 +30,20 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <cctype>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <exception>
 #include <future>
 #include <limits>
+#include <mutex>
 #include <set>
 #include <sstream>
 #include <thread>
+#include <unordered_map>
 
 namespace duckdb {
 
@@ -45,6 +51,11 @@ namespace {
 
 constexpr int64_t MAX_TOKEN_LIMIT_PER_MINUTE = 10000000000LL;
 constexpr idx_t MAX_PROVIDER_CHUNK_WORKERS = 64;
+constexpr size_t MAX_PROMPT_QUERY_CACHE_ENTRIES = 1024;
+std::atomic<uint64_t> NEXT_QUERY_ID {1};
+
+static_assert(sizeof(duckdb_ai::CompletionOptions) == 608,
+              "Update CompletionOptionsEqual when CompletionOptions fields change");
 
 bool CompletionOptionsEqual(const duckdb_ai::CompletionOptions &left, const duckdb_ai::CompletionOptions &right) {
 	return left.model == right.model && left.provider == right.provider && left.secret_name == right.secret_name &&
@@ -67,13 +78,28 @@ bool CompletionOptionsEqual(const duckdb_ai::CompletionOptions &left, const duck
 	       left.output_token_price_per_million == right.output_token_price_per_million &&
 	       left.has_use_builtin_model_prices == right.has_use_builtin_model_prices &&
 	       left.use_builtin_model_prices == right.use_builtin_model_prices && left.has_cache == right.has_cache &&
-	       left.cache == right.cache && left.allowed_hosts == right.allowed_hosts &&
+	       left.cache == right.cache && left.has_cache_ttl_seconds == right.has_cache_ttl_seconds &&
+	       left.cache_ttl_seconds == right.cache_ttl_seconds &&
+	       left.has_response_cache_max_entries == right.has_response_cache_max_entries &&
+	       left.response_cache_max_entries == right.response_cache_max_entries &&
+	       left.has_prompt_cache == right.has_prompt_cache && left.prompt_cache == right.prompt_cache &&
+	       left.has_connect_timeout_seconds == right.has_connect_timeout_seconds &&
+	       left.connect_timeout_seconds == right.connect_timeout_seconds && left.allowed_hosts == right.allowed_hosts &&
 	       left.log_endpoint == right.log_endpoint && left.log_format == right.log_format &&
 	       left.log_tags == right.log_tags && left.has_log_include_text == right.has_log_include_text &&
 	       left.log_include_text == right.log_include_text && left.has_log_strict == right.has_log_strict &&
 	       left.log_strict == right.log_strict && left.has_log_sample_rate == right.has_log_sample_rate &&
 	       left.log_sample_rate == right.log_sample_rate && left.fail_on_error == right.fail_on_error &&
-	       left.response_format == right.response_format && left.response_schema == right.response_schema;
+	       left.on_error == right.on_error && left.response_format == right.response_format &&
+	       left.response_schema == right.response_schema && left.function_name == right.function_name &&
+	       left.query_id == right.query_id;
+}
+
+void StampProviderFunction(duckdb_ai::CompletionOptions &options, const std::string &function_name) {
+	options.function_name = function_name;
+	if (options.query_id.empty()) {
+		options.query_id = "duckdb_ai_query_" + std::to_string(NEXT_QUERY_ID.fetch_add(1));
+	}
 }
 
 struct AiUsageScanData : public GlobalTableFunctionState {
@@ -133,6 +159,24 @@ struct PromptSchemaScanData : public GlobalTableFunctionState {
 	}
 
 	bool emitted;
+};
+
+struct PromptQueryCacheState : public ObjectCacheEntry {
+	static std::string ObjectType() {
+		return "duckdb_ai_prompt_query_cache";
+	}
+
+	std::string GetObjectType() override {
+		return ObjectType();
+	}
+
+	optional_idx GetEstimatedCacheMemory() const override {
+		return optional_idx {};
+	}
+
+	std::mutex mutex;
+	std::unordered_map<std::string, std::string> generated_sql;
+	std::deque<std::string> recency_order;
 };
 
 enum class PromptAssistantKind : uint8_t { EXPLAIN, FIXUP, FIX_LINE };
@@ -285,7 +329,37 @@ struct AiRecordScanData : public GlobalTableFunctionState {
 	bool emitted;
 };
 
-enum class AiTaskKind : uint8_t { SUMMARIZE, SENTIMENT, FIX_GRAMMAR, MASK, TRANSLATE, CLASSIFY, EXTRACT, FILTER };
+struct AiExtractRecordBindData : public FunctionData {
+	std::string response_schema;
+	duckdb_ai::CompletionOptions options;
+	vector<AiRecordColumn> columns;
+	bool has_model_arg = false;
+	idx_t model_index = 0;
+	bool has_provider_arg = false;
+	idx_t provider_index = 0;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<AiExtractRecordBindData>();
+		result->response_schema = response_schema;
+		result->options = options;
+		result->columns = columns;
+		result->has_model_arg = has_model_arg;
+		result->model_index = model_index;
+		result->has_provider_arg = has_provider_arg;
+		result->provider_index = provider_index;
+		return std::move(result);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<AiExtractRecordBindData>();
+		return response_schema == other.response_schema && CompletionOptionsEqual(options, other.options) &&
+		       AiRecordColumnsEqual(columns, other.columns) && has_model_arg == other.has_model_arg &&
+		       model_index == other.model_index && has_provider_arg == other.has_provider_arg &&
+		       provider_index == other.provider_index;
+	}
+};
+
+enum class AiTaskKind : uint8_t { SUMMARIZE, SENTIMENT, FIX_GRAMMAR, REDACT, TRANSLATE, CLASSIFY, EXTRACT, FILTER };
 
 enum class AiAggregateKind : uint8_t { GENERIC, SUMMARIZE };
 
@@ -300,6 +374,7 @@ struct AiTaskBindData : public FunctionData {
 	idx_t model_index = 0;
 	bool has_provider_arg = false;
 	idx_t provider_index = 0;
+	bool parameter_is_label_list = false;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<AiTaskBindData>(task, required_args);
@@ -308,6 +383,7 @@ struct AiTaskBindData : public FunctionData {
 		result->model_index = model_index;
 		result->has_provider_arg = has_provider_arg;
 		result->provider_index = provider_index;
+		result->parameter_is_label_list = parameter_is_label_list;
 		return std::move(result);
 	}
 
@@ -316,7 +392,7 @@ struct AiTaskBindData : public FunctionData {
 		return task == other.task && required_args == other.required_args &&
 		       CompletionOptionsEqual(options, other.options) && has_model_arg == other.has_model_arg &&
 		       model_index == other.model_index && has_provider_arg == other.has_provider_arg &&
-		       provider_index == other.provider_index;
+		       provider_index == other.provider_index && parameter_is_label_list == other.parameter_is_label_list;
 	}
 };
 
@@ -432,7 +508,8 @@ void ValidateResponseSchemaValue(const std::string &schema, const std::string &f
 bool TryGetOptionType(const std::string &name, LogicalType &type) {
 	if (name == "model" || name == "provider" || name == "profile" || name == "secret" || name == "secret_name" ||
 	    name == "system_prompt" || name == "base_url" || name == "response_format" || name == "response_schema" ||
-	    name == "json_schema" || name == "allowed_hosts" || name == "log_format" || name == "log_tags") {
+	    name == "json_schema" || name == "allowed_hosts" || name == "log_format" || name == "log_tags" ||
+	    name == "on_error") {
 		type = LogicalType::VARCHAR;
 		return true;
 	}
@@ -446,11 +523,11 @@ bool TryGetOptionType(const std::string &name, LogicalType &type) {
 		type = LogicalType::BIGINT;
 		return true;
 	}
-	if (name == "timeout_seconds") {
+	if (name == "timeout_seconds" || name == "cache_ttl_seconds") {
 		type = LogicalType::BIGINT;
 		return true;
 	}
-	if (name == "cache" || name == "fail_on_error" || name == "use_builtin_model_prices") {
+	if (name == "cache" || name == "prompt_cache" || name == "fail_on_error" || name == "use_builtin_model_prices") {
 		type = LogicalType::BOOLEAN;
 		return true;
 	}
@@ -465,10 +542,11 @@ LogicalType OptionType(const std::string &name) {
 	throw BinderException("Unsupported AI option \"%s\". Supported options: model, provider, temperature, "
 	                      "system_prompt, max_tokens, base_url, timeout_seconds, retry_count, retry_backoff_ms, "
 	                      "max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, cache, "
+	                      "cache_ttl_seconds, prompt_cache, "
 	                      "allowed_hosts, "
 	                      "input_token_price_per_million, output_token_price_per_million, use_builtin_model_prices, "
-	                      "fail_on_error, profile, secret, response_format, response_schema, json_schema, log_format, "
-	                      "log_tags, log_sample_rate",
+	                      "fail_on_error, on_error, profile, secret, response_format, response_schema, json_schema, "
+	                      "log_format, log_tags, log_sample_rate",
 	                      name);
 }
 
@@ -527,7 +605,16 @@ std::string NormalizeLogFormatValue(const std::string &value, const std::string 
 	    log_format == "otlp") {
 		return log_format;
 	}
-	throw BinderException("%s option \"log_format\" must be one of: generic_json, otlp_json", function_name);
+	throw BinderException("%s option \"log_format\" must be one of: generic, json, generic_json, otlp, otlp_json",
+	                      function_name);
+}
+
+std::string NormalizeOnErrorValue(const std::string &value, const std::string &function_name) {
+	auto on_error = LowerAscii(value);
+	if (on_error == "fail" || on_error == "null" || on_error == "capture") {
+		return on_error;
+	}
+	throw BinderException("%s option \"on_error\" must be one of: fail, null, capture", function_name);
 }
 
 bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std::string &function_name,
@@ -625,6 +712,19 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 		options.has_cache = true;
 		return true;
 	}
+	if (name == "cache_ttl_seconds") {
+		options.cache_ttl_seconds = OptionBigIntValue(value, function_name, name);
+		if (options.cache_ttl_seconds < 0 || options.cache_ttl_seconds > 31536000) {
+			throw BinderException("%s option \"cache_ttl_seconds\" must be between 0 and 31536000", function_name);
+		}
+		options.has_cache_ttl_seconds = true;
+		return true;
+	}
+	if (name == "prompt_cache") {
+		options.prompt_cache = OptionBoolValue(value, function_name, name);
+		options.has_prompt_cache = true;
+		return true;
+	}
 	if (name == "max_tokens") {
 		options.max_tokens = OptionBigIntValue(value, function_name, name);
 		if (options.max_tokens <= 0) {
@@ -651,8 +751,10 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 	}
 	if (name == "max_concurrent_requests") {
 		options.max_concurrent_requests = OptionBigIntValue(value, function_name, name);
-		if (options.max_concurrent_requests < 0 || options.max_concurrent_requests > 1024) {
-			throw BinderException("%s option \"max_concurrent_requests\" must be between 0 and 1024", function_name);
+		if (options.max_concurrent_requests < 0 ||
+		    options.max_concurrent_requests > static_cast<int64_t>(MAX_PROVIDER_CHUNK_WORKERS)) {
+			throw BinderException("%s option \"max_concurrent_requests\" must be between 0 and %llu", function_name,
+			                      static_cast<unsigned long long>(MAX_PROVIDER_CHUNK_WORKERS));
 		}
 		options.has_max_concurrent_requests = true;
 		return true;
@@ -684,6 +786,12 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 	}
 	if (name == "fail_on_error") {
 		options.fail_on_error = OptionBoolValue(value, function_name, name);
+		options.on_error = options.fail_on_error ? "fail" : "null";
+		return true;
+	}
+	if (name == "on_error") {
+		options.on_error = NormalizeOnErrorValue(OptionStringValue(value, function_name, name), function_name);
+		options.fail_on_error = options.on_error == "fail";
 		return true;
 	}
 	if (name == "log_include_text") {
@@ -755,7 +863,7 @@ std::string ModelSettingName(AiModelSettingKind kind) {
 	case AiModelSettingKind::EMBEDDING:
 		return "duckdb_ai_embedding_model";
 	case AiModelSettingKind::SQL_ASSISTANT:
-		return "duckdb_ai_sql_model";
+		return "duckdb_ai_sql_assistant_model";
 	case AiModelSettingKind::GENERIC:
 		break;
 	}
@@ -875,6 +983,7 @@ void ApplySettingsWithPrefix(ClientContext &context, const std::string &prefix, 
 	ApplyStringSetting(context, prefix + "_log_endpoint", options.log_endpoint);
 	ApplyStringSetting(context, prefix + "_log_format", options.log_format);
 	ApplyStringSetting(context, prefix + "_log_tags", options.log_tags);
+	ApplyStringSetting(context, prefix + "_on_error", options.on_error);
 	ApplyBoolSetting(context, prefix + "_log_include_text", options.log_include_text, options.has_log_include_text);
 	ApplyBoolSetting(context, prefix + "_log_strict", options.log_strict, options.has_log_strict);
 	ApplyDoubleSetting(context, prefix + "_log_sample_rate", options.log_sample_rate, options.has_log_sample_rate);
@@ -882,7 +991,8 @@ void ApplySettingsWithPrefix(ClientContext &context, const std::string &prefix, 
 	ApplyBigIntRangeSetting(context, prefix + "_retry_backoff_ms", options.retry_backoff_ms,
 	                        options.has_retry_backoff_ms, 0, 60000);
 	ApplyOptionalBigIntRangeSetting(context, prefix + "_max_concurrent_requests", options.max_concurrent_requests,
-	                                options.has_max_concurrent_requests, 0, 1024);
+	                                options.has_max_concurrent_requests, 0,
+	                                static_cast<int64_t>(MAX_PROVIDER_CHUNK_WORKERS));
 	ApplyOptionalBigIntRangeSetting(context, prefix + "_min_request_interval_ms", options.min_request_interval_ms,
 	                                options.has_min_request_interval_ms, 0, 60000);
 	ApplyOptionalBigIntRangeSetting(context, prefix + "_token_limit_per_minute", options.token_limit_per_minute,
@@ -894,6 +1004,9 @@ void ApplySettingsWithPrefix(ClientContext &context, const std::string &prefix, 
 	ApplyBoolSetting(context, prefix + "_use_builtin_model_prices", options.use_builtin_model_prices,
 	                 options.has_use_builtin_model_prices);
 	ApplyBoolSetting(context, prefix + "_cache", options.cache, options.has_cache);
+	ApplyOptionalBigIntRangeSetting(context, prefix + "_cache_ttl_seconds", options.cache_ttl_seconds,
+	                                options.has_cache_ttl_seconds, 0, 31536000);
+	ApplyBoolSetting(context, prefix + "_prompt_cache", options.prompt_cache, options.has_prompt_cache);
 	ApplyTimeoutSetting(context, prefix + "_timeout_seconds", options);
 }
 
@@ -918,9 +1031,15 @@ void ApplySettings(ClientContext &context, duckdb_ai::CompletionOptions &options
 		options.log_format = LowerAscii(options.log_format);
 		if (options.log_format != "generic_json" && options.log_format != "generic" && options.log_format != "json" &&
 		    options.log_format != "otlp_json" && options.log_format != "otlp") {
-			throw BinderException("Setting duckdb_ai_log_format must be one of: generic_json, otlp_json");
+			throw BinderException(
+			    "Setting duckdb_ai_log_format must be one of: generic, json, generic_json, otlp, otlp_json");
 		}
 	}
+	if (!options.on_error.empty()) {
+		options.on_error = NormalizeOnErrorValue(options.on_error, "AI setting");
+		options.fail_on_error = options.on_error == "fail";
+	}
+	duckdb_ai::SnapshotEnvironmentOptions(options);
 }
 
 bool TryReadSecretString(const KeyValueSecret &secret, const std::string &key, std::string &target) {
@@ -1019,6 +1138,7 @@ unique_ptr<FunctionData> AiCompletionBindInternal(ClientContext &context, Scalar
                                                   bool validate_json_output = false) {
 	auto bind_data = make_uniq<AiCompletionBindData>(false, validate_json_output);
 	ApplySettings(context, bind_data->options, AiModelSettingKind::COMPLETION);
+	StampProviderFunction(bind_data->options, bound_function.name);
 	if (arguments.empty()) {
 		throw BinderException("%s requires a prompt argument", bound_function.name);
 	}
@@ -1054,8 +1174,8 @@ unique_ptr<FunctionData> AiCompleteBind(ClientContext &context, ScalarFunction &
 	return AiCompletionBindInternal(context, bound_function, arguments);
 }
 
-unique_ptr<FunctionData> AiRequestJsonBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> AiCompletionRequestJsonBind(ClientContext &context, ScalarFunction &bound_function,
+                                                     vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = AiCompletionBindInternal(context, bound_function, arguments);
 	bind_data->Cast<AiCompletionBindData>().request_json = true;
 	return bind_data;
@@ -1101,6 +1221,67 @@ unique_ptr<StringVectorReader> OptionalStringReader(DataChunk &args, bool enable
 	return enabled ? make_uniq<StringVectorReader>(args, column) : nullptr;
 }
 
+std::string QuoteClassificationLabel(const std::string &label) {
+	std::string result = "\"";
+	for (auto c : label) {
+		if (c == '"' || c == '\\') {
+			result += '\\';
+		}
+		result += c;
+	}
+	result += "\"";
+	return result;
+}
+
+std::string FormatClassificationLabels(const vector<std::string> &labels) {
+	std::string result;
+	for (idx_t i = 0; i < labels.size(); i++) {
+		if (i > 0) {
+			result += ", ";
+		}
+		result += QuoteClassificationLabel(labels[i]);
+	}
+	return result;
+}
+
+struct StringListVectorReader {
+	StringListVectorReader(DataChunk &args, idx_t column) {
+		auto &list_vector = args.data[column];
+		list_vector.ToUnifiedFormat(args.size(), data);
+		entries = UnifiedVectorFormat::GetData<list_entry_t>(data);
+		auto &child_vector = ListVector::GetEntry(list_vector);
+		child_vector.ToUnifiedFormat(ListVector::GetListSize(list_vector), child_data);
+		child_values = UnifiedVectorFormat::GetData<string_t>(child_data);
+	}
+
+	bool Read(idx_t row, std::string &value) const {
+		auto mapped_row = data.sel->get_index(row);
+		if (!data.validity.RowIsValid(mapped_row)) {
+			return false;
+		}
+		auto entry = entries[mapped_row];
+		if (entry.length == 0) {
+			return false;
+		}
+		vector<std::string> labels;
+		labels.reserve(entry.length);
+		for (idx_t i = 0; i < entry.length; i++) {
+			auto child_row = child_data.sel->get_index(entry.offset + i);
+			if (!child_data.validity.RowIsValid(child_row)) {
+				return false;
+			}
+			labels.push_back(child_values[child_row].GetString());
+		}
+		value = FormatClassificationLabels(labels);
+		return true;
+	}
+
+	UnifiedVectorFormat data;
+	UnifiedVectorFormat child_data;
+	const list_entry_t *entries;
+	const string_t *child_values;
+};
+
 struct ProviderJobBase {
 	idx_t row = 0;
 	duckdb_ai::CompletionOptions options;
@@ -1114,6 +1295,12 @@ struct ProviderStringJob : public ProviderJobBase {
 	std::string input;
 	std::string parameter;
 	std::string output;
+};
+
+struct ProviderStringListJob : public ProviderJobBase {
+	std::string input;
+	std::string parameter;
+	std::vector<std::string> output;
 };
 
 struct ProviderBoolJob : public ProviderJobBase {
@@ -1130,8 +1317,38 @@ struct ProviderEmbeddingJob : public ProviderJobBase {
 struct ProviderDoubleJob : public ProviderJobBase {
 	std::string left;
 	std::string right;
+	bool has_left_embedding = false;
+	bool has_right_embedding = false;
+	std::vector<double> left_embedding;
+	std::vector<double> right_embedding;
 	double output = 0;
 };
+
+struct SimilarityEmbeddingCacheEntry {
+	std::string input;
+	duckdb_ai::CompletionOptions options;
+	std::vector<double> values;
+};
+
+struct SecretResolutionCacheEntry {
+	duckdb_ai::CompletionOptions input_options;
+	duckdb_ai::CompletionOptions resolved_options;
+};
+
+void ApplyAiProviderSecretCached(ClientContext &context, duckdb_ai::CompletionOptions &options,
+                                 std::vector<SecretResolutionCacheEntry> &cache) {
+	for (auto &entry : cache) {
+		if (CompletionOptionsEqual(entry.input_options, options)) {
+			options = entry.resolved_options;
+			return;
+		}
+	}
+	SecretResolutionCacheEntry entry;
+	entry.input_options = options;
+	ApplyAiProviderSecret(context, options);
+	entry.resolved_options = options;
+	cache.push_back(std::move(entry));
+}
 
 template <class JOB>
 idx_t ProviderWorkerCount(const std::vector<JOB> &jobs) {
@@ -1234,7 +1451,7 @@ std::string TrimJsonWhitespace(const std::string &input) {
 	return input.substr(start, end - start);
 }
 
-std::string BuildJsonCompletionPrompt(const std::string &prompt, const std::string &response_schema) {
+std::string BuildJsonCompletionSystemPrompt(const std::string &response_schema) {
 	std::string output =
 	    "Return only valid JSON. Do not include markdown, code fences, comments, or explanatory text.\n";
 	if (!response_schema.empty()) {
@@ -1244,9 +1461,29 @@ std::string BuildJsonCompletionPrompt(const std::string &prompt, const std::stri
 	} else {
 		output += "The JSON response must be a top-level object or array.\n";
 	}
-	output += "\nRequest:\n";
-	output += prompt;
 	return output;
+}
+
+void ApplyJsonCompletionSystemPrompt(duckdb_ai::CompletionOptions &options, const std::string &response_schema) {
+	auto json_system_prompt = BuildJsonCompletionSystemPrompt(response_schema);
+	if (options.system_prompt.empty()) {
+		options.system_prompt = std::move(json_system_prompt);
+		return;
+	}
+	options.system_prompt += "\n\n";
+	options.system_prompt += json_system_prompt;
+}
+
+void AppendSystemPrompt(duckdb_ai::CompletionOptions &options, const std::string &system_prompt) {
+	if (system_prompt.empty()) {
+		return;
+	}
+	if (options.system_prompt.empty()) {
+		options.system_prompt = system_prompt;
+		return;
+	}
+	options.system_prompt += "\n\n";
+	options.system_prompt += system_prompt;
 }
 
 bool ValidateJsonCompletionOutput(const std::string &output, const std::string &response_schema, std::string &error) {
@@ -1282,6 +1519,7 @@ void AiCompletionFunction(DataChunk &args, ExpressionState &state, Vector &resul
 
 	std::vector<ProviderStringJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string prompt;
 		if (!prompt_reader.Read(row, prompt)) {
@@ -1297,13 +1535,15 @@ void AiCompletionFunction(DataChunk &args, ExpressionState &state, Vector &resul
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderStringJob job;
 			job.row = row;
+			if (bind_data.validate_json_output) {
+				ApplyJsonCompletionSystemPrompt(options, options.response_schema);
+			}
 			job.options = options;
 			job.fail_on_error = options.fail_on_error;
-			job.input =
-			    bind_data.validate_json_output ? BuildJsonCompletionPrompt(prompt, options.response_schema) : prompt;
+			job.input = std::move(prompt);
 			jobs.push_back(std::move(job));
 		} catch (std::exception &ex) {
 			if (options.fail_on_error) {
@@ -1350,6 +1590,9 @@ LogicalType AiTryCompleteReturnType() {
 unique_ptr<FunctionData> AiTryCompleteBind(ClientContext &context, ScalarFunction &bound_function,
                                            vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = AiCompletionBindInternal(context, bound_function, arguments);
+	auto &completion_bind_data = bind_data->Cast<AiCompletionBindData>();
+	completion_bind_data.options.on_error = "capture";
+	completion_bind_data.options.fail_on_error = false;
 	bound_function.SetReturnType(AiTryCompleteReturnType());
 	return bind_data;
 }
@@ -1381,6 +1624,7 @@ void AiTryCompleteFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 	std::vector<ProviderStringJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string prompt;
 		if (!prompt_reader.Read(row, prompt)) {
@@ -1396,7 +1640,7 @@ void AiTryCompleteFunction(DataChunk &args, ExpressionState &state, Vector &resu
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderStringJob job;
 			job.row = row;
 			job.options = options;
@@ -1604,6 +1848,7 @@ unique_ptr<FunctionData> AiRecordBind(ClientContext &context, TableFunctionBindI
 	}
 	auto bind_data = make_uniq<AiRecordBindData>();
 	ApplySettings(context, bind_data->options, AiModelSettingKind::COMPLETION);
+	StampProviderFunction(bind_data->options, "ai_complete_record");
 	bind_data->prompt = RequiredRecordStringInput(input, 0, "prompt");
 	bind_data->response_schema = RequiredRecordStringInput(input, 1, "response_schema");
 	ValidateResponseSchemaValue(bind_data->response_schema, "ai_complete_record");
@@ -1647,8 +1892,8 @@ void AiRecordFunction(ClientContext &context, TableFunctionInput &input, DataChu
 		auto options = bind_data.options;
 		duckdb_ai::AttachProviderRuntimeState(options, context);
 		ApplyAiProviderSecret(context, options);
-		auto request_prompt = BuildJsonCompletionPrompt(bind_data.prompt, bind_data.response_schema);
-		auto result = duckdb_ai::Complete(request_prompt, options).text;
+		ApplyJsonCompletionSystemPrompt(options, bind_data.response_schema);
+		auto result = duckdb_ai::Complete(bind_data.prompt, options).text;
 		std::string error;
 		if (!ValidateJsonCompletionOutput(result, bind_data.response_schema, error)) {
 			throw InvalidInputException("ai_complete_record expected valid JSON output: %s", error);
@@ -1678,19 +1923,167 @@ void AiRecordFunction(ClientContext &context, TableFunctionInput &input, DataChu
 	state.emitted = true;
 }
 
+Value AiRecordStructValue(const vector<AiRecordColumn> &columns, const vector<duckdb_ai::JsonExtractedValue> &values) {
+	vector<Value> children;
+	children.reserve(columns.size());
+	for (idx_t column_index = 0; column_index < columns.size(); column_index++) {
+		children.push_back(AiRecordValue(values[column_index], columns[column_index]));
+	}
+	return Value::STRUCT(AiRecordStructType(columns), std::move(children));
+}
+
+unique_ptr<FunctionData> AiExtractRecordBind(ClientContext &context, ScalarFunction &bound_function,
+                                             vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() < 2) {
+		throw BinderException("%s requires text and response_schema arguments", bound_function.name);
+	}
+	auto bind_data = make_uniq<AiExtractRecordBindData>();
+	ApplySettings(context, bind_data->options, AiModelSettingKind::COMPLETION);
+	StampProviderFunction(bind_data->options, bound_function.name);
+	bind_data->response_schema =
+	    StringValue::Get(EvaluateConstantOption(context, *arguments[1], "response_schema", LogicalType::VARCHAR));
+	ValidateResponseSchemaValue(bind_data->response_schema, bound_function.name);
+	bind_data->options.response_schema = bind_data->response_schema;
+	bind_data->options.response_format = "json_schema";
+
+	idx_t positional_option_count = 0;
+	for (idx_t i = 2; i < arguments.size(); i++) {
+		auto alias = LowerAscii(arguments[i]->GetAlias());
+		if (alias.empty()) {
+			positional_option_count++;
+			if (positional_option_count == 1) {
+				bind_data->has_model_arg = true;
+				bind_data->model_index = i;
+				bound_function.arguments.emplace_back(LogicalType::VARCHAR);
+			} else if (positional_option_count == 2) {
+				bind_data->has_provider_arg = true;
+				bind_data->provider_index = i;
+				bound_function.arguments.emplace_back(LogicalType::VARCHAR);
+			} else {
+				throw BinderException("%s supports at most two positional options after response_schema: model and "
+				                      "provider",
+				                      bound_function.name);
+			}
+			continue;
+		}
+		if (alias == "response_schema" || alias == "json_schema" || alias == "response_format") {
+			throw BinderException("%s takes response_schema as the second argument", bound_function.name);
+		}
+		ApplyNamedOption(context, bind_data->options, *arguments[i], alias);
+		bound_function.arguments.emplace_back(OptionType(alias));
+	}
+
+	vector<duckdb_ai::JsonSchemaProperty> properties;
+	std::string error;
+	if (!duckdb_ai::ExtractJsonSchemaProperties(bind_data->response_schema, properties, error)) {
+		throw BinderException("%s response_schema cannot be projected as a record: %s", bound_function.name, error);
+	}
+	for (auto &property : properties) {
+		bind_data->columns.push_back(BuildAiRecordColumn(property));
+	}
+	bound_function.SetReturnType(AiRecordStructType(bind_data->columns));
+	return std::move(bind_data);
+}
+
+void AiExtractRecordFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &bind_data = func_expr.bind_info->Cast<AiExtractRecordBindData>();
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, 0);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
+
+	std::vector<ProviderStringJob> jobs;
+	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
+	for (idx_t row = 0; row < args.size(); row++) {
+		std::string input_text;
+		if (!input_reader.Read(row, input_text)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(state.GetContext(), bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		try {
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
+			ApplyJsonCompletionSystemPrompt(options, bind_data.response_schema);
+			ProviderStringJob job;
+			job.row = row;
+			job.options = options;
+			job.fail_on_error = options.fail_on_error;
+			job.input = std::move(input_text);
+			jobs.push_back(std::move(job));
+		} catch (std::exception &ex) {
+			if (options.fail_on_error) {
+				throw;
+			}
+			result_validity.SetInvalid(row);
+		}
+	}
+
+	RunProviderJobs(jobs,
+	                [&](ProviderStringJob &job) { job.output = duckdb_ai::Complete(job.input, job.options).text; });
+
+	for (auto &job : jobs) {
+		if (job.exception) {
+			if (job.fail_on_error) {
+				std::rethrow_exception(job.exception);
+			}
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		if (!job.completed) {
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		std::string error;
+		if (!ValidateJsonCompletionOutput(job.output, job.options.response_schema, error)) {
+			if (job.fail_on_error) {
+				throw InvalidInputException("ai_extract_record expected valid JSON output: %s", error);
+			}
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		vector<std::string> field_names;
+		field_names.reserve(bind_data.columns.size());
+		for (auto &column : bind_data.columns) {
+			field_names.push_back(column.name);
+		}
+		vector<duckdb_ai::JsonExtractedValue> values;
+		if (!duckdb_ai::ExtractJsonObjectFields(job.output, field_names, values, error)) {
+			if (job.fail_on_error) {
+				throw InvalidInputException("ai_extract_record could not project JSON output: %s", error);
+			}
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		result.SetValue(job.row, AiRecordStructValue(bind_data.columns, values));
+	}
+}
+
 bool IsEmbeddingOption(const std::string &name) {
 	return name == "model" || name == "provider" || name == "profile" || name == "secret" || name == "secret_name" ||
 	       name == "base_url" || name == "timeout_seconds" || name == "retry_count" || name == "retry_backoff_ms" ||
 	       name == "max_concurrent_requests" || name == "min_request_interval_ms" || name == "token_limit_per_minute" ||
 	       name == "input_token_price_per_million" || name == "output_token_price_per_million" ||
 	       name == "use_builtin_model_prices" || name == "cache" || name == "allowed_hosts" ||
-	       name == "fail_on_error" || name == "log_format" || name == "log_tags" || name == "log_sample_rate";
+	       name == "fail_on_error" || name == "on_error" || name == "log_format" || name == "log_tags" ||
+	       name == "log_sample_rate";
 }
 
 unique_ptr<FunctionData> AiEmbeddingBindInternal(ClientContext &context, ScalarFunction &bound_function,
                                                  vector<unique_ptr<Expression>> &arguments, bool request_json) {
 	auto bind_data = make_uniq<AiCompletionBindData>(request_json);
 	ApplySettings(context, bind_data->options, AiModelSettingKind::EMBEDDING);
+	StampProviderFunction(bind_data->options, bound_function.name);
 	if (arguments.empty()) {
 		throw BinderException("%s requires an input argument", bound_function.name);
 	}
@@ -1718,7 +2111,7 @@ unique_ptr<FunctionData> AiEmbeddingBindInternal(ClientContext &context, ScalarF
 			throw BinderException(
 			    "Unsupported AI embedding option \"%s\". Supported options: model, provider, "
 			    "profile, secret, base_url, timeout_seconds, retry_count, retry_backoff_ms, fail_on_error, "
-			    "max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, "
+			    "on_error, max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, "
 			    "cache, allowed_hosts, input_token_price_per_million, output_token_price_per_million, "
 			    "use_builtin_model_prices, log_format, log_tags, log_sample_rate",
 			    alias);
@@ -1744,6 +2137,7 @@ unique_ptr<FunctionData> AiSimilarityBind(ClientContext &context, ScalarFunction
                                           vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = make_uniq<AiCompletionBindData>(false);
 	ApplySettings(context, bind_data->options, AiModelSettingKind::EMBEDDING);
+	StampProviderFunction(bind_data->options, bound_function.name);
 	if (arguments.size() < 2) {
 		throw BinderException("%s requires two text arguments", bound_function.name);
 	}
@@ -1771,10 +2165,45 @@ unique_ptr<FunctionData> AiSimilarityBind(ClientContext &context, ScalarFunction
 			throw BinderException(
 			    "Unsupported AI similarity option \"%s\". Supported options: model, provider, "
 			    "profile, secret, base_url, timeout_seconds, retry_count, retry_backoff_ms, fail_on_error, "
-			    "max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, cache, allowed_hosts, "
-			    "input_token_price_per_million, output_token_price_per_million, "
+			    "on_error, max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, cache, "
+			    "allowed_hosts, input_token_price_per_million, output_token_price_per_million, "
 			    "use_builtin_model_prices, log_format, log_tags, log_sample_rate",
 			    alias);
+		}
+		ApplyNamedOption(context, bind_data->options, *arguments[i], alias);
+		bound_function.arguments.emplace_back(OptionType(alias));
+	}
+	bound_function.SetReturnType(LogicalType::DOUBLE);
+	return std::move(bind_data);
+}
+
+unique_ptr<FunctionData> AiRerankBind(ClientContext &context, ScalarFunction &bound_function,
+                                      vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = make_uniq<AiCompletionBindData>(false);
+	ApplySettings(context, bind_data->options, AiModelSettingKind::COMPLETION);
+	StampProviderFunction(bind_data->options, bound_function.name);
+	if (arguments.size() < 2) {
+		throw BinderException("%s requires query and candidate text arguments", bound_function.name);
+	}
+
+	idx_t positional_option_count = 0;
+	for (idx_t i = 2; i < arguments.size(); i++) {
+		auto alias = LowerAscii(arguments[i]->GetAlias());
+		if (alias.empty()) {
+			positional_option_count++;
+			if (positional_option_count == 1) {
+				bind_data->has_model_arg = true;
+				bind_data->model_index = i;
+				bound_function.arguments.emplace_back(LogicalType::VARCHAR);
+			} else if (positional_option_count == 2) {
+				bind_data->has_provider_arg = true;
+				bind_data->provider_index = i;
+				bound_function.arguments.emplace_back(LogicalType::VARCHAR);
+			} else {
+				throw BinderException("%s supports at most two positional options: model and provider",
+				                      bound_function.name);
+			}
+			continue;
 		}
 		ApplyNamedOption(context, bind_data->options, *arguments[i], alias);
 		bound_function.arguments.emplace_back(OptionType(alias));
@@ -1816,6 +2245,150 @@ double CosineSimilarity(const std::vector<double> &left, const std::vector<doubl
 	return dot / (std::sqrt(left_norm) * std::sqrt(right_norm));
 }
 
+bool IsAsciiWhitespace(char c);
+std::string StripMarkdownJsonFence(const std::string &text);
+
+std::string BuildRerankSystemPrompt() {
+	return "Score candidate relevance to the search query on a scale from 0 to 1. Return only one decimal number. "
+	       "Use 0 for not relevant and 1 for exactly relevant.";
+}
+
+std::string BuildRerankPrompt(const std::string &query, const std::string &candidate) {
+	return "Query:\n" + query + "\n\nCandidate:\n" + candidate;
+}
+
+bool ParseRerankScore(const std::string &input, double &score) {
+	auto trimmed = StripMarkdownJsonFence(input);
+	if (trimmed.size() >= 2 && trimmed.front() == '"' && trimmed.back() == '"') {
+		trimmed = trimmed.substr(1, trimmed.size() - 2);
+	}
+	auto *begin = trimmed.c_str();
+	char *end = nullptr;
+	errno = 0;
+	auto value = std::strtod(begin, &end);
+	if (begin == end || errno == ERANGE) {
+		return false;
+	}
+	while (end && *end && IsAsciiWhitespace(*end)) {
+		end++;
+	}
+	if (end && *end) {
+		return false;
+	}
+	if (!std::isfinite(value) || value < 0 || value > 1) {
+		return false;
+	}
+	score = value;
+	return true;
+}
+
+void AiRerankFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &bind_data = func_expr.bind_info->Cast<AiCompletionBindData>();
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<double>(result);
+	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader query_reader(args, 0);
+	StringVectorReader candidate_reader(args, 1);
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
+
+	std::vector<ProviderDoubleJob> jobs;
+	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
+	for (idx_t row = 0; row < args.size(); row++) {
+		std::string query;
+		std::string candidate;
+		if (!query_reader.Read(row, query) || !candidate_reader.Read(row, candidate)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(state.GetContext(), bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		try {
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
+			ProviderDoubleJob job;
+			job.row = row;
+			job.options = options;
+			job.fail_on_error = options.fail_on_error;
+			job.left = std::move(query);
+			job.right = std::move(candidate);
+			jobs.push_back(std::move(job));
+		} catch (std::exception &ex) {
+			if (options.fail_on_error) {
+				throw;
+			}
+			result_validity.SetInvalid(row);
+		}
+	}
+
+	RunProviderJobs(jobs, [&](ProviderDoubleJob &job) {
+		AppendSystemPrompt(job.options, BuildRerankSystemPrompt());
+		auto output = duckdb_ai::Complete(BuildRerankPrompt(job.left, job.right), job.options).text;
+		if (!ParseRerankScore(output, job.output)) {
+			throw InvalidInputException("ai_rerank expected a numeric score from 0 to 1, got: %s", output);
+		}
+	});
+
+	for (auto &job : jobs) {
+		if (job.exception) {
+			if (job.fail_on_error) {
+				std::rethrow_exception(job.exception);
+			}
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		if (!job.completed) {
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		result_data[job.row] = job.output;
+	}
+}
+
+void PrecomputeConstantSimilarityEmbeddings(std::vector<ProviderDoubleJob> &jobs, bool left_side) {
+	std::vector<SimilarityEmbeddingCacheEntry> cache;
+	for (auto &job : jobs) {
+		if (job.exception) {
+			continue;
+		}
+		auto &input = left_side ? job.left : job.right;
+		auto cache_entry = std::find_if(cache.begin(), cache.end(), [&](const SimilarityEmbeddingCacheEntry &entry) {
+			return entry.input == input && CompletionOptionsEqual(entry.options, job.options);
+		});
+		try {
+			if (cache_entry == cache.end()) {
+				SimilarityEmbeddingCacheEntry entry;
+				entry.input = input;
+				entry.options = job.options;
+				entry.values = duckdb_ai::Embed(input, job.options).values;
+				cache.push_back(std::move(entry));
+				cache_entry = cache.end() - 1;
+			}
+			if (left_side) {
+				job.has_left_embedding = true;
+				job.left_embedding = cache_entry->values;
+			} else {
+				job.has_right_embedding = true;
+				job.right_embedding = cache_entry->values;
+			}
+		} catch (std::exception &ex) {
+			job.exception = std::current_exception();
+			job.error_message = ex.what();
+			if (job.fail_on_error) {
+				throw;
+			}
+		}
+	}
+}
+
 void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &bind_data = func_expr.bind_info->Cast<AiCompletionBindData>();
@@ -1823,6 +2396,8 @@ void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<double>(result);
 	auto &result_validity = FlatVector::Validity(result);
+	auto left_is_constant = args.data[0].GetVectorType() == VectorType::CONSTANT_VECTOR;
+	auto right_is_constant = args.data[1].GetVectorType() == VectorType::CONSTANT_VECTOR;
 	StringVectorReader left_reader(args, 0);
 	StringVectorReader right_reader(args, 1);
 	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
@@ -1830,6 +2405,7 @@ void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &resul
 
 	std::vector<ProviderDoubleJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string left;
 		std::string right;
@@ -1846,7 +2422,7 @@ void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &resul
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderDoubleJob job;
 			job.row = row;
 			job.options = options;
@@ -1862,10 +2438,22 @@ void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &resul
 		}
 	}
 
+	if (left_is_constant) {
+		PrecomputeConstantSimilarityEmbeddings(jobs, true);
+	}
+	if (right_is_constant) {
+		PrecomputeConstantSimilarityEmbeddings(jobs, false);
+	}
+
 	RunProviderJobs(jobs, [&](ProviderDoubleJob &job) {
-		auto left_embedding = duckdb_ai::Embed(job.left, job.options);
-		auto right_embedding = duckdb_ai::Embed(job.right, job.options);
-		job.output = CosineSimilarity(left_embedding.values, right_embedding.values);
+		if (job.exception) {
+			return;
+		}
+		auto left_embedding =
+		    job.has_left_embedding ? job.left_embedding : duckdb_ai::Embed(job.left, job.options).values;
+		auto right_embedding =
+		    job.has_right_embedding ? job.right_embedding : duckdb_ai::Embed(job.right, job.options).values;
+		job.output = CosineSimilarity(left_embedding, right_embedding);
 	});
 
 	for (auto &job : jobs) {
@@ -1897,6 +2485,7 @@ void AiEmbeddingRequestJsonFunction(DataChunk &args, ExpressionState &state, Vec
 
 	std::vector<ProviderStringJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
 		duckdb_ai::CompletionOptions options;
@@ -1909,7 +2498,7 @@ void AiEmbeddingRequestJsonFunction(DataChunk &args, ExpressionState &state, Vec
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderStringJob job;
 			job.row = row;
 			job.options = options;
@@ -1957,6 +2546,7 @@ void AiEmbedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 
 	std::vector<ProviderEmbeddingJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
 		duckdb_ai::CompletionOptions options;
@@ -1969,7 +2559,7 @@ void AiEmbedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderEmbeddingJob job;
 			job.row = row;
 			job.options = options;
@@ -1984,8 +2574,37 @@ void AiEmbedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 		}
 	}
 
-	RunProviderJobs(jobs,
-	                [&](ProviderEmbeddingJob &job) { job.output = duckdb_ai::Embed(job.input, job.options).values; });
+	auto can_batch = jobs.size() > 1;
+	for (idx_t i = 1; i < jobs.size() && can_batch; i++) {
+		can_batch = CompletionOptionsEqual(jobs[0].options, jobs[i].options);
+	}
+	if (can_batch) {
+		try {
+			std::vector<std::string> inputs;
+			inputs.reserve(jobs.size());
+			for (auto &job : jobs) {
+				inputs.push_back(job.input);
+			}
+			auto outputs = duckdb_ai::EmbedMany(inputs, jobs[0].options);
+			if (outputs.size() != jobs.size()) {
+				throw InvalidInputException("AI embedding provider returned %llu embeddings for %llu inputs",
+				                            static_cast<unsigned long long>(outputs.size()),
+				                            static_cast<unsigned long long>(jobs.size()));
+			}
+			for (idx_t i = 0; i < jobs.size(); i++) {
+				jobs[i].output = std::move(outputs[i].values);
+				jobs[i].completed = true;
+			}
+		} catch (std::exception &ex) {
+			for (auto &job : jobs) {
+				job.exception = std::current_exception();
+				job.error_message = ex.what();
+			}
+		}
+	} else {
+		RunProviderJobs(
+		    jobs, [&](ProviderEmbeddingJob &job) { job.output = duckdb_ai::Embed(job.input, job.options).values; });
+	}
 
 	for (auto &job : jobs) {
 		if (job.exception) {
@@ -2012,6 +2631,7 @@ unique_ptr<FunctionData> AiTaskBindInternal(ClientContext &context, ScalarFuncti
                                             idx_t required_args) {
 	auto bind_data = make_uniq<AiTaskBindData>(task, required_args);
 	ApplySettings(context, bind_data->options, AiModelSettingKind::TASK);
+	StampProviderFunction(bind_data->options, bound_function.name);
 	if (arguments.size() < required_args) {
 		throw BinderException("%s requires %llu argument(s)", bound_function.name, required_args);
 	}
@@ -2057,9 +2677,9 @@ unique_ptr<FunctionData> AiFixGrammarBind(ClientContext &context, ScalarFunction
 	return AiTaskBindInternal(context, bound_function, arguments, AiTaskKind::FIX_GRAMMAR, 1);
 }
 
-unique_ptr<FunctionData> AiMaskBind(ClientContext &context, ScalarFunction &bound_function,
-                                    vector<unique_ptr<Expression>> &arguments) {
-	return AiTaskBindInternal(context, bound_function, arguments, AiTaskKind::MASK, 1);
+unique_ptr<FunctionData> AiRedactBind(ClientContext &context, ScalarFunction &bound_function,
+                                      vector<unique_ptr<Expression>> &arguments) {
+	return AiTaskBindInternal(context, bound_function, arguments, AiTaskKind::REDACT, 1);
 }
 
 unique_ptr<FunctionData> AiTranslateBind(ClientContext &context, ScalarFunction &bound_function,
@@ -2069,7 +2689,29 @@ unique_ptr<FunctionData> AiTranslateBind(ClientContext &context, ScalarFunction 
 
 unique_ptr<FunctionData> AiClassifyBind(ClientContext &context, ScalarFunction &bound_function,
                                         vector<unique_ptr<Expression>> &arguments) {
-	return AiTaskBindInternal(context, bound_function, arguments, AiTaskKind::CLASSIFY, 2);
+	auto bind_data = AiTaskBindInternal(context, bound_function, arguments, AiTaskKind::CLASSIFY, 2);
+	if (arguments.size() >= 2 && arguments[1]->return_type.id() == LogicalTypeId::LIST) {
+		auto &task_bind_data = bind_data->Cast<AiTaskBindData>();
+		task_bind_data.parameter_is_label_list = true;
+		bound_function.arguments[1] = LogicalType::LIST(LogicalType::VARCHAR);
+	} else {
+		bound_function.arguments[1] = LogicalType::VARCHAR;
+	}
+	return bind_data;
+}
+
+unique_ptr<FunctionData> AiClassifyLabelsBind(ClientContext &context, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = AiTaskBindInternal(context, bound_function, arguments, AiTaskKind::CLASSIFY, 2);
+	if (arguments.size() >= 2 && arguments[1]->return_type.id() == LogicalTypeId::LIST) {
+		auto &task_bind_data = bind_data->Cast<AiTaskBindData>();
+		task_bind_data.parameter_is_label_list = true;
+		bound_function.arguments[1] = LogicalType::LIST(LogicalType::VARCHAR);
+	} else {
+		bound_function.arguments[1] = LogicalType::VARCHAR;
+	}
+	bound_function.SetReturnType(LogicalType::LIST(LogicalType::VARCHAR));
+	return bind_data;
 }
 
 unique_ptr<FunctionData> AiExtractBind(ClientContext &context, ScalarFunction &bound_function,
@@ -2088,6 +2730,7 @@ unique_ptr<FunctionData> AiPromptSqlBind(ClientContext &context, ScalarFunction 
                                          vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = make_uniq<AiPromptSqlBindData>();
 	ApplySettings(context, bind_data->options, AiModelSettingKind::SQL_ASSISTANT);
+	StampProviderFunction(bind_data->options, bound_function.name);
 	if (arguments.empty()) {
 		throw BinderException("%s requires a question argument", bound_function.name);
 	}
@@ -2158,6 +2801,7 @@ unique_ptr<FunctionData> AiAggregateBindInternal(ClientContext &context, Aggrega
                                                  vector<unique_ptr<Expression>> &arguments, AiAggregateKind kind) {
 	auto bind_data = make_uniq<AiAggregateBindData>(kind);
 	ApplySettings(context, bind_data->options, AiModelSettingKind::AGGREGATE);
+	StampProviderFunction(bind_data->options, function.name);
 	duckdb_ai::AttachProviderRuntimeState(bind_data->options, context);
 	if (arguments.empty()) {
 		throw BinderException("%s requires an input text argument", function.name);
@@ -2355,39 +2999,49 @@ struct AiAggregateOperation {
 	}
 };
 
-std::string BuildTaskPrompt(AiTaskKind task, const std::string &input, const std::string &parameter) {
+std::string BuildTaskSystemPrompt(AiTaskKind task, const std::string &parameter) {
 	switch (task) {
 	case AiTaskKind::SUMMARIZE:
-		return "Summarize the following text concisely. Return only the summary.\n\nText:\n" + input;
+		return "Summarize the following text concisely. Return only the summary.";
 	case AiTaskKind::SENTIMENT:
-		return "Classify the sentiment of the following text as positive, neutral, or negative. Return only one "
-		       "label.\n\nText:\n" +
-		       input;
+		return BuildTaskSystemPrompt(AiTaskKind::CLASSIFY, "positive, neutral, negative");
 	case AiTaskKind::FIX_GRAMMAR:
 		return "Fix grammar, spelling, and punctuation in the following text. Preserve the original meaning and "
-		       "return only the corrected text.\n\nText:\n" +
-		       input;
-	case AiTaskKind::MASK:
+		       "return only the corrected text.";
+	case AiTaskKind::REDACT:
 		return "Mask direct personal data, credentials, secrets, and payment identifiers in the following text. "
-		       "Return only the redacted text.\n\nText:\n" +
-		       input;
+		       "Return only the redacted text.";
 	case AiTaskKind::TRANSLATE:
 		return "Translate the following text to " + parameter +
-		       ". Preserve meaning and formatting. Return only the translation.\n\nText:\n" + input;
+		       ". Preserve meaning and formatting. Return only the translation.";
 	case AiTaskKind::CLASSIFY:
 		return "Classify the following text into exactly one of these labels: " + parameter +
-		       ". Return only the chosen label.\n\nText:\n" + input;
+		       ". Return only the chosen label.";
 	case AiTaskKind::EXTRACT:
 		return "Extract the requested information from the following text. Return concise JSON when the request "
-		       "asks for structured data.\n\nExtraction request:\n" +
-		       parameter + "\n\nText:\n" + input;
+		       "asks for structured data.";
 	case AiTaskKind::FILTER:
 		return "Evaluate whether the following text matches the natural-language predicate. Return only true or "
-		       "false.\n\nPredicate:\n" +
-		       parameter + "\n\nText:\n" + input;
+		       "false.";
 	default:
 		throw InternalException("Unknown AI task kind");
 	}
+}
+
+std::string BuildTaskUserPrompt(AiTaskKind task, const std::string &input, const std::string &parameter) {
+	switch (task) {
+	case AiTaskKind::EXTRACT:
+		return "Extraction request:\n" + parameter + "\n\nText:\n" + input;
+	case AiTaskKind::FILTER:
+		return "Predicate:\n" + parameter + "\n\nText:\n" + input;
+	default:
+		return "Text:\n" + input;
+	}
+}
+
+std::string BuildMultiLabelClassifySystemPrompt(const std::string &labels) {
+	return "Classify the following text into zero or more of these labels: " + labels +
+	       ". Return only a JSON array of chosen labels. Use [] when none apply.";
 }
 
 bool IsAsciiWhitespace(char c) {
@@ -2404,6 +3058,22 @@ std::string TrimAscii(const std::string &input) {
 		end--;
 	}
 	return input.substr(start, end - start);
+}
+
+std::string StripMarkdownJsonFence(const std::string &text) {
+	auto trimmed = TrimAscii(text);
+	if (trimmed.size() < 3 || trimmed.compare(0, 3, "```") != 0) {
+		return trimmed;
+	}
+	auto first_newline = trimmed.find('\n');
+	if (first_newline == std::string::npos) {
+		return trimmed;
+	}
+	auto last_fence = trimmed.rfind("```");
+	if (last_fence == std::string::npos || last_fence <= first_newline) {
+		return trimmed;
+	}
+	return TrimAscii(trimmed.substr(first_newline + 1, last_fence - first_newline - 1));
 }
 
 bool StartsWith(const std::string &input, const std::string &prefix) {
@@ -2430,7 +3100,7 @@ std::string StripMarkdownSqlFence(const std::string &input) {
 	return TrimAscii(output.substr(first_newline + 1, close_fence - first_newline - 1));
 }
 
-std::string BuildPromptSqlPrompt(const std::string &question, const std::string &schema_context) {
+std::string BuildPromptSqlSystemPrompt(const std::string &schema_context) {
 	std::string prompt =
 	    "Generate one DuckDB SQL SELECT statement for the request below.\n"
 	    "Rules:\n"
@@ -2444,6 +3114,11 @@ std::string BuildPromptSqlPrompt(const std::string &question, const std::string 
 		prompt += schema_context;
 		prompt += "\n";
 	}
+	return prompt;
+}
+
+std::string BuildPromptSqlPrompt(const std::string &question) {
+	std::string prompt;
 	prompt += "\nRequest:\n";
 	prompt += question;
 	return prompt;
@@ -2805,12 +3480,18 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto result_data = FlatVector::GetData<string_t>(result);
 	auto &result_validity = FlatVector::Validity(result);
 	StringVectorReader input_reader(args, 0);
-	auto parameter_reader = OptionalStringReader(args, bind_data.required_args == 2, 1);
+	auto parameter_reader =
+	    OptionalStringReader(args, bind_data.required_args == 2 && !bind_data.parameter_is_label_list, 1);
+	unique_ptr<StringListVectorReader> label_list_reader;
+	if (bind_data.required_args == 2 && bind_data.parameter_is_label_list) {
+		label_list_reader = make_uniq<StringListVectorReader>(args, 1);
+	}
 	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
 	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
 
 	std::vector<ProviderStringJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
 		if (!input_reader.Read(row, input)) {
@@ -2818,9 +3499,13 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 			continue;
 		}
 		std::string parameter;
-		if (bind_data.required_args == 2 && !parameter_reader->Read(row, parameter)) {
-			result_validity.SetInvalid(row);
-			continue;
+		if (bind_data.required_args == 2) {
+			auto read_parameter = bind_data.parameter_is_label_list ? label_list_reader->Read(row, parameter)
+			                                                        : parameter_reader->Read(row, parameter);
+			if (!read_parameter) {
+				result_validity.SetInvalid(row);
+				continue;
+			}
 		}
 
 		duckdb_ai::CompletionOptions options;
@@ -2831,7 +3516,7 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderStringJob job;
 			job.row = row;
 			job.options = options;
@@ -2848,12 +3533,13 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	}
 
 	RunProviderJobs(jobs, [&](ProviderStringJob &job) {
-		if (bind_data.task == AiTaskKind::MASK &&
+		if (bind_data.task == AiTaskKind::REDACT &&
 		    duckdb_ai::ResolveProvider(job.options).protocol == "privacy_filter") {
 			job.output = duckdb_ai::Redact(job.input, job.options).text;
 			return;
 		}
-		auto prompt = BuildTaskPrompt(bind_data.task, job.input, job.parameter);
+		AppendSystemPrompt(job.options, BuildTaskSystemPrompt(bind_data.task, job.parameter));
+		auto prompt = BuildTaskUserPrompt(bind_data.task, job.input, job.parameter);
 		job.output = duckdb_ai::Complete(prompt, job.options).text;
 	});
 
@@ -2870,6 +3556,90 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 			continue;
 		}
 		result_data[job.row] = StringVector::AddString(result, job.output);
+	}
+}
+
+void AiClassifyLabelsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &bind_data = func_expr.bind_info->Cast<AiTaskBindData>();
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, 0);
+	auto label_reader = OptionalStringReader(args, !bind_data.parameter_is_label_list, 1);
+	unique_ptr<StringListVectorReader> label_list_reader;
+	if (bind_data.parameter_is_label_list) {
+		label_list_reader = make_uniq<StringListVectorReader>(args, 1);
+	}
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
+
+	std::vector<ProviderStringListJob> jobs;
+	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
+	for (idx_t row = 0; row < args.size(); row++) {
+		std::string input;
+		std::string labels;
+		auto read_labels =
+		    bind_data.parameter_is_label_list ? label_list_reader->Read(row, labels) : label_reader->Read(row, labels);
+		if (!input_reader.Read(row, input) || !read_labels) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(state.GetContext(), bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+
+		try {
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
+			ProviderStringListJob job;
+			job.row = row;
+			job.options = options;
+			job.fail_on_error = options.fail_on_error;
+			job.input = std::move(input);
+			job.parameter = std::move(labels);
+			jobs.push_back(std::move(job));
+		} catch (std::exception &ex) {
+			if (options.fail_on_error) {
+				throw;
+			}
+			result_validity.SetInvalid(row);
+		}
+	}
+
+	RunProviderJobs(jobs, [&](ProviderStringListJob &job) {
+		AppendSystemPrompt(job.options, BuildMultiLabelClassifySystemPrompt(job.parameter));
+		auto prompt = BuildTaskUserPrompt(AiTaskKind::CLASSIFY, job.input, job.parameter);
+		auto output = StripMarkdownJsonFence(duckdb_ai::Complete(prompt, job.options).text);
+		std::string error;
+		if (!duckdb_ai::ExtractJsonStringArray(output, job.output, error)) {
+			throw InvalidInputException("ai_classify_labels expected a JSON array of strings: %s", error);
+		}
+	});
+
+	for (auto &job : jobs) {
+		if (job.exception) {
+			if (job.fail_on_error) {
+				std::rethrow_exception(job.exception);
+			}
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		if (!job.completed) {
+			result_validity.SetInvalid(job.row);
+			continue;
+		}
+		result_data[job.row].offset = ListVector::GetListSize(result);
+		result_data[job.row].length = job.output.size();
+		ListVector::Reserve(result, result_data[job.row].offset + job.output.size());
+		for (auto &label : job.output) {
+			ListVector::PushBack(result, Value(label));
+		}
 	}
 }
 
@@ -2903,6 +3673,7 @@ void AiFilterFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 
 	std::vector<ProviderBoolJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string input;
 		std::string predicate;
@@ -2919,7 +3690,7 @@ void AiFilterFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderBoolJob job;
 			job.row = row;
 			job.options = options;
@@ -2936,7 +3707,8 @@ void AiFilterFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	}
 
 	RunProviderJobs(jobs, [&](ProviderBoolJob &job) {
-		auto prompt = BuildTaskPrompt(bind_data.task, job.input, job.parameter);
+		AppendSystemPrompt(job.options, BuildTaskSystemPrompt(bind_data.task, job.parameter));
+		auto prompt = BuildTaskUserPrompt(bind_data.task, job.input, job.parameter);
 		auto output = duckdb_ai::Complete(prompt, job.options).text;
 		bool parsed = false;
 		if (!ParseAiBooleanResult(output, parsed)) {
@@ -3090,8 +3862,10 @@ void RequireReadOnlySql(const std::string &sql, const std::string &function_name
 
 std::string GeneratePromptSql(const std::string &question, const std::string &schema_context,
                               const duckdb_ai::CompletionOptions &options) {
-	auto prompt = BuildPromptSqlPrompt(question, schema_context);
-	auto generated_sql = StripMarkdownSqlFence(duckdb_ai::Complete(prompt, options).text);
+	auto request_options = options;
+	AppendSystemPrompt(request_options, BuildPromptSqlSystemPrompt(schema_context));
+	auto prompt = BuildPromptSqlPrompt(question);
+	auto generated_sql = StripMarkdownSqlFence(duckdb_ai::Complete(prompt, request_options).text);
 	std::string error;
 	if (!ValidateReadOnlySql(generated_sql, error)) {
 		throw InvalidInputException("AI generated SQL is not a single read-only SELECT statement: %s", error);
@@ -3099,7 +3873,7 @@ std::string GeneratePromptSql(const std::string &question, const std::string &sc
 	return generated_sql;
 }
 
-std::string BuildPromptExplainPrompt(const std::string &sql, const std::string &schema_context) {
+std::string BuildPromptExplainSystemPrompt(const std::string &schema_context) {
 	std::string prompt =
 	    "Explain the DuckDB SQL query below in plain English.\n"
 	    "Rules:\n"
@@ -3111,12 +3885,17 @@ std::string BuildPromptExplainPrompt(const std::string &sql, const std::string &
 		prompt += schema_context;
 		prompt += "\n";
 	}
+	return prompt;
+}
+
+std::string BuildPromptExplainPrompt(const std::string &sql) {
+	std::string prompt;
 	prompt += "\nSQL query:\n";
 	prompt += sql;
 	return prompt;
 }
 
-std::string BuildPromptFixupPrompt(const std::string &sql, const std::string &schema_context) {
+std::string BuildPromptFixupSystemPrompt(const std::string &schema_context) {
 	std::string prompt = "Correct the DuckDB SQL query below.\n"
 	                     "Rules:\n"
 	                     "- Return only one corrected DuckDB SQL SELECT statement.\n"
@@ -3128,6 +3907,11 @@ std::string BuildPromptFixupPrompt(const std::string &sql, const std::string &sc
 		prompt += schema_context;
 		prompt += "\n";
 	}
+	return prompt;
+}
+
+std::string BuildPromptFixupPrompt(const std::string &sql) {
+	std::string prompt;
 	prompt += "\nBroken SQL query:\n";
 	prompt += sql;
 	return prompt;
@@ -3153,8 +3937,7 @@ idx_t ExtractLineNumber(const std::string &error_message) {
 	return 1;
 }
 
-std::string BuildPromptFixLinePrompt(const std::string &sql, const std::string &error_message,
-                                     const std::string &schema_context, idx_t line_number) {
+std::string BuildPromptFixLineSystemPrompt(const std::string &schema_context) {
 	std::string prompt = "Correct one line in the DuckDB SQL query below.\n"
 	                     "Rules:\n"
 	                     "- Return only the corrected replacement line text.\n"
@@ -3165,6 +3948,11 @@ std::string BuildPromptFixLinePrompt(const std::string &sql, const std::string &
 		prompt += schema_context;
 		prompt += "\n";
 	}
+	return prompt;
+}
+
+std::string BuildPromptFixLinePrompt(const std::string &sql, const std::string &error_message, idx_t line_number) {
+	std::string prompt;
 	if (!error_message.empty()) {
 		prompt += "\nError message:\n";
 		prompt += error_message;
@@ -3177,10 +3965,33 @@ std::string BuildPromptFixLinePrompt(const std::string &sql, const std::string &
 	return prompt;
 }
 
+std::string ReplaceSqlLine(const std::string &sql, idx_t one_based_line_number, const std::string &replacement) {
+	std::string output;
+	idx_t current_line = 1;
+	size_t line_start = 0;
+	while (line_start <= sql.size()) {
+		auto line_end = sql.find('\n', line_start);
+		auto has_newline = line_end != std::string::npos;
+		auto line = sql.substr(line_start, has_newline ? line_end - line_start : std::string::npos);
+		if (!output.empty()) {
+			output += "\n";
+		}
+		output += current_line == one_based_line_number ? replacement : line;
+		if (!has_newline) {
+			break;
+		}
+		line_start = line_end + 1;
+		current_line++;
+	}
+	return output;
+}
+
 std::string GeneratePromptFixupSql(const std::string &sql, const std::string &schema_context,
                                    const duckdb_ai::CompletionOptions &options) {
-	auto prompt = BuildPromptFixupPrompt(sql, schema_context);
-	auto fixed_sql = StripMarkdownSqlFence(duckdb_ai::Complete(prompt, options).text);
+	auto request_options = options;
+	AppendSystemPrompt(request_options, BuildPromptFixupSystemPrompt(schema_context));
+	auto prompt = BuildPromptFixupPrompt(sql);
+	auto fixed_sql = StripMarkdownSqlFence(duckdb_ai::Complete(prompt, request_options).text);
 	std::string error;
 	if (!ValidateReadOnlySql(fixed_sql, error)) {
 		throw InvalidInputException("AI corrected SQL is not a single read-only SELECT statement: %s", error);
@@ -3255,9 +4066,96 @@ unique_ptr<TableRef> EmptyPromptQueryResult(const ParserOptions &options) {
 	return ParseReadOnlySubquery("SELECT NULL::VARCHAR AS ai_query_data_error WHERE FALSE", options);
 }
 
+PromptQueryCacheState &PromptQueryCache(ClientContext &context) {
+	return *ObjectCache::GetObjectCache(context).GetOrCreate<PromptQueryCacheState>(
+	    PromptQueryCacheState::ObjectType());
+}
+
+void AppendPromptQueryCacheKeyPart(std::string &key, const std::string &value) {
+	key += std::to_string(value.size());
+	key += ":";
+	key += value;
+	key += "\n";
+}
+
+void AppendPromptQueryCacheKeyPart(std::string &key, int64_t value) {
+	AppendPromptQueryCacheKeyPart(key, std::to_string(value));
+}
+
+void AppendPromptQueryCacheKeyPart(std::string &key, double value) {
+	std::ostringstream out;
+	out.precision(17);
+	out << value;
+	AppendPromptQueryCacheKeyPart(key, out.str());
+}
+
+std::string PromptQueryCacheKey(const std::string &question, const std::string &schema_context,
+                                const duckdb_ai::CompletionOptions &options) {
+	std::string key;
+	AppendPromptQueryCacheKeyPart(key, "ai_query_data_v1");
+	AppendPromptQueryCacheKeyPart(key, question);
+	AppendPromptQueryCacheKeyPart(key, schema_context);
+	AppendPromptQueryCacheKeyPart(key, options.provider);
+	AppendPromptQueryCacheKeyPart(key, options.model);
+	AppendPromptQueryCacheKeyPart(key, options.base_url);
+	AppendPromptQueryCacheKeyPart(key, options.system_prompt);
+	AppendPromptQueryCacheKeyPart(key, options.response_format);
+	AppendPromptQueryCacheKeyPart(key, options.response_schema);
+	AppendPromptQueryCacheKeyPart(key, options.has_temperature ? int64_t(1) : int64_t(0));
+	if (options.has_temperature) {
+		AppendPromptQueryCacheKeyPart(key, options.temperature);
+	}
+	AppendPromptQueryCacheKeyPart(key, options.has_max_tokens ? int64_t(1) : int64_t(0));
+	if (options.has_max_tokens) {
+		AppendPromptQueryCacheKeyPart(key, options.max_tokens);
+	}
+	return key;
+}
+
+void RemovePromptQueryCacheOrderEntry(PromptQueryCacheState &cache, const std::string &cache_key) {
+	auto entry = std::find(cache.recency_order.begin(), cache.recency_order.end(), cache_key);
+	if (entry != cache.recency_order.end()) {
+		cache.recency_order.erase(entry);
+	}
+}
+
+bool TryGetPromptQueryCachedSql(ClientContext &context, const std::string &cache_key, std::string &generated_sql) {
+	auto &cache = PromptQueryCache(context);
+	std::lock_guard<std::mutex> lock(cache.mutex);
+	auto entry = cache.generated_sql.find(cache_key);
+	if (entry == cache.generated_sql.end()) {
+		return false;
+	}
+	generated_sql = entry->second;
+	RemovePromptQueryCacheOrderEntry(cache, cache_key);
+	cache.recency_order.push_back(cache_key);
+	return true;
+}
+
+void StorePromptQueryCachedSql(ClientContext &context, const std::string &cache_key, std::string generated_sql) {
+	auto &cache = PromptQueryCache(context);
+	std::lock_guard<std::mutex> lock(cache.mutex);
+	RemovePromptQueryCacheOrderEntry(cache, cache_key);
+	cache.generated_sql[cache_key] = std::move(generated_sql);
+	cache.recency_order.push_back(cache_key);
+	while (cache.generated_sql.size() > MAX_PROMPT_QUERY_CACHE_ENTRIES && !cache.recency_order.empty()) {
+		auto oldest = std::move(cache.recency_order.front());
+		cache.recency_order.pop_front();
+		cache.generated_sql.erase(oldest);
+	}
+}
+
+void ClearPromptQueryCache(ClientContext &context) {
+	auto &cache = PromptQueryCache(context);
+	std::lock_guard<std::mutex> lock(cache.mutex);
+	cache.generated_sql.clear();
+	cache.recency_order.clear();
+}
+
 unique_ptr<TableRef> PromptQueryBindReplace(ClientContext &context, TableFunctionBindInput &input) {
 	auto options = duckdb_ai::CompletionOptions();
 	ApplySettings(context, options, AiModelSettingKind::SQL_ASSISTANT);
+	StampProviderFunction(options, "ai_query_data");
 	duckdb_ai::AttachProviderRuntimeState(options, context);
 	auto question = RequiredTableStringInput(input, 0, "question");
 	auto schema_context = OptionalTableStringInput(input, 1);
@@ -3278,7 +4176,15 @@ unique_ptr<TableRef> PromptQueryBindReplace(ClientContext &context, TableFunctio
 
 	try {
 		ApplyAiProviderSecret(context, options);
-		auto generated_sql = GeneratePromptSql(question, schema_context, options);
+		auto cache_key = PromptQueryCacheKey(question, schema_context, options);
+		std::string generated_sql;
+		if (TryGetPromptQueryCachedSql(context, cache_key, generated_sql)) {
+			duckdb_ai::RecordLocalUsageEvent(&context, "ai_query_data_cache_hit", static_cast<int64_t>(question.size()),
+			                                 static_cast<int64_t>(generated_sql.size()));
+			return ParseReadOnlySubquery(generated_sql, context.GetParserOptions());
+		}
+		generated_sql = GeneratePromptSql(question, schema_context, options);
+		StorePromptQueryCachedSql(context, cache_key, generated_sql);
 		return ParseReadOnlySubquery(generated_sql, context.GetParserOptions());
 	} catch (std::exception &ex) {
 		if (options.fail_on_error) {
@@ -3305,6 +4211,7 @@ void AiPromptSqlFunction(DataChunk &args, ExpressionState &state, Vector &result
 
 	std::vector<ProviderStringJob> jobs;
 	jobs.reserve(args.size());
+	std::vector<SecretResolutionCacheEntry> secret_cache;
 	for (idx_t row = 0; row < args.size(); row++) {
 		std::string question;
 		if (!question_reader.Read(row, question)) {
@@ -3333,7 +4240,7 @@ void AiPromptSqlFunction(DataChunk &args, ExpressionState &state, Vector &result
 		}
 
 		try {
-			ApplyAiProviderSecret(state.GetContext(), options);
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
 			ProviderStringJob job;
 			job.row = row;
 			job.options = options;
@@ -3524,9 +4431,50 @@ void ApplyPromptAssistantValueOption(PromptAssistantBindData &bind_data, PromptS
 		has_error = true;
 		return;
 	}
+	if (name == "mode") {
+		if (function_name != "ai_fix_sql") {
+			throw BinderException("%s does not support a mode option", function_name);
+		}
+		auto mode = LowerAscii(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)));
+		if (mode != "query" && mode != "full" && mode != "line") {
+			throw BinderException("%s mode must be query, full, or line", function_name);
+		}
+		return;
+	}
 	if (!ApplyCompletionValueOption(bind_data.options, function_name, name, value_p, true, false)) {
 		throw BinderException("Unsupported %s option \"%s\"", function_name, name);
 	}
+}
+
+PromptAssistantKind PromptFixSqlKindFromInput(TableFunctionBindInput &input) {
+	bool has_explicit_mode = false;
+	PromptAssistantKind kind = PromptAssistantKind::FIXUP;
+	for (auto &named_parameter : input.named_parameters) {
+		auto name = LowerAscii(named_parameter.first);
+		if (name == "mode") {
+			if (named_parameter.second.IsNull()) {
+				throw BinderException("ai_fix_sql option \"mode\" must not be NULL");
+			}
+			auto value = named_parameter.second;
+			auto mode = LowerAscii(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)));
+			if (mode == "line") {
+				kind = PromptAssistantKind::FIX_LINE;
+			} else if (mode == "query" || mode == "full") {
+				kind = PromptAssistantKind::FIXUP;
+			} else {
+				throw BinderException("ai_fix_sql mode must be query, full, or line");
+			}
+			has_explicit_mode = true;
+			continue;
+		}
+		if (!has_explicit_mode && name == "error") {
+			kind = PromptAssistantKind::FIX_LINE;
+		}
+	}
+	if (!has_explicit_mode && input.inputs.size() > 1) {
+		kind = PromptAssistantKind::FIX_LINE;
+	}
+	return kind;
 }
 
 unique_ptr<FunctionData> PromptAssistantBindInternal(ClientContext &context, TableFunctionBindInput &input,
@@ -3534,6 +4482,7 @@ unique_ptr<FunctionData> PromptAssistantBindInternal(ClientContext &context, Tab
                                                      PromptAssistantKind kind, const std::string &function_name) {
 	auto bind_data = make_uniq<PromptAssistantBindData>(kind);
 	ApplySettings(context, bind_data->options, AiModelSettingKind::SQL_ASSISTANT);
+	StampProviderFunction(bind_data->options, function_name);
 	auto max_positional_args = kind == PromptAssistantKind::FIX_LINE ? 2 : 1;
 	if (input.inputs.empty() || input.inputs.size() > max_positional_args) {
 		throw BinderException("%s expects %s", function_name,
@@ -3581,13 +4530,8 @@ unique_ptr<FunctionData> PromptExplainBind(ClientContext &context, TableFunction
 
 unique_ptr<FunctionData> PromptFixupBind(ClientContext &context, TableFunctionBindInput &input,
                                          vector<LogicalType> &return_types, vector<string> &names) {
-	return PromptAssistantBindInternal(context, input, return_types, names, PromptAssistantKind::FIXUP, "ai_fix_sql");
-}
-
-unique_ptr<FunctionData> PromptFixLineBind(ClientContext &context, TableFunctionBindInput &input,
-                                           vector<LogicalType> &return_types, vector<string> &names) {
-	return PromptAssistantBindInternal(context, input, return_types, names, PromptAssistantKind::FIX_LINE,
-	                                   "ai_fix_sql_line");
+	return PromptAssistantBindInternal(context, input, return_types, names, PromptFixSqlKindFromInput(input),
+	                                   "ai_fix_sql");
 }
 
 unique_ptr<GlobalTableFunctionState> PromptAssistantInit(ClientContext &, TableFunctionInitInput &) {
@@ -3616,7 +4560,8 @@ void PromptAssistantFunction(ClientContext &context, TableFunctionInput &input, 
 		ApplyAiProviderSecret(context, options);
 		if (bind_data.kind == PromptAssistantKind::EXPLAIN) {
 			RequireReadOnlySql(bind_data.sql, "ai_explain_sql");
-			auto prompt = BuildPromptExplainPrompt(bind_data.sql, bind_data.schema_context);
+			AppendSystemPrompt(options, BuildPromptExplainSystemPrompt(bind_data.schema_context));
+			auto prompt = BuildPromptExplainPrompt(bind_data.sql);
 			auto explanation = duckdb_ai::Complete(prompt, options).text;
 			output.SetValue(0, 0, Value(explanation));
 		} else if (bind_data.kind == PromptAssistantKind::FIXUP) {
@@ -3624,9 +4569,15 @@ void PromptAssistantFunction(ClientContext &context, TableFunctionInput &input, 
 			output.SetValue(0, 0, Value(fixed_sql));
 		} else {
 			auto line_number = ExtractLineNumber(bind_data.error_message);
-			auto prompt =
-			    BuildPromptFixLinePrompt(bind_data.sql, bind_data.error_message, bind_data.schema_context, line_number);
+			AppendSystemPrompt(options, BuildPromptFixLineSystemPrompt(bind_data.schema_context));
+			auto prompt = BuildPromptFixLinePrompt(bind_data.sql, bind_data.error_message, line_number);
 			auto replacement = StripMarkdownSqlFence(duckdb_ai::Complete(prompt, options).text);
+			std::string error;
+			if (!ValidateReadOnlySql(ReplaceSqlLine(bind_data.sql, line_number, TrimAscii(replacement)), error)) {
+				throw InvalidInputException("AI corrected SQL line does not produce a single read-only SELECT "
+				                            "statement: %s",
+				                            error);
+			}
 			output.SetValue(0, 0, Value::BIGINT(static_cast<int64_t>(line_number)));
 			output.SetValue(1, 0, Value(TrimAscii(replacement)));
 		}
@@ -3770,6 +4721,12 @@ unique_ptr<FunctionData> AiUsageBind(ClientContext &, TableFunctionBindInput &, 
 	names.emplace_back("event");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("function_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("query_id");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
 	names.emplace_back("provider");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -3800,11 +4757,29 @@ unique_ptr<FunctionData> AiUsageBind(ClientContext &, TableFunctionBindInput &, 
 	names.emplace_back("total_tokens");
 	return_types.emplace_back(LogicalType::BIGINT);
 
+	names.emplace_back("cached_prompt_tokens");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("cache_creation_prompt_tokens");
+	return_types.emplace_back(LogicalType::BIGINT);
+
 	names.emplace_back("elapsed_ms");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("retries");
 	return_types.emplace_back(LogicalType::BIGINT);
 
 	names.emplace_back("http_status");
 	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("cache_hit");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("status");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("error");
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("estimated_cost_usd");
 	return_types.emplace_back(LogicalType::DOUBLE);
@@ -3829,6 +4804,8 @@ void AiUsageFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &out
 		output.SetValue(col++, count, Value::UBIGINT(event.event_id));
 		output.SetValue(col++, count, Value(event.created_at));
 		output.SetValue(col++, count, Value(event.event));
+		output.SetValue(col++, count, event.function_name.empty() ? Value() : Value(event.function_name));
+		output.SetValue(col++, count, event.query_id.empty() ? Value() : Value(event.query_id));
 		output.SetValue(col++, count, Value(event.provider));
 		output.SetValue(col++, count, Value(event.protocol));
 		output.SetValue(col++, count, Value(event.model));
@@ -3839,8 +4816,18 @@ void AiUsageFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &out
 		output.SetValue(col++, count, Value::BIGINT(event.prompt_tokens));
 		output.SetValue(col++, count, Value::BIGINT(event.completion_tokens));
 		output.SetValue(col++, count, Value::BIGINT(event.total_tokens));
+		output.SetValue(col++, count, Value::BIGINT(event.cached_prompt_tokens));
+		output.SetValue(col++, count, Value::BIGINT(event.cache_creation_prompt_tokens));
 		output.SetValue(col++, count, Value::BIGINT(event.elapsed_ms));
+		output.SetValue(col++, count, Value::BIGINT(event.retries));
 		output.SetValue(col++, count, Value::BIGINT(event.http_status));
+		output.SetValue(col++, count, Value::BOOLEAN(event.cache_hit));
+		output.SetValue(col++, count, Value(event.status));
+		if (event.error.empty()) {
+			output.SetValue(col++, count, Value());
+		} else {
+			output.SetValue(col++, count, Value(event.error));
+		}
 		if (event.estimated_cost_usd >= 0 && std::isfinite(event.estimated_cost_usd)) {
 			output.SetValue(col++, count, Value::DOUBLE(event.estimated_cost_usd));
 		} else {
@@ -3879,6 +4866,7 @@ void AiClearCacheFunction(ClientContext &context, TableFunctionInput &data_p, Da
 		return;
 	}
 	duckdb_ai::ClearResponseCache(context);
+	ClearPromptQueryCache(context);
 	output.SetValue(0, 0, Value::BOOLEAN(true));
 	output.SetCardinality(1);
 	data.emitted = true;
@@ -3962,6 +4950,12 @@ void RegisterSettingsForPrefix(DBConfig &config, const std::string &prefix, cons
 	           LogicalType::VARCHAR, Value(""));
 	AddSetting(config, prefix + "_cache", "Cache successful AI provider responses in the current DuckDB instance",
 	           LogicalType::BOOLEAN, Value(LogicalType::BOOLEAN));
+	AddSetting(config, prefix + "_cache_ttl_seconds",
+	           "Maximum response-cache entry age in seconds between 0 and 31536000; 0 disables age expiry, -1 uses "
+	           "default",
+	           LogicalType::BIGINT, Value::BIGINT(-1));
+	AddSetting(config, prefix + "_prompt_cache", "Enable provider-side prompt caching hints when supported",
+	           LogicalType::BOOLEAN, Value(LogicalType::BOOLEAN));
 	AddSetting(config, prefix + "_response_format", "Default AI response format: text, json_object, or json_schema",
 	           LogicalType::VARCHAR, Value(""));
 	AddSetting(config, prefix + "_response_schema", "Default AI JSON schema object for structured responses",
@@ -3974,7 +4968,7 @@ void RegisterSettingsForPrefix(DBConfig &config, const std::string &prefix, cons
 	           "AI provider retry backoff in milliseconds between 0 and 60000; -1 uses default", LogicalType::BIGINT,
 	           Value::BIGINT(-1));
 	AddSetting(config, prefix + "_max_concurrent_requests",
-	           "Maximum concurrent AI provider requests between 0 and 1024; 0 disables the limit, -1 uses default",
+	           "Maximum concurrent AI provider requests between 0 and 64; 0 disables the limit, -1 uses default",
 	           LogicalType::BIGINT, Value::BIGINT(-1));
 	AddSetting(config, prefix + "_min_request_interval_ms",
 	           "Minimum milliseconds between AI provider request starts between 0 and 60000; -1 uses default",
@@ -4000,6 +4994,8 @@ void RegisterSettingsForPrefix(DBConfig &config, const std::string &prefix, cons
 	           Value(""));
 	AddSetting(config, prefix + "_log_sample_rate", "AI usage log sampling rate between 0 and 1; -1 uses default",
 	           LogicalType::DOUBLE, Value::DOUBLE(-1));
+	AddSetting(config, prefix + "_on_error", "AI error handling: fail, null, or capture", LogicalType::VARCHAR,
+	           Value(""));
 	AddSetting(config, prefix + "_log_include_text", "Include prompt and response text in AI usage logs",
 	           LogicalType::BOOLEAN, Value(LogicalType::BOOLEAN));
 	AddSetting(config, prefix + "_log_strict", "Fail SQL queries when AI usage log delivery fails",
@@ -4017,8 +5013,8 @@ void RegisterSettings(ExtensionLoader &loader) {
 	           Value(""));
 	AddSetting(config, "duckdb_ai_embedding_model", "Default AI model for embedding functions", LogicalType::VARCHAR,
 	           Value(""));
-	AddSetting(config, "duckdb_ai_sql_model", "Default AI model for SQL assistant functions", LogicalType::VARCHAR,
-	           Value(""));
+	AddSetting(config, "duckdb_ai_sql_assistant_model", "Default AI model for SQL assistant functions",
+	           LogicalType::VARCHAR, Value(""));
 }
 
 void RegisterAiProviderSecretType(ExtensionLoader &loader, const std::string &type_name) {
@@ -4048,6 +5044,27 @@ void RegisterAiProviderSecret(ExtensionLoader &loader) {
 void RegisterTaskFunction(ExtensionLoader &loader, const std::string &name, vector<LogicalType> arguments,
                           bind_scalar_function_t bind) {
 	auto function = ScalarFunction(name, std::move(arguments), LogicalType::VARCHAR, AiTaskFunction, bind);
+	function.varargs = LogicalType::ANY;
+	function.SetFallible();
+	function.SetVolatile();
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	loader.RegisterFunction(function);
+}
+
+void RegisterClassifyFunction(ExtensionLoader &loader) {
+	auto function = ScalarFunction("ai_classify", {LogicalType::VARCHAR, LogicalType::ANY}, LogicalType::VARCHAR,
+	                               AiTaskFunction, AiClassifyBind);
+	function.varargs = LogicalType::ANY;
+	function.SetFallible();
+	function.SetVolatile();
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	loader.RegisterFunction(function);
+}
+
+void RegisterClassifyLabelsFunction(ExtensionLoader &loader) {
+	auto function =
+	    ScalarFunction("ai_classify_labels", {LogicalType::VARCHAR, LogicalType::ANY},
+	                   LogicalType::LIST(LogicalType::VARCHAR), AiClassifyLabelsFunction, AiClassifyLabelsBind);
 	function.varargs = LogicalType::ANY;
 	function.SetFallible();
 	function.SetVolatile();
@@ -4151,6 +5168,8 @@ void AddCompletionNamedParameters(TableFunction &function, bool include_response
 	                                           "min_request_interval_ms",
 	                                           "token_limit_per_minute",
 	                                           "cache",
+	                                           "cache_ttl_seconds",
+	                                           "prompt_cache",
 	                                           "allowed_hosts",
 	                                           "input_token_price_per_million",
 	                                           "output_token_price_per_million",
@@ -4158,6 +5177,7 @@ void AddCompletionNamedParameters(TableFunction &function, bool include_response
 	                                           "log_format",
 	                                           "log_tags",
 	                                           "log_sample_rate",
+	                                           "on_error",
 	                                           "fail_on_error"};
 	for (auto name : completion_options) {
 		function.named_parameters[name] = OptionType(name);
@@ -4196,6 +5216,7 @@ void AddPromptAssistantNamedParameters(TableFunction &function, bool include_err
 	AddPromptQueryNamedParameters(function);
 	if (include_error) {
 		function.named_parameters["error"] = LogicalType::VARCHAR;
+		function.named_parameters["mode"] = LogicalType::VARCHAR;
 	}
 }
 
@@ -4226,6 +5247,14 @@ void RegisterAiRecordFunction(ExtensionLoader &loader) {
 		ai_complete_record.AddFunction(std::move(function));
 	}
 	loader.RegisterFunction(std::move(ai_complete_record));
+
+	auto ai_extract_record = ScalarFunction("ai_extract_record", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                        LogicalType::ANY, AiExtractRecordFunction, AiExtractRecordBind);
+	ai_extract_record.varargs = LogicalType::ANY;
+	ai_extract_record.SetFallible();
+	ai_extract_record.SetVolatile();
+	ai_extract_record.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	loader.RegisterFunction(ai_extract_record);
 }
 
 void RegisterPromptExplainFunction(ExtensionLoader &loader, const std::string &name) {
@@ -4238,24 +5267,16 @@ void RegisterPromptExplainFunction(ExtensionLoader &loader, const std::string &n
 
 void RegisterPromptFixupFunction(ExtensionLoader &loader, const std::string &name) {
 	TableFunctionSet ai_fix_sql(name);
-	TableFunction function({LogicalType::VARCHAR}, PromptAssistantFunction, PromptFixupBind, PromptAssistantInit);
-	AddPromptAssistantNamedParameters(function, false);
-	ai_fix_sql.AddFunction(std::move(function));
-	loader.RegisterFunction(std::move(ai_fix_sql));
-}
-
-void RegisterPromptFixLineFunction(ExtensionLoader &loader, const std::string &name) {
-	TableFunctionSet ai_fix_sql_line(name);
 	vector<vector<LogicalType>> overloads = {
 	    {LogicalType::VARCHAR},
 	    {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	};
 	for (auto &arguments : overloads) {
-		TableFunction function(std::move(arguments), PromptAssistantFunction, PromptFixLineBind, PromptAssistantInit);
+		TableFunction function(std::move(arguments), PromptAssistantFunction, PromptFixupBind, PromptAssistantInit);
 		AddPromptAssistantNamedParameters(function, true);
-		ai_fix_sql_line.AddFunction(std::move(function));
+		ai_fix_sql.AddFunction(std::move(function));
 	}
-	loader.RegisterFunction(std::move(ai_fix_sql_line));
+	loader.RegisterFunction(std::move(ai_fix_sql));
 }
 
 void RegisterPromptQueryFunction(ExtensionLoader &loader, const std::string &name) {
@@ -4282,7 +5303,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	RegisterCompletionFunction(loader, "ai_complete", AiCompleteBind);
 	RegisterTryCompletionFunction(loader);
-	RegisterCompletionFunction(loader, "ai_request_json", AiRequestJsonBind);
+	RegisterCompletionFunction(loader, "ai_completion_request_json", AiCompletionRequestJsonBind);
 
 	auto ai_complete_json = ScalarFunction("ai_complete_json", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                                       AiCompletionFunction, AiCompleteJsonBind);
@@ -4312,12 +5333,21 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ai_similarity.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	loader.RegisterFunction(ai_similarity);
 
+	auto ai_rerank = ScalarFunction("ai_rerank", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::DOUBLE,
+	                                AiRerankFunction, AiRerankBind);
+	ai_rerank.varargs = LogicalType::ANY;
+	ai_rerank.SetFallible();
+	ai_rerank.SetVolatile();
+	ai_rerank.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	loader.RegisterFunction(ai_rerank);
+
 	RegisterTaskFunction(loader, "ai_summarize", {LogicalType::VARCHAR}, AiSummarizeBind);
 	RegisterTaskFunction(loader, "ai_sentiment", {LogicalType::VARCHAR}, AiSentimentBind);
 	RegisterTaskFunction(loader, "ai_fix_grammar", {LogicalType::VARCHAR}, AiFixGrammarBind);
-	RegisterTaskFunction(loader, "ai_redact", {LogicalType::VARCHAR}, AiMaskBind);
+	RegisterTaskFunction(loader, "ai_redact", {LogicalType::VARCHAR}, AiRedactBind);
 	RegisterTaskFunction(loader, "ai_translate", {LogicalType::VARCHAR, LogicalType::VARCHAR}, AiTranslateBind);
-	RegisterTaskFunction(loader, "ai_classify", {LogicalType::VARCHAR, LogicalType::VARCHAR}, AiClassifyBind);
+	RegisterClassifyFunction(loader);
+	RegisterClassifyLabelsFunction(loader);
 	RegisterTaskFunction(loader, "ai_extract", {LogicalType::VARCHAR, LogicalType::VARCHAR}, AiExtractBind);
 	RegisterAiFilterFunction(loader);
 
@@ -4329,7 +5359,6 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterPromptSchemaFunction(loader, "ai_schema_prompt");
 	RegisterPromptExplainFunction(loader, "ai_explain_sql");
 	RegisterPromptFixupFunction(loader, "ai_fix_sql");
-	RegisterPromptFixLineFunction(loader, "ai_fix_sql_line");
 	RegisterPromptQueryFunction(loader, "ai_query_data");
 
 	loader.RegisterFunction(
@@ -4367,7 +5396,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    TableFunction("ai_clear_cache", {}, AiClearCacheFunction, AiClearUsageBind, AiClearUsageInit));
 	loader.RegisterFunction(TableFunction("ai_secrets", {}, AiSecretsFunction, AiSecretsBind, AiSecretsInit));
 	loader.RegisterFunction(
-	    TableFunction("ai_models", {}, AiModelPricesFunction, AiModelPricesBind, AiModelPricesInit));
+	    TableFunction("ai_model_prices", {}, AiModelPricesFunction, AiModelPricesBind, AiModelPricesInit));
 }
 
 void DuckdbAiExtension::Load(ExtensionLoader &loader) {

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -36,26 +36,57 @@ namespace duckdb_ai {
 namespace {
 
 struct HttpResponse {
-	HttpResponse() : status(0), elapsed_ms(0), retry_after_ms(-1) {
+	HttpResponse() : status(0), elapsed_ms(0), retry_after_ms(-1), retries(0), cache_hit(false) {
 	}
 
 	HttpResponse(std::string body_p, long status_p, int64_t elapsed_ms_p, long retry_after_ms_p)
-	    : body(std::move(body_p)), status(status_p), elapsed_ms(elapsed_ms_p), retry_after_ms(retry_after_ms_p) {
+	    : body(std::move(body_p)), status(status_p), elapsed_ms(elapsed_ms_p), retry_after_ms(retry_after_ms_p),
+	      retries(0), cache_hit(false) {
 	}
 
 	std::string body;
 	long status;
 	int64_t elapsed_ms;
 	long retry_after_ms;
+	int64_t retries;
+	bool cache_hit;
 };
 
+struct CachedHttpResponse {
+	HttpResponse response;
+	std::chrono::steady_clock::time_point created_at;
+};
+
+struct PendingHttpResponse {
+	std::condition_variable cv;
+	bool done = false;
+	HttpResponse response;
+	std::string error;
+};
+
+struct UsageLogJob {
+	std::string url;
+	std::string payload;
+	std::vector<std::string> headers;
+	long timeout_seconds;
+	long retry_count;
+	long retry_backoff_ms;
+};
+
+struct ProviderRuntimeState;
+void StopUsageLogWorker(ProviderRuntimeState &state);
+
 const size_t MAX_USAGE_EVENTS = 1024;
+const size_t MAX_USAGE_LOG_QUEUE = 4096;
 constexpr int64_t MAX_TOKEN_LIMIT_PER_MINUTE = 10000000000LL;
+constexpr int64_t MAX_PROVIDER_CHUNK_WORKERS = 64;
 constexpr int64_t DEFAULT_COMPLETION_OUTPUT_TOKEN_ESTIMATE = 512;
 std::once_flag curl_global_init_once;
 const size_t DEFAULT_MAX_RESPONSE_CACHE_ENTRIES = 1024;
 
 struct ProviderRuntimeState : public ObjectCacheEntry {
+	~ProviderRuntimeState();
+
 	static std::string ObjectType() {
 		return "duckdb_ai_runtime_state";
 	}
@@ -81,8 +112,16 @@ struct ProviderRuntimeState : public ObjectCacheEntry {
 	int64_t provider_token_window_tokens = 0;
 
 	std::mutex response_cache_mutex;
-	std::unordered_map<std::string, HttpResponse> response_cache;
+	std::unordered_map<std::string, CachedHttpResponse> response_cache;
 	std::deque<std::string> response_cache_order;
+	std::unordered_map<std::string, std::shared_ptr<PendingHttpResponse>> response_cache_pending;
+
+	std::mutex usage_log_mutex;
+	std::condition_variable usage_log_cv;
+	std::deque<UsageLogJob> usage_log_queue;
+	std::thread usage_log_worker;
+	bool usage_log_worker_started = false;
+	bool usage_log_shutdown = false;
 };
 
 ProviderRuntimeState fallback_runtime_state;
@@ -106,8 +145,8 @@ std::string LowerAscii(std::string input) {
 
 std::string NormalizeProviderNameInternal(const std::string &provider_input) {
 	auto provider = LowerAscii(provider_input);
-	if (provider == "anthropic") {
-		return "claude";
+	if (provider == "claude") {
+		return "anthropic";
 	}
 	if (provider == "gcp" || provider == "google" || provider == "google_gemini") {
 		return "gemini";
@@ -140,6 +179,62 @@ std::string GetEnv(const std::string &name) {
 bool EnvFlagEnabled(const std::string &name) {
 	auto value = LowerAscii(GetEnv(name));
 	return value == "1" || value == "true" || value == "yes" || value == "on";
+}
+
+bool TryReadEnvFlag(const std::string &name, bool &target) {
+	auto value = LowerAscii(GetEnv(name));
+	if (value.empty()) {
+		return false;
+	}
+	if (value == "1" || value == "true" || value == "yes" || value == "on") {
+		target = true;
+		return true;
+	}
+	if (value == "0" || value == "false" || value == "no" || value == "off") {
+		target = false;
+		return true;
+	}
+	throw InvalidInputException("%s must be a boolean", name);
+}
+
+bool TryReadEnvInt64(const std::string &name, int64_t &target, int64_t min_value, int64_t max_value) {
+	auto configured = GetEnv(name);
+	if (configured.empty()) {
+		return false;
+	}
+	try {
+		auto value = std::stoll(configured);
+		if (value < min_value || value > max_value) {
+			throw InvalidInputException("%s must be between %lld and %lld", name, static_cast<long long>(min_value),
+			                            static_cast<long long>(max_value));
+		}
+		target = value;
+		return true;
+	} catch (InvalidInputException &) {
+		throw;
+	} catch (...) {
+		throw InvalidInputException("%s must be an integer between %lld and %lld", name,
+		                            static_cast<long long>(min_value), static_cast<long long>(max_value));
+	}
+}
+
+bool TryReadEnvDouble(const std::string &name, double &target, double min_value, double max_value) {
+	auto configured = GetEnv(name);
+	if (configured.empty()) {
+		return false;
+	}
+	try {
+		auto value = std::stod(configured);
+		if (value < min_value || value > max_value) {
+			throw InvalidInputException("%s must be between %.0f and %.0f", name, min_value, max_value);
+		}
+		target = value;
+		return true;
+	} catch (InvalidInputException &) {
+		throw;
+	} catch (...) {
+		throw InvalidInputException("%s must be a number between %.0f and %.0f", name, min_value, max_value);
+	}
 }
 
 std::string TrimTrailingSlash(std::string value) {
@@ -271,6 +366,46 @@ void EnforceAllowedHost(const std::string &url, const CompletionOptions &options
 
 void EnsureCurlGlobalInit() {
 	std::call_once(curl_global_init_once, []() { curl_global_init(CURL_GLOBAL_DEFAULT); });
+}
+
+void CurlShareLock(CURL *, curl_lock_data, curl_lock_access, void *userptr) {
+	reinterpret_cast<std::mutex *>(userptr)->lock();
+}
+
+void CurlShareUnlock(CURL *, curl_lock_data, void *userptr) {
+	reinterpret_cast<std::mutex *>(userptr)->unlock();
+}
+
+struct CurlShareHandle {
+	CurlShareHandle() {
+		EnsureCurlGlobalInit();
+		handle = curl_share_init();
+		if (!handle) {
+			throw IOException("Could not initialize libcurl share handle for AI requests");
+		}
+		if (curl_share_setopt(handle, CURLSHOPT_LOCKFUNC, CurlShareLock) != CURLSHE_OK ||
+		    curl_share_setopt(handle, CURLSHOPT_UNLOCKFUNC, CurlShareUnlock) != CURLSHE_OK ||
+		    curl_share_setopt(handle, CURLSHOPT_USERDATA, &mutex) != CURLSHE_OK ||
+		    curl_share_setopt(handle, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT) != CURLSHE_OK) {
+			curl_share_cleanup(handle);
+			handle = nullptr;
+			throw IOException("Could not configure libcurl connection sharing for AI requests");
+		}
+	}
+
+	~CurlShareHandle() {
+		if (handle) {
+			curl_share_cleanup(handle);
+		}
+	}
+
+	CURLSH *handle;
+	std::mutex mutex;
+};
+
+CURLSH *SharedCurlHandle() {
+	static CurlShareHandle share;
+	return share.handle;
 }
 
 struct CurlEasyHandle {
@@ -418,6 +553,16 @@ std::string JsonDouble(double input) {
 	return out.str();
 }
 
+uint64_t StableHash(const std::string &input);
+
+std::string ExtensionUserAgent() {
+#ifdef EXT_VERSION_DUCKDB_AI
+	return std::string("duckdb_ai/") + EXT_VERSION_DUCKDB_AI;
+#else
+	return "duckdb_ai/dev";
+#endif
+}
+
 bool HasEstimatedCost(double estimated_cost_usd) {
 	return estimated_cost_usd >= 0 && std::isfinite(estimated_cost_usd);
 }
@@ -433,11 +578,11 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	    {"openai", "text-embedding-3-small", "embedding", 0.02, -1,
 	     "https://developers.openai.com/api/docs/models/text-embedding-3-small", "embedding input tokens only",
 	     "2026-06-30"},
-	    {"claude", "claude-haiku-4-5", "completion", 1.00, 5.00,
+	    {"anthropic", "claude-haiku-4-5", "completion", 1.00, 5.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-06-30"},
-	    {"claude", "claude-3-5-haiku-latest", "completion", 0.80, 4.00,
+	    {"anthropic", "claude-3-5-haiku-latest", "completion", 0.80, 4.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "legacy Haiku 3.5 pricing", "2026-06-30"},
-	    {"claude", "claude-sonnet-4-5", "completion", 3.00, 15.00,
+	    {"anthropic", "claude-sonnet-4-5", "completion", 3.00, 15.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-06-30"},
 	    {"gemini", "gemini-2.5-flash", "completion", 0.30, 2.50, "https://ai.google.dev/gemini-api/docs/pricing",
 	     "text/image/video input <= 200k tokens", "2026-06-30"},
@@ -495,7 +640,105 @@ bool ResponseCacheEnabled(const CompletionOptions &options) {
 	return EnvFlagEnabled("DUCKDB_AI_CACHE");
 }
 
-size_t MaxResponseCacheEntries() {
+bool PromptCacheEnabled(const CompletionOptions &options) {
+	if (options.has_prompt_cache) {
+		return options.prompt_cache;
+	}
+	return EnvFlagEnabled("DUCKDB_AI_PROMPT_CACHE");
+}
+
+std::string PromptCacheKey(const ProviderConfig &config, const CompletionOptions &options) {
+	std::string static_prefix;
+	if (!options.system_prompt.empty()) {
+		static_prefix += "system:";
+		static_prefix += options.system_prompt;
+	}
+	if (!options.response_schema.empty()) {
+		static_prefix += "\nschema:";
+		static_prefix += options.response_schema;
+	}
+	if (static_prefix.empty()) {
+		return "";
+	}
+	auto key_material = config.provider + "\n" + config.model + "\n" + static_prefix;
+	return "duckdb-ai-" + std::to_string(StableHash(key_material));
+}
+
+void SnapshotEnvironmentOptionsInternal(CompletionOptions &options) {
+	if (options.allowed_hosts.empty()) {
+		options.allowed_hosts = GetEnv("DUCKDB_AI_ALLOWED_HOSTS");
+	}
+	if (options.log_endpoint.empty()) {
+		options.log_endpoint = GetEnv("DUCKDB_AI_LOG_ENDPOINT");
+	}
+	if (options.log_format.empty()) {
+		options.log_format = GetEnv("DUCKDB_AI_LOG_FORMAT");
+	}
+	if (options.log_tags.empty()) {
+		options.log_tags = GetEnv("DUCKDB_AI_LOG_TAGS");
+	}
+	if (!options.has_use_builtin_model_prices &&
+	    TryReadEnvFlag("DUCKDB_AI_USE_BUILTIN_MODEL_PRICES", options.use_builtin_model_prices)) {
+		options.has_use_builtin_model_prices = true;
+	}
+	if (!options.has_cache && TryReadEnvFlag("DUCKDB_AI_CACHE", options.cache)) {
+		options.has_cache = true;
+	}
+	if (!options.has_prompt_cache && TryReadEnvFlag("DUCKDB_AI_PROMPT_CACHE", options.prompt_cache)) {
+		options.has_prompt_cache = true;
+	}
+	if (!options.has_log_include_text && TryReadEnvFlag("DUCKDB_AI_LOG_INCLUDE_TEXT", options.log_include_text)) {
+		options.has_log_include_text = true;
+	}
+	if (!options.has_log_strict && TryReadEnvFlag("DUCKDB_AI_LOG_STRICT", options.log_strict)) {
+		options.has_log_strict = true;
+	}
+	if (!options.has_timeout_seconds &&
+	    TryReadEnvInt64("DUCKDB_AI_TIMEOUT_SECONDS", options.timeout_seconds, 1, 31536000)) {
+		options.has_timeout_seconds = true;
+	}
+	if (!options.has_connect_timeout_seconds &&
+	    TryReadEnvInt64("DUCKDB_AI_CONNECT_TIMEOUT_SECONDS", options.connect_timeout_seconds, 1, 31536000)) {
+		options.has_connect_timeout_seconds = true;
+	}
+	if (!options.has_retry_count && TryReadEnvInt64("DUCKDB_AI_RETRY_COUNT", options.retry_count, 0, 10)) {
+		options.has_retry_count = true;
+	}
+	if (!options.has_retry_backoff_ms &&
+	    TryReadEnvInt64("DUCKDB_AI_RETRY_BACKOFF_MS", options.retry_backoff_ms, 0, 60000)) {
+		options.has_retry_backoff_ms = true;
+	}
+	if (!options.has_max_concurrent_requests &&
+	    TryReadEnvInt64("DUCKDB_AI_MAX_CONCURRENT_REQUESTS", options.max_concurrent_requests, 0,
+	                    MAX_PROVIDER_CHUNK_WORKERS)) {
+		options.has_max_concurrent_requests = true;
+	}
+	if (!options.has_min_request_interval_ms &&
+	    TryReadEnvInt64("DUCKDB_AI_MIN_REQUEST_INTERVAL_MS", options.min_request_interval_ms, 0, 60000)) {
+		options.has_min_request_interval_ms = true;
+	}
+	if (!options.has_token_limit_per_minute &&
+	    TryReadEnvInt64("DUCKDB_AI_TOKEN_LIMIT_PER_MINUTE", options.token_limit_per_minute, 0,
+	                    MAX_TOKEN_LIMIT_PER_MINUTE)) {
+		options.has_token_limit_per_minute = true;
+	}
+	if (!options.has_cache_ttl_seconds &&
+	    TryReadEnvInt64("DUCKDB_AI_CACHE_TTL_SECONDS", options.cache_ttl_seconds, 0, 31536000)) {
+		options.has_cache_ttl_seconds = true;
+	}
+	if (!options.has_response_cache_max_entries &&
+	    TryReadEnvInt64("DUCKDB_AI_CACHE_MAX_ENTRIES", options.response_cache_max_entries, 0, 1000000)) {
+		options.has_response_cache_max_entries = true;
+	}
+	if (!options.has_log_sample_rate && TryReadEnvDouble("DUCKDB_AI_LOG_SAMPLE_RATE", options.log_sample_rate, 0, 1)) {
+		options.has_log_sample_rate = true;
+	}
+}
+
+size_t MaxResponseCacheEntries(const CompletionOptions &options) {
+	if (options.has_response_cache_max_entries) {
+		return static_cast<size_t>(options.response_cache_max_entries);
+	}
 	auto configured = GetEnv("DUCKDB_AI_CACHE_MAX_ENTRIES");
 	if (configured.empty()) {
 		return DEFAULT_MAX_RESPONSE_CACHE_ENTRIES;
@@ -513,6 +756,35 @@ size_t MaxResponseCacheEntries() {
 	}
 }
 
+int64_t ResponseCacheTtlSeconds(const CompletionOptions &options) {
+	if (options.has_cache_ttl_seconds) {
+		return options.cache_ttl_seconds;
+	}
+	auto configured = GetEnv("DUCKDB_AI_CACHE_TTL_SECONDS");
+	if (configured.empty()) {
+		return 0;
+	}
+	try {
+		auto value = std::stoll(configured);
+		if (value < 0 || value > 31536000) {
+			throw InvalidInputException("DUCKDB_AI_CACHE_TTL_SECONDS must be between 0 and 31536000");
+		}
+		return value;
+	} catch (InvalidInputException &) {
+		throw;
+	} catch (...) {
+		throw InvalidInputException("DUCKDB_AI_CACHE_TTL_SECONDS must be an integer between 0 and 31536000");
+	}
+}
+
+bool ResponseCacheEntryExpired(const CachedHttpResponse &entry, const CompletionOptions &options) {
+	auto ttl_seconds = ResponseCacheTtlSeconds(options);
+	if (ttl_seconds <= 0) {
+		return false;
+	}
+	return std::chrono::steady_clock::now() - entry.created_at > std::chrono::seconds(ttl_seconds);
+}
+
 std::string ResponseCacheKey(const std::string &operation, const ProviderConfig &config, const std::string &endpoint,
                              const std::string &payload) {
 	auto api_key_hash =
@@ -521,32 +793,94 @@ std::string ResponseCacheKey(const std::string &operation, const ProviderConfig 
 	       api_key_hash + "\n" + payload;
 }
 
-bool TryGetCachedResponse(ProviderRuntimeState &state, const std::string &cache_key, HttpResponse &response) {
+void RemoveResponseCacheOrderEntry(ProviderRuntimeState &state, const std::string &cache_key) {
+	auto order_entry = std::find(state.response_cache_order.begin(), state.response_cache_order.end(), cache_key);
+	if (order_entry != state.response_cache_order.end()) {
+		state.response_cache_order.erase(order_entry);
+	}
+}
+
+bool TryGetCachedResponse(ProviderRuntimeState &state, const std::string &cache_key, const CompletionOptions &options,
+                          HttpResponse &response) {
 	std::lock_guard<std::mutex> lock(state.response_cache_mutex);
 	auto entry = state.response_cache.find(cache_key);
 	if (entry == state.response_cache.end()) {
 		return false;
 	}
-	response = entry->second;
+	if (ResponseCacheEntryExpired(entry->second, options)) {
+		state.response_cache.erase(entry);
+		RemoveResponseCacheOrderEntry(state, cache_key);
+		return false;
+	}
+	response = entry->second.response;
 	response.elapsed_ms = 0;
+	response.retries = 0;
+	response.cache_hit = true;
+	RemoveResponseCacheOrderEntry(state, cache_key);
+	state.response_cache_order.push_back(cache_key);
 	return true;
 }
 
-void StoreCachedResponse(ProviderRuntimeState &state, const std::string &cache_key, const HttpResponse &response) {
-	auto max_entries = MaxResponseCacheEntries();
+void StoreCachedResponse(ProviderRuntimeState &state, const std::string &cache_key, const HttpResponse &response,
+                         const CompletionOptions &options) {
+	auto max_entries = MaxResponseCacheEntries(options);
 	if (max_entries == 0) {
 		return;
 	}
 	std::lock_guard<std::mutex> lock(state.response_cache_mutex);
-	if (state.response_cache.find(cache_key) == state.response_cache.end()) {
-		state.response_cache_order.push_back(cache_key);
-	}
-	state.response_cache[cache_key] = response;
+	RemoveResponseCacheOrderEntry(state, cache_key);
+	auto stored_response = response;
+	stored_response.cache_hit = false;
+	state.response_cache_order.push_back(cache_key);
+	state.response_cache[cache_key] = {std::move(stored_response), std::chrono::steady_clock::now()};
 	while (state.response_cache.size() > max_entries && !state.response_cache_order.empty()) {
 		auto oldest = std::move(state.response_cache_order.front());
 		state.response_cache_order.pop_front();
 		state.response_cache.erase(oldest);
 	}
+}
+
+std::shared_ptr<PendingHttpResponse> BeginPendingCachedResponse(ProviderRuntimeState &state,
+                                                                const std::string &cache_key, bool &owner) {
+	std::lock_guard<std::mutex> lock(state.response_cache_mutex);
+	auto entry = state.response_cache_pending.find(cache_key);
+	if (entry != state.response_cache_pending.end()) {
+		owner = false;
+		return entry->second;
+	}
+	auto pending = std::make_shared<PendingHttpResponse>();
+	state.response_cache_pending[cache_key] = pending;
+	owner = true;
+	return pending;
+}
+
+HttpResponse WaitForPendingCachedResponse(ProviderRuntimeState &state, const std::string &cache_key,
+                                          const std::shared_ptr<PendingHttpResponse> &pending) {
+	std::unique_lock<std::mutex> lock(state.response_cache_mutex);
+	pending->cv.wait(lock, [&]() { return pending->done; });
+	if (!pending->error.empty()) {
+		throw IOException("%s", pending->error);
+	}
+	return pending->response;
+}
+
+void FinishPendingCachedResponse(ProviderRuntimeState &state, const std::string &cache_key,
+                                 const std::shared_ptr<PendingHttpResponse> &pending, const HttpResponse &response) {
+	std::lock_guard<std::mutex> lock(state.response_cache_mutex);
+	pending->response = response;
+	pending->error.clear();
+	pending->done = true;
+	state.response_cache_pending.erase(cache_key);
+	pending->cv.notify_all();
+}
+
+void FailPendingCachedResponse(ProviderRuntimeState &state, const std::string &cache_key,
+                               const std::shared_ptr<PendingHttpResponse> &pending, const std::string &error) {
+	std::lock_guard<std::mutex> lock(state.response_cache_mutex);
+	pending->error = error;
+	pending->done = true;
+	state.response_cache_pending.erase(cache_key);
+	pending->cv.notify_all();
 }
 
 enum class JsonValueType { NULL_VALUE, BOOLEAN, NUMBER, STRING, ARRAY, OBJECT };
@@ -583,6 +917,59 @@ YyjsonDocPtr ReadYyjsonDocument(const std::string &input, std::string &error) {
 
 std::string YyjsonString(duckdb_yyjson::yyjson_val *value) {
 	return std::string(duckdb_yyjson::yyjson_get_str(value), duckdb_yyjson::yyjson_get_len(value));
+}
+
+duckdb_yyjson::yyjson_val *YyjsonObjectGet(duckdb_yyjson::yyjson_val *object, const char *key) {
+	if (!object || !duckdb_yyjson::yyjson_is_obj(object)) {
+		return nullptr;
+	}
+	return duckdb_yyjson::yyjson_obj_get(object, key);
+}
+
+duckdb_yyjson::yyjson_val *YyjsonArrayGet(duckdb_yyjson::yyjson_val *array, idx_t index) {
+	if (!array || !duckdb_yyjson::yyjson_is_arr(array)) {
+		return nullptr;
+	}
+	return duckdb_yyjson::yyjson_arr_get(array, static_cast<size_t>(index));
+}
+
+bool YyjsonDirectString(duckdb_yyjson::yyjson_val *object, const char *key, std::string &result) {
+	auto value = YyjsonObjectGet(object, key);
+	if (!value || !duckdb_yyjson::yyjson_is_str(value)) {
+		return false;
+	}
+	result = YyjsonString(value);
+	return true;
+}
+
+bool YyjsonDirectInteger(duckdb_yyjson::yyjson_val *object, const char *key, int64_t &result) {
+	auto value = YyjsonObjectGet(object, key);
+	if (!value || !duckdb_yyjson::yyjson_is_int(value)) {
+		return false;
+	}
+	if (duckdb_yyjson::yyjson_is_uint(value)) {
+		auto unsigned_value = duckdb_yyjson::yyjson_get_uint(value);
+		if (unsigned_value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+			return false;
+		}
+		result = static_cast<int64_t>(unsigned_value);
+	} else {
+		result = duckdb_yyjson::yyjson_get_sint(value);
+	}
+	return true;
+}
+
+int64_t YyjsonIntegerOrMissing(duckdb_yyjson::yyjson_val *object, const char *key) {
+	int64_t result = -1;
+	YyjsonDirectInteger(object, key, result);
+	return result;
+}
+
+bool YyjsonNumericArray(duckdb_yyjson::yyjson_val *value, std::vector<double> &result);
+
+bool YyjsonDirectNumberArray(duckdb_yyjson::yyjson_val *object, const char *key, std::vector<double> &result) {
+	auto value = YyjsonObjectGet(object, key);
+	return value && YyjsonNumericArray(value, result);
 }
 
 bool ConvertYyjsonValue(duckdb_yyjson::yyjson_val *source, JsonValue &target, std::string &error) {
@@ -1029,9 +1416,25 @@ void ExtractSchemaPropertyList(const JsonValue &schema, std::vector<JsonSchemaPr
 }
 
 bool RegexMatches(const std::string &value, const std::string &pattern, const std::string &path, std::string &error) {
+	static std::mutex regex_cache_mutex;
+	static std::unordered_map<std::string, std::shared_ptr<std::regex>> regex_cache;
+	constexpr size_t max_regex_cache_entries = 256;
 	try {
-		std::regex regex(pattern);
-		return std::regex_search(value, regex);
+		std::shared_ptr<std::regex> regex;
+		{
+			std::lock_guard<std::mutex> lock(regex_cache_mutex);
+			auto entry = regex_cache.find(pattern);
+			if (entry == regex_cache.end()) {
+				if (regex_cache.size() >= max_regex_cache_entries) {
+					regex_cache.clear();
+				}
+				regex = std::make_shared<std::regex>(pattern);
+				regex_cache.emplace(pattern, regex);
+			} else {
+				regex = entry->second;
+			}
+		}
+		return std::regex_search(value, *regex);
 	} catch (std::regex_error &ex) {
 		error = path + " schema pattern is invalid: " + ex.what();
 		return false;
@@ -1465,6 +1868,35 @@ long TimeoutSeconds(const CompletionOptions &options) {
 	return static_cast<long>(options.timeout_seconds);
 }
 
+long ConnectTimeoutSeconds(long timeout_seconds) {
+	auto configured = GetEnv("DUCKDB_AI_CONNECT_TIMEOUT_SECONDS");
+	if (configured.empty()) {
+		return std::max<long>(1, std::min<long>(10, timeout_seconds));
+	}
+	try {
+		auto timeout = std::stol(configured);
+		if (timeout <= 0 || timeout > timeout_seconds) {
+			throw InvalidInputException("DUCKDB_AI_CONNECT_TIMEOUT_SECONDS must be between 1 and the total timeout");
+		}
+		return timeout;
+	} catch (InvalidInputException &) {
+		throw;
+	} catch (...) {
+		throw InvalidInputException("DUCKDB_AI_CONNECT_TIMEOUT_SECONDS must be a positive integer");
+	}
+}
+
+long ConnectTimeoutSeconds(const CompletionOptions &options, long timeout_seconds) {
+	if (!options.has_connect_timeout_seconds) {
+		return ConnectTimeoutSeconds(timeout_seconds);
+	}
+	auto connect_timeout_seconds = static_cast<long>(options.connect_timeout_seconds);
+	if (connect_timeout_seconds <= 0 || connect_timeout_seconds > timeout_seconds) {
+		throw InvalidInputException("AI connect timeout must be between 1 and the total timeout");
+	}
+	return connect_timeout_seconds;
+}
+
 long RetryCount(const CompletionOptions &options) {
 	if (options.has_retry_count) {
 		return static_cast<long>(options.retry_count);
@@ -1517,14 +1949,16 @@ int64_t MaxConcurrentRequests(const CompletionOptions &options) {
 	}
 	try {
 		auto max_concurrent_requests = std::stoll(configured);
-		if (max_concurrent_requests < 0 || max_concurrent_requests > 1024) {
-			throw InvalidInputException("DUCKDB_AI_MAX_CONCURRENT_REQUESTS must be between 0 and 1024");
+		if (max_concurrent_requests < 0 || max_concurrent_requests > MAX_PROVIDER_CHUNK_WORKERS) {
+			throw InvalidInputException("DUCKDB_AI_MAX_CONCURRENT_REQUESTS must be between 0 and %lld",
+			                            static_cast<long long>(MAX_PROVIDER_CHUNK_WORKERS));
 		}
 		return max_concurrent_requests;
 	} catch (InvalidInputException &) {
 		throw;
 	} catch (...) {
-		throw InvalidInputException("DUCKDB_AI_MAX_CONCURRENT_REQUESTS must be an integer between 0 and 1024");
+		throw InvalidInputException("DUCKDB_AI_MAX_CONCURRENT_REQUESTS must be an integer between 0 and %lld",
+		                            static_cast<long long>(MAX_PROVIDER_CHUNK_WORKERS));
 	}
 }
 
@@ -1722,7 +2156,8 @@ void SleepBeforeRetry(long retry_delay_ms, ClientContext *client_context) {
 
 HttpResponse HttpPost(const std::string &url, const std::string &payload, const std::vector<std::string> &headers,
                       long timeout_seconds, bool throw_http_errors = true, long retry_count = 0,
-                      long retry_backoff_ms = 1000, ClientContext *client_context = nullptr) {
+                      long retry_backoff_ms = 1000, ClientContext *client_context = nullptr,
+                      long connect_timeout_seconds = 0) {
 	EnsureCurlGlobalInit();
 	int64_t total_elapsed_ms = 0;
 	for (long attempt = 0; attempt <= retry_count; attempt++) {
@@ -1740,11 +2175,15 @@ HttpResponse HttpPost(const std::string &url, const std::string &payload, const 
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(payload.size()));
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+		curl_easy_setopt(curl, CURLOPT_SHARE, SharedCurlHandle());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
 		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, HeaderCallback);
 		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &header_capture);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
+		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT,
+		                 connect_timeout_seconds > 0 ? connect_timeout_seconds
+		                                             : ConnectTimeoutSeconds(timeout_seconds));
 		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
 		curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 0L);
@@ -1777,7 +2216,103 @@ HttpResponse HttpPost(const std::string &url, const std::string &payload, const 
 		if (throw_http_errors && (status < 200 || status >= 300)) {
 			throw IOException("AI provider returned HTTP %ld: %s", status, response_body);
 		}
-		return HttpResponse(response_body, status, total_elapsed_ms, header_capture.retry_after_ms);
+		auto response = HttpResponse(response_body, status, total_elapsed_ms, header_capture.retry_after_ms);
+		response.retries = attempt;
+		return response;
+	}
+	throw InternalException("AI provider retry loop exited unexpectedly");
+}
+
+void UsageLogWorkerLoop(ProviderRuntimeState *state) {
+	while (true) {
+		UsageLogJob job;
+		{
+			std::unique_lock<std::mutex> lock(state->usage_log_mutex);
+			state->usage_log_cv.wait(lock,
+			                         [&]() { return state->usage_log_shutdown || !state->usage_log_queue.empty(); });
+			if (state->usage_log_queue.empty() && state->usage_log_shutdown) {
+				return;
+			}
+			job = std::move(state->usage_log_queue.front());
+			state->usage_log_queue.pop_front();
+		}
+		try {
+			HttpPost(job.url, job.payload, job.headers, job.timeout_seconds, true, job.retry_count,
+			         job.retry_backoff_ms);
+		} catch (...) {
+			// Non-strict usage logs are best-effort and must not fail later queries from the worker thread.
+		}
+	}
+}
+
+void StartUsageLogWorkerLocked(ProviderRuntimeState &state) {
+	if (state.usage_log_worker_started) {
+		return;
+	}
+	state.usage_log_worker = std::thread(UsageLogWorkerLoop, &state);
+	state.usage_log_worker_started = true;
+}
+
+void EnqueueUsageLog(ProviderRuntimeState &state, UsageLogJob job) {
+	{
+		std::lock_guard<std::mutex> lock(state.usage_log_mutex);
+		StartUsageLogWorkerLocked(state);
+		if (state.usage_log_queue.size() >= MAX_USAGE_LOG_QUEUE) {
+			state.usage_log_queue.pop_front();
+		}
+		state.usage_log_queue.push_back(std::move(job));
+	}
+	state.usage_log_cv.notify_one();
+}
+
+void StopUsageLogWorker(ProviderRuntimeState &state) {
+	{
+		std::lock_guard<std::mutex> lock(state.usage_log_mutex);
+		state.usage_log_shutdown = true;
+	}
+	state.usage_log_cv.notify_all();
+	if (state.usage_log_worker_started && state.usage_log_worker.joinable()) {
+		state.usage_log_worker.join();
+	}
+}
+
+ProviderRuntimeState::~ProviderRuntimeState() {
+	StopUsageLogWorker(*this);
+}
+
+HttpResponse ProviderHttpPost(const std::string &url, const std::string &payload,
+                              const std::vector<std::string> &headers, const CompletionOptions &options,
+                              int64_t estimated_tokens) {
+	auto retry_count = RetryCount(options);
+	auto retry_backoff_ms = RetryBackoffMs(options);
+	auto timeout_seconds = TimeoutSeconds(options);
+	auto connect_timeout_seconds = ConnectTimeoutSeconds(options, timeout_seconds);
+	int64_t total_elapsed_ms = 0;
+	for (long attempt = 0; attempt <= retry_count; attempt++) {
+		try {
+			HttpResponse response;
+			{
+				ProviderRequestGuard request_guard(options, estimated_tokens);
+				response = HttpPost(url, payload, headers, timeout_seconds, false, 0, retry_backoff_ms,
+				                    options.client_context, connect_timeout_seconds);
+			}
+			total_elapsed_ms += response.elapsed_ms;
+			response.elapsed_ms = total_elapsed_ms;
+			response.retries = attempt;
+			if (attempt < retry_count && IsRetryableHttpStatus(response.status)) {
+				SleepBeforeRetry(RetryDelayMs(retry_backoff_ms, attempt, response.retry_after_ms),
+				                 options.client_context);
+				continue;
+			}
+			return response;
+		} catch (InterruptException &) {
+			throw;
+		} catch (std::exception &) {
+			if (attempt >= retry_count) {
+				throw;
+			}
+			SleepBeforeRetry(RetryDelayMs(retry_backoff_ms, attempt, -1), options.client_context);
+		}
 	}
 	throw InternalException("AI provider retry loop exited unexpectedly");
 }
@@ -1909,10 +2444,10 @@ ProviderConfig ProviderDefaults(const std::string &provider_input) {
 		        "",
 		        true};
 	}
-	if (provider == "claude" || provider == "anthropic") {
-		return {"claude",
+	if (provider == "anthropic" || provider == "claude") {
+		return {"anthropic",
 		        "anthropic_messages",
-		        "claude-3-5-haiku-latest",
+		        "claude-haiku-4-5",
 		        "",
 		        "https://api.anthropic.com/v1",
 		        "ANTHROPIC_API_KEY",
@@ -1923,10 +2458,11 @@ ProviderConfig ProviderDefaults(const std::string &provider_input) {
 		return {provider, "ollama_chat", "llama3.2", "", "http://localhost:11434", "OLLAMA_API_KEY", "", false};
 	}
 
-	throw InvalidInputException("Unsupported AI provider \"%s\". Supported providers: ollama, openai, azure, claude, "
-	                            "anthropic, databricks, gemini, gcp, mistral, snowflake, zai, deepseek, openrouter, "
-	                            "openai_privacy_filter, openai_compatible, local",
-	                            provider_input);
+	throw InvalidInputException(
+	    "Unsupported AI provider \"%s\". Supported providers: ollama, openai, azure, "
+	    "anthropic, claude, databricks, gemini, gcp, mistral, snowflake, zai, deepseek, openrouter, "
+	    "openai_privacy_filter, openai_compatible, local",
+	    provider_input);
 }
 
 std::string ResolveBaseUrl(const ProviderConfig &config) {
@@ -1954,6 +2490,12 @@ std::string ResolveBaseUrl(const ProviderConfig &config) {
 		       : config.provider == "databricks" ? DatabricksBaseUrl(generic_base_url)
 		       : config.provider == "snowflake"  ? SnowflakeCortexBaseUrl(generic_base_url)
 		                                         : TrimTrailingSlash(generic_base_url);
+	}
+	if (config.provider == "anthropic") {
+		auto claude_base_url = GetEnv("CLAUDE_BASE_URL");
+		if (!claude_base_url.empty()) {
+			return TrimTrailingSlash(claude_base_url);
+		}
 	}
 	if (config.provider == "databricks") {
 		auto databricks_host = GetEnv("DATABRICKS_HOST");
@@ -2000,7 +2542,7 @@ std::string ResolveApiKey(const ProviderConfig &config) {
 	if (!generic_key.empty()) {
 		return generic_key;
 	}
-	if (config.provider == "claude") {
+	if (config.provider == "anthropic") {
 		auto claude_key = GetEnv("CLAUDE_API_KEY");
 		if (!claude_key.empty()) {
 			return claude_key;
@@ -2047,6 +2589,12 @@ std::string ResolveModel(const ProviderConfig &config, const std::string &model_
 	}
 	if (!generic_model.empty()) {
 		return generic_model;
+	}
+	if (config.provider == "anthropic") {
+		auto claude_model = GetEnv("CLAUDE_MODEL");
+		if (!claude_model.empty()) {
+			return claude_model;
+		}
 	}
 	return config.default_model;
 }
@@ -2186,14 +2734,25 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 	if (config.protocol == "anthropic_messages") {
 		ValidateResponseSchema(options);
 		auto format = NormalizeResponseFormat(options);
+		if (!options.response_schema.empty()) {
+			throw InvalidInputException(
+			    "AI option \"response_schema\" is not supported for provider \"%s\". Use an OpenAI-compatible or "
+			    "Ollama provider for enforced JSON Schema output.",
+			    config.provider);
+		}
 		if (format == "json_schema" && options.response_schema.empty()) {
 			throw InvalidInputException(
 			    "AI option \"response_schema\" must be provided when response_format is json_schema");
 		}
-		auto max_tokens = options.has_max_tokens ? options.max_tokens : 1024;
+		auto max_tokens = options.has_max_tokens ? options.max_tokens : 4096;
 		auto payload = "{\"model\":\"" + escaped_model + "\",\"max_tokens\":" + std::to_string(max_tokens);
 		if (!options.system_prompt.empty()) {
-			payload += ",\"system\":\"" + JsonEscape(options.system_prompt) + "\"";
+			if (PromptCacheEnabled(options)) {
+				payload += ",\"system\":[{\"type\":\"text\",\"text\":\"" + JsonEscape(options.system_prompt) +
+				           "\",\"cache_control\":{\"type\":\"ephemeral\"}}]";
+			} else {
+				payload += ",\"system\":\"" + JsonEscape(options.system_prompt) + "\"";
+			}
 		}
 		if (options.has_temperature) {
 			payload += ",\"temperature\":" + JsonDouble(options.temperature);
@@ -2236,6 +2795,12 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 	auto response_format = OpenAIResponseFormatJson(options);
 	if (!response_format.empty()) {
 		payload += "," + response_format;
+	}
+	if (config.provider == "openai" && PromptCacheEnabled(options)) {
+		auto prompt_cache_key = PromptCacheKey(config, options);
+		if (!prompt_cache_key.empty()) {
+			payload += ",\"prompt_cache_key\":\"" + JsonEscape(prompt_cache_key) + "\"";
+		}
 	}
 	payload += "}";
 	return payload;
@@ -2298,6 +2863,21 @@ std::string EmbeddingPayload(const ProviderConfig &config, const std::string &in
 	return "{\"model\":\"" + JsonEscape(config.model) + "\",\"input\":\"" + JsonEscape(input) + "\"}";
 }
 
+std::string EmbeddingPayload(const ProviderConfig &config, const std::vector<std::string> &inputs) {
+	if (inputs.size() == 1) {
+		return EmbeddingPayload(config, inputs[0]);
+	}
+	std::string payload = "{\"model\":\"" + JsonEscape(config.model) + "\",\"input\":[";
+	for (idx_t i = 0; i < inputs.size(); i++) {
+		if (i > 0) {
+			payload += ",";
+		}
+		payload += "\"" + JsonEscape(inputs[i]) + "\"";
+	}
+	payload += "]}";
+	return payload;
+}
+
 std::vector<double> FindEmbeddingArray(const std::string &body, const std::string &key) {
 	std::string error;
 	auto doc = ReadYyjsonDocument(body, error);
@@ -2309,6 +2889,44 @@ std::vector<double> FindEmbeddingArray(const std::string &body, const std::strin
 		return values;
 	}
 	return {};
+}
+
+std::vector<std::vector<double>> ParseEmbeddingArrays(const ProviderConfig &config, const std::string &body) {
+	std::string error;
+	auto doc = ReadYyjsonDocument(body, error);
+	if (!doc) {
+		return {};
+	}
+	auto root = duckdb_yyjson::yyjson_doc_get_root(doc.get());
+	std::vector<std::vector<double>> embeddings;
+	if (config.protocol == "ollama_embed") {
+		auto embedding_values = YyjsonObjectGet(root, "embeddings");
+		if (duckdb_yyjson::yyjson_is_arr(embedding_values)) {
+			duckdb_yyjson::yyjson_val *entry;
+			size_t index;
+			size_t max;
+			yyjson_arr_foreach(embedding_values, index, max, entry) {
+				std::vector<double> values;
+				if (YyjsonNumericArray(entry, values)) {
+					embeddings.push_back(std::move(values));
+				}
+			}
+		}
+		return embeddings;
+	}
+	auto data = YyjsonObjectGet(root, "data");
+	if (duckdb_yyjson::yyjson_is_arr(data)) {
+		duckdb_yyjson::yyjson_val *entry;
+		size_t index;
+		size_t max;
+		yyjson_arr_foreach(data, index, max, entry) {
+			std::vector<double> values;
+			if (YyjsonDirectNumberArray(entry, "embedding", values)) {
+				embeddings.push_back(std::move(values));
+			}
+		}
+	}
+	return embeddings;
 }
 
 EmbeddingResult ParseEmbeddingResult(const ProviderConfig &config, const HttpResponse &response) {
@@ -2323,13 +2941,55 @@ EmbeddingResult ParseEmbeddingResult(const ProviderConfig &config, const HttpRes
 	result.raw_response = response.body;
 	result.http_status = response.status;
 	result.elapsed_ms = response.elapsed_ms;
+	result.retries = response.retries;
+	result.cache_hit = response.cache_hit;
 	result.prompt_tokens = FindJsonIntegerValue(response.body, "prompt_tokens");
 	result.total_tokens = FindJsonIntegerValue(response.body, "total_tokens");
 	return result;
 }
 
+std::vector<EmbeddingResult> ParseEmbeddingResults(const ProviderConfig &config, const HttpResponse &response,
+                                                   idx_t expected_count) {
+	auto values = ParseEmbeddingArrays(config, response.body);
+	if (values.size() != expected_count) {
+		if (expected_count == 1) {
+			return {ParseEmbeddingResult(config, response)};
+		}
+		throw IOException("AI provider embedding response returned %llu embeddings for %llu inputs",
+		                  static_cast<unsigned long long>(values.size()),
+		                  static_cast<unsigned long long>(expected_count));
+	}
+	auto prompt_tokens = FindJsonIntegerValue(response.body, "prompt_tokens");
+	auto total_tokens = FindJsonIntegerValue(response.body, "total_tokens");
+	std::vector<EmbeddingResult> results;
+	results.reserve(values.size());
+	for (idx_t i = 0; i < values.size(); i++) {
+		EmbeddingResult result;
+		result.values = std::move(values[i]);
+		result.raw_response = response.body;
+		result.http_status = response.status;
+		result.elapsed_ms = response.elapsed_ms;
+		result.retries = response.retries;
+		result.cache_hit = response.cache_hit;
+		if (prompt_tokens >= 0) {
+			result.prompt_tokens = static_cast<int64_t>(
+			    std::ceil(static_cast<double>(prompt_tokens) / static_cast<double>(std::max<idx_t>(1, values.size()))));
+		} else {
+			result.prompt_tokens = -1;
+		}
+		if (total_tokens >= 0) {
+			result.total_tokens = static_cast<int64_t>(
+			    std::ceil(static_cast<double>(total_tokens) / static_cast<double>(std::max<idx_t>(1, values.size()))));
+		} else {
+			result.total_tokens = -1;
+		}
+		results.push_back(std::move(result));
+	}
+	return results;
+}
+
 std::vector<std::string> RequestHeaders(const ProviderConfig &config) {
-	std::vector<std::string> headers {"Content-Type: application/json"};
+	std::vector<std::string> headers {"Content-Type: application/json", "User-Agent: " + ExtensionUserAgent()};
 	if (config.protocol == "anthropic_messages") {
 		headers.push_back("anthropic-version: 2023-06-01");
 		headers.push_back("x-api-key: " + config.api_key);
@@ -2359,6 +3019,47 @@ std::vector<std::string> RequestHeaders(const ProviderConfig &config) {
 
 std::string ExtractCompletionText(const ProviderConfig &config, const std::string &body) {
 	std::string value;
+	std::string error;
+	auto doc = ReadYyjsonDocument(body, error);
+	if (doc) {
+		auto root = duckdb_yyjson::yyjson_doc_get_root(doc.get());
+		if (config.protocol == "privacy_filter") {
+			if (YyjsonDirectString(root, "redacted_text", value) || YyjsonDirectString(root, "masked_text", value) ||
+			    YyjsonDirectString(root, "text", value) || YyjsonDirectString(root, "output", value)) {
+				return value;
+			}
+		} else if (config.protocol == "anthropic_messages") {
+			auto content = YyjsonObjectGet(root, "content");
+			if (duckdb_yyjson::yyjson_is_arr(content)) {
+				duckdb_yyjson::yyjson_val *entry;
+				size_t index;
+				size_t max;
+				yyjson_arr_foreach(content, index, max, entry) {
+					std::string type;
+					if (YyjsonDirectString(entry, "type", type) && type != "text") {
+						continue;
+					}
+					if (YyjsonDirectString(entry, "text", value)) {
+						return value;
+					}
+				}
+			}
+		} else if (config.protocol == "ollama_chat") {
+			auto message = YyjsonObjectGet(root, "message");
+			if (YyjsonDirectString(message, "content", value)) {
+				return value;
+			}
+		} else {
+			auto first_choice = YyjsonArrayGet(YyjsonObjectGet(root, "choices"), 0);
+			auto message = YyjsonObjectGet(first_choice, "message");
+			if (YyjsonDirectString(message, "content", value)) {
+				return value;
+			}
+			if (YyjsonDirectString(message, "refusal", value)) {
+				throw IOException("AI provider response contained a refusal instead of completion text: %s", value);
+			}
+		}
+	}
 	if (config.protocol == "privacy_filter") {
 		if (FindJsonStringValue(body, "redacted_text", value) || FindJsonStringValue(body, "masked_text", value) ||
 		    FindJsonStringValue(body, "text", value) || FindJsonStringValue(body, "output", value)) {
@@ -2380,29 +3081,62 @@ CompletionResult ParseCompletionResult(const ProviderConfig &config, const HttpR
 	result.raw_response = response.body;
 	result.http_status = response.status;
 	result.elapsed_ms = response.elapsed_ms;
-	result.prompt_tokens = FindJsonIntegerValue(response.body, "prompt_tokens");
-	result.completion_tokens = FindJsonIntegerValue(response.body, "completion_tokens");
-	result.total_tokens = FindJsonIntegerValue(response.body, "total_tokens");
+	result.retries = response.retries;
+	result.cache_hit = response.cache_hit;
+	result.prompt_tokens = -1;
+	result.completion_tokens = -1;
+	result.total_tokens = -1;
+	result.cached_prompt_tokens = -1;
+	result.cache_creation_prompt_tokens = -1;
 
+	std::string error;
+	auto doc = ReadYyjsonDocument(response.body, error);
+	auto root = doc ? duckdb_yyjson::yyjson_doc_get_root(doc.get()) : nullptr;
 	if (config.protocol == "anthropic_messages") {
-		result.prompt_tokens = FindJsonIntegerValue(response.body, "input_tokens");
-		result.completion_tokens = FindJsonIntegerValue(response.body, "output_tokens");
+		auto usage = YyjsonObjectGet(root, "usage");
+		result.prompt_tokens = YyjsonIntegerOrMissing(usage, "input_tokens");
+		result.completion_tokens = YyjsonIntegerOrMissing(usage, "output_tokens");
+		result.cached_prompt_tokens = YyjsonIntegerOrMissing(usage, "cache_read_input_tokens");
+		result.cache_creation_prompt_tokens = YyjsonIntegerOrMissing(usage, "cache_creation_input_tokens");
 		if (result.prompt_tokens >= 0 && result.completion_tokens >= 0) {
 			result.total_tokens = result.prompt_tokens + result.completion_tokens;
 		}
+		YyjsonDirectString(root, "stop_reason", result.finish_reason);
+		if (result.finish_reason == "max_tokens") {
+			throw IOException("AI provider response stopped because max_tokens was reached; raise max_tokens or "
+			                  "request a shorter response");
+		}
+		return result;
 	}
 	if (config.protocol == "ollama_chat") {
-		result.prompt_tokens = FindJsonIntegerValue(response.body, "prompt_eval_count");
-		result.completion_tokens = FindJsonIntegerValue(response.body, "eval_count");
+		result.prompt_tokens = YyjsonIntegerOrMissing(root, "prompt_eval_count");
+		result.completion_tokens = YyjsonIntegerOrMissing(root, "eval_count");
 		if (result.prompt_tokens >= 0 && result.completion_tokens >= 0) {
 			result.total_tokens = result.prompt_tokens + result.completion_tokens;
 		}
+		YyjsonDirectString(root, "done_reason", result.finish_reason);
+		return result;
+	}
+	auto usage = YyjsonObjectGet(root, "usage");
+	result.prompt_tokens = YyjsonIntegerOrMissing(usage, "prompt_tokens");
+	result.completion_tokens = YyjsonIntegerOrMissing(usage, "completion_tokens");
+	result.total_tokens = YyjsonIntegerOrMissing(usage, "total_tokens");
+	auto prompt_token_details = YyjsonObjectGet(usage, "prompt_tokens_details");
+	result.cached_prompt_tokens = YyjsonIntegerOrMissing(prompt_token_details, "cached_tokens");
+	auto first_choice = YyjsonArrayGet(YyjsonObjectGet(root, "choices"), 0);
+	YyjsonDirectString(first_choice, "finish_reason", result.finish_reason);
+	if (result.finish_reason == "length") {
+		throw IOException("AI provider response stopped because max_tokens was reached; raise max_tokens or request a "
+		                  "shorter response");
 	}
 	return result;
 }
 
 double EstimateCompletionCostUsd(const ProviderConfig &config, const CompletionOptions &options,
                                  const CompletionResult &result) {
+	if (result.cache_hit) {
+		return 0;
+	}
 	auto has_input_price = options.has_input_token_price_per_million;
 	auto input_price = options.input_token_price_per_million;
 	auto has_output_price = options.has_output_token_price_per_million;
@@ -2423,14 +3157,25 @@ double EstimateCompletionCostUsd(const ProviderConfig &config, const CompletionO
 	if (!has_input_price || !has_output_price || result.prompt_tokens < 0 || result.completion_tokens < 0) {
 		return -1;
 	}
-	auto cost = (static_cast<double>(result.prompt_tokens) * input_price +
-	             static_cast<double>(result.completion_tokens) * output_price) /
-	            1000000.0;
+	auto cached_prompt_tokens = std::max<int64_t>(0, result.cached_prompt_tokens);
+	auto cache_creation_prompt_tokens = std::max<int64_t>(0, result.cache_creation_prompt_tokens);
+	auto billable_prompt_tokens =
+	    std::max<int64_t>(0, result.prompt_tokens - cached_prompt_tokens - cache_creation_prompt_tokens);
+	auto cached_input_multiplier = config.protocol == "anthropic_messages" ? 0.1 : 0.5;
+	auto cache_creation_multiplier = config.protocol == "anthropic_messages" ? 1.25 : 1.0;
+	auto input_cost = static_cast<double>(billable_prompt_tokens) * input_price;
+	input_cost += static_cast<double>(cached_prompt_tokens) * input_price * cached_input_multiplier;
+	input_cost += static_cast<double>(cache_creation_prompt_tokens) * input_price * cache_creation_multiplier;
+	auto output_cost = static_cast<double>(result.completion_tokens) * output_price;
+	auto cost = (input_cost + output_cost) / 1000000.0;
 	return HasEstimatedCost(cost) ? cost : -1;
 }
 
 double EstimateEmbeddingCostUsd(const ProviderConfig &config, const CompletionOptions &options,
                                 const EmbeddingResult &result) {
+	if (result.cache_hit) {
+		return 0;
+	}
 	auto has_input_price = options.has_input_token_price_per_million;
 	auto input_price = options.input_token_price_per_million;
 	if (BuiltinModelPricingEnabled(options)) {
@@ -2462,6 +3207,8 @@ void RecordUsageEvent(const ProviderConfig &config, const std::string &prompt, c
 	UsageEvent event;
 	event.created_at = CurrentTimestamp();
 	event.event = "ai_completion";
+	event.function_name = options.function_name;
+	event.query_id = options.query_id;
 	event.provider = config.provider;
 	event.protocol = config.protocol;
 	event.model = config.model;
@@ -2472,9 +3219,44 @@ void RecordUsageEvent(const ProviderConfig &config, const std::string &prompt, c
 	event.prompt_tokens = result.prompt_tokens;
 	event.completion_tokens = result.completion_tokens;
 	event.total_tokens = result.total_tokens;
+	event.cached_prompt_tokens = result.cached_prompt_tokens;
+	event.cache_creation_prompt_tokens = result.cache_creation_prompt_tokens;
 	event.elapsed_ms = result.elapsed_ms;
+	event.retries = result.retries;
 	event.http_status = result.http_status;
+	event.cache_hit = result.cache_hit;
+	event.status = "ok";
+	event.error = "";
 	event.estimated_cost_usd = EstimateCompletionCostUsd(config, options, result);
+	PushUsageEvent(RuntimeState(options), std::move(event));
+}
+
+void RecordFailedUsageEvent(const ProviderConfig &config, const std::string &prompt, const CompletionOptions &options,
+                            long http_status, const std::string &error, int64_t retries) {
+	UsageEvent event;
+	event.created_at = CurrentTimestamp();
+	event.event = "ai_completion";
+	event.function_name = options.function_name;
+	event.query_id = options.query_id;
+	event.provider = config.provider;
+	event.protocol = config.protocol;
+	event.model = config.model;
+	event.prompt_chars = static_cast<int64_t>(prompt.size());
+	event.response_chars = 0;
+	event.input_chars = -1;
+	event.dimensions = -1;
+	event.prompt_tokens = -1;
+	event.completion_tokens = -1;
+	event.total_tokens = -1;
+	event.cached_prompt_tokens = -1;
+	event.cache_creation_prompt_tokens = -1;
+	event.elapsed_ms = -1;
+	event.retries = retries;
+	event.http_status = http_status;
+	event.cache_hit = false;
+	event.status = "error";
+	event.error = error;
+	event.estimated_cost_usd = -1;
 	PushUsageEvent(RuntimeState(options), std::move(event));
 }
 
@@ -2483,6 +3265,8 @@ void RecordEmbeddingUsageEvent(const ProviderConfig &config, const std::string &
 	UsageEvent event;
 	event.created_at = CurrentTimestamp();
 	event.event = "ai_embedding";
+	event.function_name = options.function_name;
+	event.query_id = options.query_id;
 	event.provider = config.provider;
 	event.protocol = config.protocol;
 	event.model = config.model;
@@ -2493,9 +3277,45 @@ void RecordEmbeddingUsageEvent(const ProviderConfig &config, const std::string &
 	event.prompt_tokens = result.prompt_tokens;
 	event.completion_tokens = -1;
 	event.total_tokens = result.total_tokens;
+	event.cached_prompt_tokens = -1;
+	event.cache_creation_prompt_tokens = -1;
 	event.elapsed_ms = result.elapsed_ms;
+	event.retries = result.retries;
 	event.http_status = result.http_status;
+	event.cache_hit = result.cache_hit;
+	event.status = "ok";
+	event.error = "";
 	event.estimated_cost_usd = EstimateEmbeddingCostUsd(config, options, result);
+	PushUsageEvent(RuntimeState(options), std::move(event));
+}
+
+void RecordFailedEmbeddingUsageEvent(const ProviderConfig &config, const std::string &input,
+                                     const CompletionOptions &options, long http_status, const std::string &error,
+                                     int64_t retries) {
+	UsageEvent event;
+	event.created_at = CurrentTimestamp();
+	event.event = "ai_embedding";
+	event.function_name = options.function_name;
+	event.query_id = options.query_id;
+	event.provider = config.provider;
+	event.protocol = config.protocol;
+	event.model = config.model;
+	event.prompt_chars = static_cast<int64_t>(input.size());
+	event.response_chars = 0;
+	event.input_chars = static_cast<int64_t>(input.size());
+	event.dimensions = -1;
+	event.prompt_tokens = -1;
+	event.completion_tokens = -1;
+	event.total_tokens = -1;
+	event.cached_prompt_tokens = -1;
+	event.cache_creation_prompt_tokens = -1;
+	event.elapsed_ms = -1;
+	event.retries = retries;
+	event.http_status = http_status;
+	event.cache_hit = false;
+	event.status = "error";
+	event.error = error;
+	event.estimated_cost_usd = -1;
 	PushUsageEvent(RuntimeState(options), std::move(event));
 }
 
@@ -2553,7 +3373,36 @@ std::string LogFormat(const CompletionOptions &options) {
 	if (format == "otlp" || format == "otlp_json") {
 		return "otlp_json";
 	}
-	throw InvalidInputException("DUCKDB_AI_LOG_FORMAT must be one of: generic_json, otlp_json");
+	throw InvalidInputException("DUCKDB_AI_LOG_FORMAT must be one of: generic, json, generic_json, otlp, otlp_json");
+}
+
+bool LogStrict(const CompletionOptions &options) {
+	return options.has_log_strict ? options.log_strict : EnvFlagEnabled("DUCKDB_AI_LOG_STRICT");
+}
+
+void SubmitUsageLog(const CompletionOptions &options, const std::string &log_endpoint, std::string payload,
+                    const std::string &error_prefix) {
+	auto log_strict = LogStrict(options);
+	try {
+		EnforceAllowedHost(log_endpoint, options);
+		if (log_strict) {
+			HttpPost(log_endpoint, payload, {"Content-Type: application/json"}, TimeoutSeconds(options), true,
+			         RetryCount(options), RetryBackoffMs(options), options.client_context);
+			return;
+		}
+		UsageLogJob job;
+		job.url = log_endpoint;
+		job.payload = std::move(payload);
+		job.headers = {"Content-Type: application/json"};
+		job.timeout_seconds = TimeoutSeconds(options);
+		job.retry_count = RetryCount(options);
+		job.retry_backoff_ms = RetryBackoffMs(options);
+		EnqueueUsageLog(RuntimeState(options), std::move(job));
+	} catch (std::exception &ex) {
+		if (log_strict) {
+			throw IOException("%s: %s", error_prefix, ex.what());
+		}
+	}
 }
 
 void AppendJsonAttribute(std::string &payload, bool &wrote, const std::string &attribute) {
@@ -2576,14 +3425,20 @@ std::string OtlpDoubleAttribute(const std::string &key, double value) {
 	return "{\"key\":\"" + JsonEscape(key) + "\",\"value\":{\"doubleValue\":" + JsonDouble(value) + "}}";
 }
 
-std::string OtlpLogPayload(const std::string &event, const std::string &provider, const std::string &protocol,
-                           const std::string &model, const std::string &log_tags, const std::string &text_name,
-                           const std::string &text_value, const std::string &extra_text_name,
-                           const std::string &extra_text_value, bool include_text,
+std::string OtlpLogPayload(const std::string &event, const std::string &function_name, const std::string &query_id,
+                           const std::string &provider, const std::string &protocol, const std::string &model,
+                           const std::string &log_tags, const std::string &text_name, const std::string &text_value,
+                           const std::string &extra_text_name, const std::string &extra_text_value, bool include_text,
                            const std::vector<std::pair<std::string, int64_t>> &metrics, double estimated_cost_usd) {
 	std::string attributes;
 	bool wrote_attribute = false;
 	AppendJsonAttribute(attributes, wrote_attribute, OtlpStringAttribute("ai.event", event));
+	if (!function_name.empty()) {
+		AppendJsonAttribute(attributes, wrote_attribute, OtlpStringAttribute("ai.function_name", function_name));
+	}
+	if (!query_id.empty()) {
+		AppendJsonAttribute(attributes, wrote_attribute, OtlpStringAttribute("ai.query_id", query_id));
+	}
 	AppendJsonAttribute(attributes, wrote_attribute, OtlpStringAttribute("ai.provider", provider));
 	AppendJsonAttribute(attributes, wrote_attribute, OtlpStringAttribute("ai.protocol", protocol));
 	AppendJsonAttribute(attributes, wrote_attribute, OtlpStringAttribute("ai.model", model));
@@ -2633,22 +3488,31 @@ void MaybePostUsageLog(const ProviderConfig &config, const std::string &prompt, 
 		    {"ai.prompt_tokens", result.prompt_tokens},
 		    {"ai.completion_tokens", result.completion_tokens},
 		    {"ai.total_tokens", result.total_tokens},
+		    {"ai.cached_prompt_tokens", result.cached_prompt_tokens},
+		    {"ai.cache_creation_prompt_tokens", result.cache_creation_prompt_tokens},
 		    {"ai.elapsed_ms", result.elapsed_ms},
+		    {"ai.retries", result.retries},
 		    {"http.status_code", result.http_status},
 		};
-		payload = OtlpLogPayload("ai_completion", config.provider, config.protocol, config.model, log_tags, "ai.prompt",
-		                         prompt, "ai.response", result.text, include_text, metrics, estimated_cost_usd);
+		payload = OtlpLogPayload("ai_completion", options.function_name, options.query_id, config.provider,
+		                         config.protocol, config.model, log_tags, "ai.prompt", prompt, "ai.response",
+		                         result.text, include_text, metrics, estimated_cost_usd);
 	} else {
 		payload = std::string("{") + "\"extension\":\"duckdb_ai\"," + "\"event\":\"ai_completion\"," +
-		          "\"provider\":\"" + JsonEscape(config.provider) + "\"," + "\"protocol\":\"" +
-		          JsonEscape(config.protocol) + "\"," + "\"model\":\"" + JsonEscape(config.model) + "\"," +
-		          "\"prompt_chars\":" + std::to_string(prompt.size()) + "," +
+		          "\"function_name\":\"" + JsonEscape(options.function_name) + "\"," + "\"query_id\":\"" +
+		          JsonEscape(options.query_id) + "\"," + "\"provider\":\"" + JsonEscape(config.provider) + "\"," +
+		          "\"protocol\":\"" + JsonEscape(config.protocol) + "\"," + "\"model\":\"" + JsonEscape(config.model) +
+		          "\"," + "\"prompt_chars\":" + std::to_string(prompt.size()) + "," +
 		          "\"response_chars\":" + std::to_string(result.text.size()) + "," +
 		          "\"prompt_tokens\":" + std::to_string(result.prompt_tokens) + "," +
 		          "\"completion_tokens\":" + std::to_string(result.completion_tokens) + "," +
 		          "\"total_tokens\":" + std::to_string(result.total_tokens) + "," +
+		          "\"cached_prompt_tokens\":" + std::to_string(result.cached_prompt_tokens) + "," +
+		          "\"cache_creation_prompt_tokens\":" + std::to_string(result.cache_creation_prompt_tokens) + "," +
 		          "\"elapsed_ms\":" + std::to_string(result.elapsed_ms) + "," +
-		          "\"http_status\":" + std::to_string(result.http_status);
+		          "\"retries\":" + std::to_string(result.retries) + "," +
+		          "\"http_status\":" + std::to_string(result.http_status) + "," +
+		          "\"cache_hit\":" + std::string(result.cache_hit ? "true" : "false") + "," + "\"status\":\"ok\"";
 
 		if (HasEstimatedCost(estimated_cost_usd)) {
 			payload += ",\"estimated_cost_usd\":" + JsonDouble(estimated_cost_usd);
@@ -2662,16 +3526,7 @@ void MaybePostUsageLog(const ProviderConfig &config, const std::string &prompt, 
 		payload += "}";
 	}
 
-	try {
-		EnforceAllowedHost(log_endpoint, options);
-		HttpPost(log_endpoint, payload, {"Content-Type: application/json"}, TimeoutSeconds(options), true,
-		         RetryCount(options), RetryBackoffMs(options), options.client_context);
-	} catch (std::exception &ex) {
-		auto log_strict = options.has_log_strict ? options.log_strict : EnvFlagEnabled("DUCKDB_AI_LOG_STRICT");
-		if (log_strict) {
-			throw IOException("AI usage log request failed: %s", ex.what());
-		}
-	}
+	SubmitUsageLog(options, log_endpoint, std::move(payload), "AI usage log request failed");
 }
 
 void MaybePostEmbeddingLog(const ProviderConfig &config, const std::string &input, const EmbeddingResult &result,
@@ -2696,20 +3551,25 @@ void MaybePostEmbeddingLog(const ProviderConfig &config, const std::string &inpu
 		    {"ai.prompt_tokens", result.prompt_tokens},
 		    {"ai.total_tokens", result.total_tokens},
 		    {"ai.elapsed_ms", result.elapsed_ms},
+		    {"ai.retries", result.retries},
 		    {"http.status_code", result.http_status},
 		};
-		payload = OtlpLogPayload("ai_embedding", config.provider, config.protocol, config.model, log_tags, "ai.input",
-		                         input, "", "", include_text, metrics, estimated_cost_usd);
+		payload = OtlpLogPayload("ai_embedding", options.function_name, options.query_id, config.provider,
+		                         config.protocol, config.model, log_tags, "ai.input", input, "", "", include_text,
+		                         metrics, estimated_cost_usd);
 	} else {
 		payload = std::string("{") + "\"extension\":\"duckdb_ai\"," + "\"event\":\"ai_embedding\"," +
-		          "\"provider\":\"" + JsonEscape(config.provider) + "\"," + "\"protocol\":\"" +
-		          JsonEscape(config.protocol) + "\"," + "\"model\":\"" + JsonEscape(config.model) + "\"," +
-		          "\"input_chars\":" + std::to_string(input.size()) + "," +
+		          "\"function_name\":\"" + JsonEscape(options.function_name) + "\"," + "\"query_id\":\"" +
+		          JsonEscape(options.query_id) + "\"," + "\"provider\":\"" + JsonEscape(config.provider) + "\"," +
+		          "\"protocol\":\"" + JsonEscape(config.protocol) + "\"," + "\"model\":\"" + JsonEscape(config.model) +
+		          "\"," + "\"input_chars\":" + std::to_string(input.size()) + "," +
 		          "\"dimensions\":" + std::to_string(result.values.size()) + "," +
 		          "\"prompt_tokens\":" + std::to_string(result.prompt_tokens) + "," +
 		          "\"total_tokens\":" + std::to_string(result.total_tokens) + "," +
 		          "\"elapsed_ms\":" + std::to_string(result.elapsed_ms) + "," +
-		          "\"http_status\":" + std::to_string(result.http_status);
+		          "\"retries\":" + std::to_string(result.retries) + "," +
+		          "\"http_status\":" + std::to_string(result.http_status) + "," +
+		          "\"cache_hit\":" + std::string(result.cache_hit ? "true" : "false") + "," + "\"status\":\"ok\"";
 
 		if (HasEstimatedCost(estimated_cost_usd)) {
 			payload += ",\"estimated_cost_usd\":" + JsonDouble(estimated_cost_usd);
@@ -2723,16 +3583,7 @@ void MaybePostEmbeddingLog(const ProviderConfig &config, const std::string &inpu
 		payload += "}";
 	}
 
-	try {
-		EnforceAllowedHost(log_endpoint, options);
-		HttpPost(log_endpoint, payload, {"Content-Type: application/json"}, TimeoutSeconds(options), true,
-		         RetryCount(options), RetryBackoffMs(options), options.client_context);
-	} catch (std::exception &ex) {
-		auto log_strict = options.has_log_strict ? options.log_strict : EnvFlagEnabled("DUCKDB_AI_LOG_STRICT");
-		if (log_strict) {
-			throw IOException("AI embedding log request failed: %s", ex.what());
-		}
-	}
+	SubmitUsageLog(options, log_endpoint, std::move(payload), "AI embedding log request failed");
 }
 
 } // namespace
@@ -2750,6 +3601,10 @@ ProviderConfig ResolveProvider(const std::string &provider, const std::string &m
 
 ProviderConfig ResolveProvider(const CompletionOptions &options) {
 	return ResolveProviderConfig(options, true);
+}
+
+void SnapshotEnvironmentOptions(CompletionOptions &options) {
+	SnapshotEnvironmentOptionsInternal(options);
 }
 
 std::string ProviderBaseUrl(const std::string &provider) {
@@ -2794,28 +3649,56 @@ CompletionResult Complete(const std::string &prompt, const CompletionOptions &op
 	auto endpoint = RequestEndpoint(config);
 	auto payload = RequestPayload(config, prompt, options);
 	EnforceAllowedHost(endpoint, options);
-	auto response = [&]() {
-		if (ResponseCacheEnabled(options)) {
-			auto &runtime_state = RuntimeState(options);
-			auto cache_key = ResponseCacheKey("completion", config, endpoint, payload);
-			HttpResponse cached_response;
-			if (TryGetCachedResponse(runtime_state, cache_key, cached_response)) {
-				return cached_response;
+	HttpResponse response;
+	try {
+		response = [&]() {
+			if (ResponseCacheEnabled(options)) {
+				auto &runtime_state = RuntimeState(options);
+				auto cache_key = ResponseCacheKey("completion", config, endpoint, payload);
+				HttpResponse cached_response;
+				if (TryGetCachedResponse(runtime_state, cache_key, options, cached_response)) {
+					return cached_response;
+				}
+				bool owns_request = false;
+				auto pending = BeginPendingCachedResponse(runtime_state, cache_key, owns_request);
+				if (!owns_request) {
+					return WaitForPendingCachedResponse(runtime_state, cache_key, pending);
+				}
+				try {
+					auto fresh_response = ProviderHttpPost(endpoint, payload, RequestHeaders(config), options,
+					                                       EstimatedCompletionTokens(prompt, options));
+					if (fresh_response.status >= 200 && fresh_response.status < 300) {
+						StoreCachedResponse(runtime_state, cache_key, fresh_response, options);
+					}
+					FinishPendingCachedResponse(runtime_state, cache_key, pending, fresh_response);
+					return fresh_response;
+				} catch (std::exception &ex) {
+					FailPendingCachedResponse(runtime_state, cache_key, pending, ex.what());
+					throw;
+				} catch (...) {
+					FailPendingCachedResponse(runtime_state, cache_key, pending, "unknown AI provider error");
+					throw;
+				}
 			}
-			ProviderRequestGuard request_guard(options, EstimatedCompletionTokens(prompt, options));
-			auto fresh_response = HttpPost(endpoint, payload, RequestHeaders(config), TimeoutSeconds(options), false,
-			                               RetryCount(options), RetryBackoffMs(options), options.client_context);
-			if (fresh_response.status >= 200 && fresh_response.status < 300) {
-				StoreCachedResponse(runtime_state, cache_key, fresh_response);
-			}
-			return fresh_response;
-		}
-		ProviderRequestGuard request_guard(options, EstimatedCompletionTokens(prompt, options));
-		return HttpPost(endpoint, payload, RequestHeaders(config), TimeoutSeconds(options), false, RetryCount(options),
-		                RetryBackoffMs(options), options.client_context);
-	}();
-	ThrowIfProviderHttpError(config, response);
-	auto result = ParseCompletionResult(config, response);
+			return ProviderHttpPost(endpoint, payload, RequestHeaders(config), options,
+			                        EstimatedCompletionTokens(prompt, options));
+		}();
+	} catch (std::exception &ex) {
+		RecordFailedUsageEvent(config, prompt, options, 0, ex.what(), 0);
+		throw;
+	}
+	if (response.status < 200 || response.status >= 300) {
+		auto error = ProviderErrorDetail(config, response);
+		RecordFailedUsageEvent(config, prompt, options, response.status, error, response.retries);
+		throw IOException("%s", error);
+	}
+	CompletionResult result;
+	try {
+		result = ParseCompletionResult(config, response);
+	} catch (std::exception &ex) {
+		RecordFailedUsageEvent(config, prompt, options, response.status, ex.what(), response.retries);
+		throw;
+	}
 	RecordUsageEvent(config, prompt, result, options);
 	MaybePostUsageLog(config, prompt, result, options);
 	return result;
@@ -2833,28 +3716,55 @@ CompletionResult Redact(const std::string &text, const CompletionOptions &option
 	auto endpoint = RequestEndpoint(config);
 	auto payload = RequestPayload(config, text, options);
 	EnforceAllowedHost(endpoint, options);
-	auto response = [&]() {
-		if (ResponseCacheEnabled(options)) {
-			auto &runtime_state = RuntimeState(options);
-			auto cache_key = ResponseCacheKey("redaction", config, endpoint, payload);
-			HttpResponse cached_response;
-			if (TryGetCachedResponse(runtime_state, cache_key, cached_response)) {
-				return cached_response;
+	HttpResponse response;
+	try {
+		response = [&]() {
+			if (ResponseCacheEnabled(options)) {
+				auto &runtime_state = RuntimeState(options);
+				auto cache_key = ResponseCacheKey("redaction", config, endpoint, payload);
+				HttpResponse cached_response;
+				if (TryGetCachedResponse(runtime_state, cache_key, options, cached_response)) {
+					return cached_response;
+				}
+				bool owns_request = false;
+				auto pending = BeginPendingCachedResponse(runtime_state, cache_key, owns_request);
+				if (!owns_request) {
+					return WaitForPendingCachedResponse(runtime_state, cache_key, pending);
+				}
+				try {
+					auto fresh_response =
+					    ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, EstimateTokenCount(text));
+					if (fresh_response.status >= 200 && fresh_response.status < 300) {
+						StoreCachedResponse(runtime_state, cache_key, fresh_response, options);
+					}
+					FinishPendingCachedResponse(runtime_state, cache_key, pending, fresh_response);
+					return fresh_response;
+				} catch (std::exception &ex) {
+					FailPendingCachedResponse(runtime_state, cache_key, pending, ex.what());
+					throw;
+				} catch (...) {
+					FailPendingCachedResponse(runtime_state, cache_key, pending, "unknown AI provider error");
+					throw;
+				}
 			}
-			ProviderRequestGuard request_guard(options, EstimateTokenCount(text));
-			auto fresh_response = HttpPost(endpoint, payload, RequestHeaders(config), TimeoutSeconds(options), false,
-			                               RetryCount(options), RetryBackoffMs(options), options.client_context);
-			if (fresh_response.status >= 200 && fresh_response.status < 300) {
-				StoreCachedResponse(runtime_state, cache_key, fresh_response);
-			}
-			return fresh_response;
-		}
-		ProviderRequestGuard request_guard(options, EstimateTokenCount(text));
-		return HttpPost(endpoint, payload, RequestHeaders(config), TimeoutSeconds(options), false, RetryCount(options),
-		                RetryBackoffMs(options), options.client_context);
-	}();
-	ThrowIfProviderHttpError(config, response);
-	auto result = ParseCompletionResult(config, response);
+			return ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, EstimateTokenCount(text));
+		}();
+	} catch (std::exception &ex) {
+		RecordFailedUsageEvent(config, text, options, 0, ex.what(), 0);
+		throw;
+	}
+	if (response.status < 200 || response.status >= 300) {
+		auto error = ProviderErrorDetail(config, response);
+		RecordFailedUsageEvent(config, text, options, response.status, error, response.retries);
+		throw IOException("%s", error);
+	}
+	CompletionResult result;
+	try {
+		result = ParseCompletionResult(config, response);
+	} catch (std::exception &ex) {
+		RecordFailedUsageEvent(config, text, options, response.status, ex.what(), response.retries);
+		throw;
+	}
 	RecordUsageEvent(config, text, result, options);
 	MaybePostUsageLog(config, text, result, options);
 	return result;
@@ -2887,31 +3797,115 @@ EmbeddingResult Embed(const std::string &input, const CompletionOptions &options
 	auto endpoint = EmbeddingEndpoint(config);
 	auto payload = EmbeddingPayload(config, input);
 	EnforceAllowedHost(endpoint, options);
-	auto response = [&]() {
-		if (ResponseCacheEnabled(options)) {
-			auto &runtime_state = RuntimeState(options);
-			auto cache_key = ResponseCacheKey("embedding", config, endpoint, payload);
-			HttpResponse cached_response;
-			if (TryGetCachedResponse(runtime_state, cache_key, cached_response)) {
-				return cached_response;
+	HttpResponse response;
+	try {
+		response = [&]() {
+			if (ResponseCacheEnabled(options)) {
+				auto &runtime_state = RuntimeState(options);
+				auto cache_key = ResponseCacheKey("embedding", config, endpoint, payload);
+				HttpResponse cached_response;
+				if (TryGetCachedResponse(runtime_state, cache_key, options, cached_response)) {
+					return cached_response;
+				}
+				bool owns_request = false;
+				auto pending = BeginPendingCachedResponse(runtime_state, cache_key, owns_request);
+				if (!owns_request) {
+					return WaitForPendingCachedResponse(runtime_state, cache_key, pending);
+				}
+				try {
+					auto fresh_response =
+					    ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, EstimateTokenCount(input));
+					if (fresh_response.status >= 200 && fresh_response.status < 300) {
+						StoreCachedResponse(runtime_state, cache_key, fresh_response, options);
+					}
+					FinishPendingCachedResponse(runtime_state, cache_key, pending, fresh_response);
+					return fresh_response;
+				} catch (std::exception &ex) {
+					FailPendingCachedResponse(runtime_state, cache_key, pending, ex.what());
+					throw;
+				} catch (...) {
+					FailPendingCachedResponse(runtime_state, cache_key, pending, "unknown AI provider error");
+					throw;
+				}
 			}
-			ProviderRequestGuard request_guard(options, EstimateTokenCount(input));
-			auto fresh_response = HttpPost(endpoint, payload, RequestHeaders(config), TimeoutSeconds(options), false,
-			                               RetryCount(options), RetryBackoffMs(options), options.client_context);
-			if (fresh_response.status >= 200 && fresh_response.status < 300) {
-				StoreCachedResponse(runtime_state, cache_key, fresh_response);
-			}
-			return fresh_response;
-		}
-		ProviderRequestGuard request_guard(options, EstimateTokenCount(input));
-		return HttpPost(endpoint, payload, RequestHeaders(config), TimeoutSeconds(options), false, RetryCount(options),
-		                RetryBackoffMs(options), options.client_context);
-	}();
-	ThrowIfProviderHttpError(config, response);
-	auto result = ParseEmbeddingResult(config, response);
+			return ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, EstimateTokenCount(input));
+		}();
+	} catch (std::exception &ex) {
+		RecordFailedEmbeddingUsageEvent(config, input, options, 0, ex.what(), 0);
+		throw;
+	}
+	if (response.status < 200 || response.status >= 300) {
+		auto error = ProviderErrorDetail(config, response);
+		RecordFailedEmbeddingUsageEvent(config, input, options, response.status, error, response.retries);
+		throw IOException("%s", error);
+	}
+	EmbeddingResult result;
+	try {
+		result = ParseEmbeddingResult(config, response);
+	} catch (std::exception &ex) {
+		RecordFailedEmbeddingUsageEvent(config, input, options, response.status, ex.what(), response.retries);
+		throw;
+	}
 	RecordEmbeddingUsageEvent(config, input, result, options);
 	MaybePostEmbeddingLog(config, input, result, options);
 	return result;
+}
+
+std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, const CompletionOptions &options) {
+	if (inputs.empty()) {
+		return {};
+	}
+	if (inputs.size() == 1 || ResponseCacheEnabled(options)) {
+		std::vector<EmbeddingResult> results;
+		results.reserve(inputs.size());
+		for (auto &input : inputs) {
+			results.push_back(Embed(input, options));
+		}
+		return results;
+	}
+	for (auto &input : inputs) {
+		if (input.empty()) {
+			throw InvalidInputException("ai_embed input must not be empty");
+		}
+	}
+	auto config = ResolveEmbeddingProviderConfig(options, true);
+	auto endpoint = EmbeddingEndpoint(config);
+	auto payload = EmbeddingPayload(config, inputs);
+	EnforceAllowedHost(endpoint, options);
+	auto total_tokens = int64_t(0);
+	for (auto &input : inputs) {
+		total_tokens += EstimateTokenCount(input);
+	}
+	HttpResponse response;
+	try {
+		response = ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, total_tokens);
+	} catch (std::exception &ex) {
+		for (auto &input : inputs) {
+			RecordFailedEmbeddingUsageEvent(config, input, options, 0, ex.what(), 0);
+		}
+		throw;
+	}
+	if (response.status < 200 || response.status >= 300) {
+		auto error = ProviderErrorDetail(config, response);
+		for (auto &input : inputs) {
+			RecordFailedEmbeddingUsageEvent(config, input, options, response.status, error, response.retries);
+		}
+		throw IOException("%s", error);
+	}
+	std::vector<EmbeddingResult> results;
+	try {
+		results = ParseEmbeddingResults(config, response, inputs.size());
+	} catch (std::exception &ex) {
+		for (auto &input : inputs) {
+			RecordFailedEmbeddingUsageEvent(config, input, options, response.status, ex.what(), response.retries);
+		}
+		throw;
+	}
+	for (idx_t i = 0; i < results.size(); i++) {
+		RecordEmbeddingUsageEvent(config, inputs[i], results[i], options);
+		MaybePostEmbeddingLog(config, inputs[i], results[i], options);
+	}
+	return results;
 }
 
 void InitializeProviderRuntime() {
@@ -2971,6 +3965,8 @@ void RecordLocalUsageEvent(ClientContext *context, const std::string &event_name
 	UsageEvent event;
 	event.created_at = CurrentTimestamp();
 	event.event = event_name;
+	event.function_name = event_name;
+	event.query_id = "";
 	event.provider = "local";
 	event.protocol = "duckdb";
 	event.model = "";
@@ -2981,8 +3977,14 @@ void RecordLocalUsageEvent(ClientContext *context, const std::string &event_name
 	event.prompt_tokens = -1;
 	event.completion_tokens = -1;
 	event.total_tokens = -1;
+	event.cached_prompt_tokens = -1;
+	event.cache_creation_prompt_tokens = -1;
 	event.elapsed_ms = 0;
+	event.retries = 0;
 	event.http_status = 0;
+	event.cache_hit = false;
+	event.status = "ok";
+	event.error = "";
 	event.estimated_cost_usd = -1;
 	auto &state = context ? RuntimeState(*context) : fallback_runtime_state;
 	PushUsageEvent(state, std::move(event));
@@ -3088,6 +4090,28 @@ bool ExtractJsonObjectFields(const std::string &input, const std::vector<std::st
 		}
 		extracted = ExtractJsonValue(field->second);
 		values.push_back(std::move(extracted));
+	}
+	return true;
+}
+
+bool ExtractJsonStringArray(const std::string &input, std::vector<std::string> &values, std::string &error) {
+	JsonValue value;
+	if (!ParseJsonValueDocument(input, value, error)) {
+		return false;
+	}
+	if (value.type != JsonValueType::ARRAY) {
+		error = "expected top-level JSON array";
+		return false;
+	}
+	values.clear();
+	values.reserve(value.array_value.size());
+	for (auto &item : value.array_value) {
+		if (item.type != JsonValueType::STRING) {
+			error = "expected JSON array entries to be strings";
+			values.clear();
+			return false;
+		}
+		values.push_back(item.string_value);
 	}
 	return true;
 }

--- a/src/include/duckdb_ai_provider.hpp
+++ b/src/include/duckdb_ai_provider.hpp
@@ -53,6 +53,14 @@ struct CompletionOptions {
 	bool use_builtin_model_prices = false;
 	bool has_cache = false;
 	bool cache = false;
+	bool has_cache_ttl_seconds = false;
+	int64_t cache_ttl_seconds = 0;
+	bool has_response_cache_max_entries = false;
+	int64_t response_cache_max_entries = 0;
+	bool has_prompt_cache = false;
+	bool prompt_cache = false;
+	bool has_connect_timeout_seconds = false;
+	int64_t connect_timeout_seconds = 0;
 	std::string allowed_hosts;
 	std::string log_endpoint;
 	std::string log_format;
@@ -64,8 +72,11 @@ struct CompletionOptions {
 	bool has_log_sample_rate = false;
 	double log_sample_rate = 1;
 	bool fail_on_error = true;
+	std::string on_error;
 	std::string response_format;
 	std::string response_schema;
+	std::string function_name;
+	std::string query_id;
 	ClientContext *client_context = nullptr;
 	void *runtime_state = nullptr;
 };
@@ -78,7 +89,12 @@ struct CompletionResult {
 	int64_t prompt_tokens;
 	int64_t completion_tokens;
 	int64_t total_tokens;
+	int64_t cached_prompt_tokens;
+	int64_t cache_creation_prompt_tokens;
 	int64_t elapsed_ms;
+	int64_t retries;
+	bool cache_hit;
+	std::string finish_reason;
 };
 
 //! Parsed result from an embedding provider response.
@@ -89,6 +105,8 @@ struct EmbeddingResult {
 	int64_t prompt_tokens;
 	int64_t total_tokens;
 	int64_t elapsed_ms;
+	int64_t retries;
+	bool cache_hit;
 };
 
 //! In-process usage record exposed through ai_usage().
@@ -96,6 +114,8 @@ struct UsageEvent {
 	uint64_t event_id;
 	std::string created_at;
 	std::string event;
+	std::string function_name;
+	std::string query_id;
 	std::string provider;
 	std::string protocol;
 	std::string model;
@@ -106,12 +126,18 @@ struct UsageEvent {
 	int64_t prompt_tokens;
 	int64_t completion_tokens;
 	int64_t total_tokens;
+	int64_t cached_prompt_tokens;
+	int64_t cache_creation_prompt_tokens;
 	int64_t elapsed_ms;
+	int64_t retries;
 	long http_status;
+	bool cache_hit;
+	std::string status;
+	std::string error;
 	double estimated_cost_usd;
 };
 
-//! Built-in model pricing row exposed through ai_models().
+//! Built-in model pricing row exposed through ai_model_prices().
 struct ModelPrice {
 	std::string provider;
 	std::string model;
@@ -153,7 +179,9 @@ struct JsonExtractedValue {
 ProviderConfig ResolveProvider(const std::string &provider, const std::string &model);
 //! Resolve provider configuration from a full option set.
 ProviderConfig ResolveProvider(const CompletionOptions &options);
-//! Normalize provider aliases such as anthropic -> claude and local -> openai_compatible.
+//! Snapshot non-secret environment defaults into options once for a query bind.
+void SnapshotEnvironmentOptions(CompletionOptions &options);
+//! Normalize provider aliases such as claude -> anthropic and local -> openai_compatible.
 std::string NormalizeProviderName(const std::string &provider);
 //! Return the default base URL for a supported provider.
 std::string ProviderBaseUrl(const std::string &provider);
@@ -179,6 +207,8 @@ std::string BuildEmbeddingRequestJson(const std::string &input, const Completion
 EmbeddingResult Embed(const std::string &input, const std::string &model, const std::string &provider);
 //! Execute an embedding request from a full option set.
 EmbeddingResult Embed(const std::string &input, const CompletionOptions &options);
+//! Execute a batched embedding request from a full option set.
+std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, const CompletionOptions &options);
 //! Return the effective max_concurrent_requests value from options or env.
 int64_t EffectiveMaxConcurrentRequests(const CompletionOptions &options);
 //! Initialize provider runtime dependencies such as libcurl.
@@ -214,6 +244,8 @@ bool ExtractJsonSchemaProperties(const std::string &schema, std::vector<JsonSche
 //! Extract named fields from a top-level JSON object for typed projection.
 bool ExtractJsonObjectFields(const std::string &input, const std::vector<std::string> &field_names,
                              std::vector<JsonExtractedValue> &values, std::string &error);
+//! Extract strings from a top-level JSON array.
+bool ExtractJsonStringArray(const std::string &input, std::vector<std::string> &values, std::string &error);
 
 } // namespace duckdb_ai
 } // namespace duckdb

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
@@ -42,6 +43,7 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             request = json.loads(body)
             self.completion_requests.append(request)
             prompt = request["messages"][-1]["content"]
+            full_prompt = "\n".join(message["content"] for message in request["messages"])
             if "force provider error" in prompt:
                 self._send_json(
                     {
@@ -68,13 +70,19 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                         status=500,
                     )
                     return
+            if prompt == "cache dogpile":
+                time.sleep(0.2)
             content = "mock completion"
             if prompt == "retry once":
                 content = "mock retry completion"
+            elif prompt == "cache dogpile":
+                content = "mock dogpile completion"
             elif "return invalid schema JSON" in prompt:
                 content = '{"summary":123}'
             elif "return constrained schema JSON" in prompt:
                 content = '{"summary":"mock structured","score":0.5,"tags":["duck","ai"]}'
+            elif "return scalar record JSON object" in prompt:
+                content = '{"summary":"mock scalar record","profile":{"company":"DuckDB Labs"}}'
             elif "return record JSON object" in prompt:
                 content = (
                     '{"summary":"mock record","score":0.75,"tags":["duck","sql"],'
@@ -89,16 +97,20 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 content = '{"tags":["duck","duck"]}'
             elif "return oneOf violation JSON" in prompt:
                 content = '{"a":1,"b":2}'
-            elif request.get("response_format") or "Return only valid JSON" in prompt:
+            elif request.get("response_format") or "Return only valid JSON" in full_prompt:
                 content = '{"summary":"mock structured"}'
-            elif "Explain the DuckDB SQL query" in prompt:
+            elif "Explain the DuckDB SQL query" in full_prompt:
                 content = "This query returns a single row with 42."
-            elif "Correct the DuckDB SQL query" in prompt:
+            elif "Correct the DuckDB SQL query" in full_prompt:
                 content = "```sql\nSELECT 42\n```"
-            elif "Correct one line in the DuckDB SQL query" in prompt:
+            elif "Correct one line in the DuckDB SQL query" in full_prompt:
                 content = "SELECT 42"
-            elif "Generate one DuckDB SQL SELECT statement" in prompt:
+            elif "Generate one DuckDB SQL SELECT statement" in full_prompt:
                 content = "```sql\nSELECT 42\n```"
+            elif "Return only a JSON array of chosen labels" in full_prompt:
+                content = '["billing, overdue","performance"]'
+            elif "Score candidate relevance to the search query" in full_prompt:
+                content = "0.82"
             payload = {
                 "choices": [{"message": {"content": content}}],
                 "usage": {
@@ -112,12 +124,15 @@ class MockProviderHandler(BaseHTTPRequestHandler):
 
         if self.path == "/embeddings":
             self.authorization_headers.append(self.headers.get("authorization"))
-            self.embedding_requests.append(json.loads(body))
+            request = json.loads(body)
+            self.embedding_requests.append(request)
+            inputs = request.get("input")
+            input_count = len(inputs) if isinstance(inputs, list) else 1
             payload = {
-                "data": [{"embedding": [0.25, -0.5, 1.25]}],
+                "data": [{"embedding": [0.25, -0.5, 1.25]} for _ in range(input_count)],
                 "usage": {
-                    "prompt_tokens": 2,
-                    "total_tokens": 2,
+                    "prompt_tokens": 2 * input_count,
+                    "total_tokens": 2 * input_count,
                 },
             }
             self._send_json(payload)
@@ -187,7 +202,7 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
         SET duckdb_ai_task_model = 'mock-task-model';
         SET duckdb_ai_aggregate_model = 'mock-aggregate-model';
         SET duckdb_ai_embedding_model = 'mock-embedding-default';
-        SET duckdb_ai_sql_model = 'mock-sql-model';
+        SET duckdb_ai_sql_assistant_model = 'mock-sql-model';
         SET duckdb_ai_base_url = '{base_url}';
         SET duckdb_ai_log_endpoint = '{base_url}/log';
         SET duckdb_ai_timeout_seconds = 5;
@@ -272,12 +287,17 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
         SELECT ai_fix_grammar('duckdb are fast') AS fixed_grammar;
         SELECT ai_redact('email alice@example.com token fake-token') AS masked_text;
         SELECT ai_translate('hello', 'Dutch') AS translation;
-        SELECT ai_classify('invoice overdue', 'billing, support') AS classification;
+        SELECT ai_classify('invoice overdue', ['billing, overdue', 'support']) AS classification;
+        SELECT ai_classify_labels('invoice overdue and slow app', ['billing, overdue', 'performance', 'support']) AS labels;
         SELECT ai_extract('name: DuckDB', 'name') AS extracted;
         SELECT ai_sql(
             'count rows',
             schema_context := 'CREATE TABLE smoke_table(id INTEGER)'
         ) AS generated_sql;
+        SELECT * FROM ai_query_data(
+            'count rows',
+            schema_context := 'CREATE TABLE smoke_table(id INTEGER)'
+        );
         SELECT * FROM ai_query_data(
             'count rows',
             schema_context := 'CREATE TABLE smoke_table(id INTEGER)'
@@ -293,8 +313,9 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             schema_context := 'CREATE TABLE smoke_table(id INTEGER)'
         );
         SELECT line_number, replacement_line
-        FROM ai_fix_sql_line(
+        FROM ai_fix_sql(
             'SEELECT 42',
+            mode := 'line',
             error := 'Parser Error: syntax error at or near "SEELECT" LINE 1: SEELECT 42',
             schema_context := 'CREATE TABLE smoke_table(id INTEGER)'
         );
@@ -340,6 +361,13 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
         ) AS snowflake_completion;
         SELECT result.response, result.error IS NULL
         FROM (SELECT ai_try_complete('try complete smoke', max_tokens := 5) AS result);
+        SELECT extracted.summary, extracted.profile.company
+        FROM (
+            SELECT ai_extract_record(
+                'return scalar record JSON object',
+                '{{"type":"object","properties":{{"summary":{{"type":"string"}},"profile":{{"type":"object","properties":{{"company":{{"type":"string"}}}},"required":["company"],"additionalProperties":false}}}},"required":["summary","profile"],"additionalProperties":false}}'
+            ) AS extracted
+        );
         SELECT ai_redact(
             'email alice@example.com token fake-token',
             secret := 'smoke_privacy_filter_ai',
@@ -347,7 +375,15 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             model := 'openai/privacy-filter'
         ) AS privacy_filter_redaction;
         SELECT ai_embed('embed smoke')[1] AS first_embedding_value;
+        SELECT sum(embedding[1]) AS batched_embedding_sum
+        FROM (
+            SELECT ai_embed(value) AS embedding
+            FROM (VALUES ('embed batch one'), ('embed batch two'), ('embed batch three')) AS input(value)
+        );
         SELECT round(ai_similarity('same left', 'same right'), 6) AS similarity;
+        SELECT round(sum(ai_similarity('constant query', candidate)), 6) AS constant_similarity_sum
+        FROM (VALUES ('candidate one'), ('candidate two'), ('candidate three')) AS input(candidate);
+        SELECT ai_rerank('analytics database', 'DuckDB runs analytical SQL') AS rerank_score;
         SELECT event, provider, protocol, model, prompt_chars, response_chars, input_chars,
                dimensions, prompt_tokens, completion_tokens, total_tokens, http_status,
                estimated_cost_usd
@@ -416,6 +452,12 @@ def run_duckdb_cache_and_allowlist(duckdb_path: Path, base_url: str) -> str:
         );
         SELECT ai_complete('cache smoke', cache := true) AS first_completion;
         SELECT ai_complete('cache smoke', cache := true) AS second_completion;
+        SELECT count(*) AS dogpile_cached_rows
+        FROM (
+            SELECT ai_complete('cache dogpile', cache := true, max_concurrent_requests := 8) AS completion
+            FROM range(16)
+        )
+        WHERE completion = 'mock dogpile completion';
         SELECT count(*) AS usage_events FROM ai_usage();
     """
     env = os.environ.copy()
@@ -464,6 +506,38 @@ def run_duckdb_allowlist_error(duckdb_path: Path, base_url: str) -> str:
     return result.stdout
 
 
+def run_duckdb_strict_log_error(duckdb_path: Path, base_url: str, port: int) -> str:
+    sql = f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_model = 'mock-model';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_allowed_hosts = '{base_url}';
+        SET duckdb_ai_log_endpoint = 'http://localhost:{port}/log';
+        SET duckdb_ai_log_strict = true;
+        SET duckdb_ai_timeout_seconds = 5;
+        CREATE OR REPLACE SECRET smoke_strict_log_duckdb_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'openai'
+        );
+        SELECT ai_complete('strict log blocked');
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"duckdb strict log smoke unexpectedly succeeded\n{result.stdout}")
+    return result.stdout
+
+
 def assert_provider_error(output: str):
     required = [
         'AI provider "openai" (openai_chat, model "mock-model") returned HTTP 401',
@@ -479,19 +553,27 @@ def assert_provider_error(output: str):
 
 
 def assert_cache_and_allowlist_result(output: str):
-    required = ["first_completion", "second_completion", "mock completion", "usage_events", "2"]
+    required = [
+        "first_completion",
+        "second_completion",
+        "mock completion",
+        "dogpile_cached_rows",
+        "16",
+        "usage_events",
+        "18",
+    ]
     missing = [value for value in required if value not in output]
     if missing:
         raise AssertionError(f"cache output missing {missing}\n{output}")
-    if len(MockProviderHandler.completion_requests) != 1:
+    if len(MockProviderHandler.completion_requests) != 2:
         raise AssertionError(
-            f"expected 1 cached completion request, got {len(MockProviderHandler.completion_requests)}"
+            f"expected 2 cached completion requests, got {len(MockProviderHandler.completion_requests)}"
         )
-    if len(MockProviderHandler.authorization_headers) != 1:
-        raise AssertionError(f"expected 1 cached auth header, got {len(MockProviderHandler.authorization_headers)}")
-    prompt = MockProviderHandler.completion_requests[0]["messages"][-1]["content"]
-    if prompt != "cache smoke":
-        raise AssertionError(f"unexpected cache prompt: {prompt}")
+    if len(MockProviderHandler.authorization_headers) != 2:
+        raise AssertionError(f"expected 2 cached auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    prompts = [request["messages"][-1]["content"] for request in MockProviderHandler.completion_requests]
+    if prompts != ["cache smoke", "cache dogpile"]:
+        raise AssertionError(f"unexpected cache prompts: {prompts}")
 
 
 def assert_allowlist_error(output: str):
@@ -500,6 +582,17 @@ def assert_allowlist_error(output: str):
     if MockProviderHandler.completion_requests:
         raise AssertionError(
             f"allowlist should block before provider request: {MockProviderHandler.completion_requests}"
+        )
+
+
+def assert_strict_log_error(output: str):
+    if "AI usage log request failed" not in output or "not allowed by duckdb_ai_allowed_hosts" not in output:
+        raise AssertionError(f"strict log error missing expected message\n{output}")
+    if len(MockProviderHandler.completion_requests) != 1:
+        raise AssertionError(f"strict log should call provider once: {MockProviderHandler.completion_requests}")
+    if MockProviderHandler.log_requests:
+        raise AssertionError(
+            f"strict log allowlist should block before log request: {MockProviderHandler.log_requests}"
         )
 
 
@@ -533,8 +626,8 @@ def assert_smoke_result(output: str):
         "mock-completion-model",
         "mock-task-model",
         "mock-sql-model",
-        "mock-aggregate-model",
         "mock-embedding-default",
+        "ai_query_data_cache_hit",
         "openai_privacy_filter",
         "privacy_filter",
         "databricks",
@@ -542,8 +635,12 @@ def assert_smoke_result(output: str):
         "databricks-llama-4-maverick",
         "snowflake-llama-3.3-70b",
         "email [PRIVATE_EMAIL] token [SECRET]",
+        "billing, overdue",
+        "performance",
+        "0.82",
         "0.25",
         "1.0",
+        "3.0",
         "16",
         "15",
         "7",
@@ -555,10 +652,10 @@ def assert_smoke_result(output: str):
     if missing:
         raise AssertionError(f"duckdb output missing {missing}\n{output}")
 
-    if len(MockProviderHandler.completion_requests) != 31:
-        raise AssertionError(f"expected 31 completion requests, got {len(MockProviderHandler.completion_requests)}")
-    if len(MockProviderHandler.authorization_headers) != 35:
-        raise AssertionError(f"expected 35 auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if len(MockProviderHandler.completion_requests) != 34:
+        raise AssertionError(f"expected 34 completion requests, got {len(MockProviderHandler.completion_requests)}")
+    if len(MockProviderHandler.authorization_headers) != 43:
+        raise AssertionError(f"expected 43 auth headers, got {len(MockProviderHandler.authorization_headers)}")
     for header in MockProviderHandler.authorization_headers:
         if header != "Bearer test-key":
             raise AssertionError(f"unexpected authorization header: {header}")
@@ -566,14 +663,14 @@ def assert_smoke_result(output: str):
     completion_models = [request["model"] for request in MockProviderHandler.completion_requests]
     if completion_models[0:9] != ["mock-completion-model"] * 9:
         raise AssertionError(f"unexpected completion default models: {completion_models[0:9]}")
-    if completion_models[9:16] != ["mock-task-model"] * 7:
-        raise AssertionError(f"unexpected task default models: {completion_models[9:16]}")
-    if completion_models[16:21] != ["mock-sql-model"] * 5:
-        raise AssertionError(f"unexpected SQL assistant default models: {completion_models[16:21]}")
-    if completion_models[21:23] != ["mock-aggregate-model"] * 2:
-        raise AssertionError(f"unexpected aggregate default models: {completion_models[21:23]}")
-    if completion_models[23:27] != ["mock-completion-model"] * 4:
-        raise AssertionError(f"unexpected later completion default models: {completion_models[23:27]}")
+    if completion_models[9:17] != ["mock-task-model"] * 8:
+        raise AssertionError(f"unexpected task default models: {completion_models[9:17]}")
+    if completion_models[17:22] != ["mock-sql-model"] * 5:
+        raise AssertionError(f"unexpected SQL assistant default models: {completion_models[17:22]}")
+    if completion_models[22:24] != ["mock-aggregate-model"] * 2:
+        raise AssertionError(f"unexpected aggregate default models: {completion_models[22:24]}")
+    if completion_models[24:28] != ["mock-completion-model"] * 4:
+        raise AssertionError(f"unexpected later completion default models: {completion_models[24:28]}")
 
     completion_request = MockProviderHandler.completion_requests[0]
     if completion_request["model"] != "mock-completion-model":
@@ -593,8 +690,11 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"unexpected structured response format: {structured_request}")
     if response_format.get("json_schema", {}).get("schema", {}).get("type") != "object":
         raise AssertionError(f"unexpected structured response schema: {structured_request}")
+    structured_system = structured_request["messages"][0]["content"]
+    if "Return only valid JSON" not in structured_system:
+        raise AssertionError(f"unexpected structured system prompt: {structured_request}")
     structured_prompt = structured_request["messages"][-1]["content"]
-    if "Return only valid JSON" not in structured_prompt or "return a smoke JSON object" not in structured_prompt:
+    if structured_prompt != "return a smoke JSON object":
         raise AssertionError(f"unexpected structured prompt: {structured_prompt}")
 
     invalid_schema_prompt = MockProviderHandler.completion_requests[2]["messages"][-1]["content"]
@@ -620,86 +720,130 @@ def assert_smoke_result(output: str):
         if fragment not in prompt:
             raise AssertionError(f"schema failure prompt missing {fragment!r}: {prompt}")
 
-    task_prompts = [request["messages"][-1]["content"] for request in MockProviderHandler.completion_requests[9:16]]
-    expected_prompt_fragments = [
+    task_messages = [request["messages"] for request in MockProviderHandler.completion_requests[9:17]]
+    expected_system_fragments = [
         "Summarize the following text concisely",
-        "positive, neutral, or negative",
+        "positive, neutral, negative",
         "Fix grammar, spelling, and punctuation",
         "Mask direct personal data",
         "Translate the following text to Dutch",
-        "exactly one of these labels: billing, support",
+        'exactly one of these labels: "billing, overdue", "support"',
+        'zero or more of these labels: "billing, overdue", "performance", "support"',
+        "Extract the requested information",
+    ]
+    expected_user_fragments = [
+        "Text:\nDuckDB executes analytical SQL quickly",
+        "Text:\nI love DuckDB",
+        "Text:\nduckdb are fast",
+        "Text:\nemail alice@example.com token fake-token",
+        "Text:\nhello",
+        "Text:\ninvoice overdue",
+        "Text:\ninvoice overdue and slow app",
         "Extraction request:\nname",
     ]
-    for fragment, prompt in zip(expected_prompt_fragments, task_prompts):
-        if fragment not in prompt:
-            raise AssertionError(f"task prompt missing {fragment!r}: {prompt}")
+    for system_fragment, user_fragment, messages in zip(
+        expected_system_fragments, expected_user_fragments, task_messages
+    ):
+        system_prompt = messages[0]["content"]
+        user_prompt = messages[-1]["content"]
+        if system_fragment not in system_prompt:
+            raise AssertionError(f"task system prompt missing {system_fragment!r}: {system_prompt}")
+        if user_fragment not in user_prompt:
+            raise AssertionError(f"task user prompt missing {user_fragment!r}: {user_prompt}")
 
-    ai_sql_prompt = MockProviderHandler.completion_requests[16]["messages"][-1]["content"]
-    if "Generate one DuckDB SQL SELECT statement" not in ai_sql_prompt:
-        raise AssertionError(f"unexpected ai_sql prompt: {ai_sql_prompt}")
-    if "CREATE TABLE smoke_table(id INTEGER)" not in ai_sql_prompt:
-        raise AssertionError(f"ai_sql prompt missing schema context: {ai_sql_prompt}")
-    ai_query_data_prompt = MockProviderHandler.completion_requests[17]["messages"][-1]["content"]
-    if "Generate one DuckDB SQL SELECT statement" not in ai_query_data_prompt:
-        raise AssertionError(f"unexpected ai_query_data prompt: {ai_query_data_prompt}")
-    if "CREATE TABLE smoke_table(id INTEGER)" not in ai_query_data_prompt:
-        raise AssertionError(f"ai_query_data prompt missing schema context: {ai_query_data_prompt}")
-    ai_explain_sql_prompt = MockProviderHandler.completion_requests[18]["messages"][-1]["content"]
-    if "Explain the DuckDB SQL query" not in ai_explain_sql_prompt:
-        raise AssertionError(f"unexpected ai_explain_sql prompt: {ai_explain_sql_prompt}")
+    ai_sql_messages = MockProviderHandler.completion_requests[17]["messages"]
+    ai_sql_system = ai_sql_messages[0]["content"]
+    ai_sql_prompt = ai_sql_messages[-1]["content"]
+    if "Generate one DuckDB SQL SELECT statement" not in ai_sql_system:
+        raise AssertionError(f"unexpected ai_sql system prompt: {ai_sql_system}")
+    if "CREATE TABLE smoke_table(id INTEGER)" not in ai_sql_system:
+        raise AssertionError(f"ai_sql system prompt missing schema context: {ai_sql_system}")
+    if "Request:\ncount rows" not in ai_sql_prompt:
+        raise AssertionError(f"ai_sql user prompt missing request: {ai_sql_prompt}")
+    ai_query_data_messages = MockProviderHandler.completion_requests[18]["messages"]
+    ai_query_data_system = ai_query_data_messages[0]["content"]
+    ai_query_data_prompt = ai_query_data_messages[-1]["content"]
+    if "Generate one DuckDB SQL SELECT statement" not in ai_query_data_system:
+        raise AssertionError(f"unexpected ai_query_data system prompt: {ai_query_data_system}")
+    if "CREATE TABLE smoke_table(id INTEGER)" not in ai_query_data_system:
+        raise AssertionError(f"ai_query_data system prompt missing schema context: {ai_query_data_system}")
+    if "Request:\ncount rows" not in ai_query_data_prompt:
+        raise AssertionError(f"ai_query_data user prompt missing request: {ai_query_data_prompt}")
+    ai_explain_sql_messages = MockProviderHandler.completion_requests[19]["messages"]
+    ai_explain_sql_system = ai_explain_sql_messages[0]["content"]
+    ai_explain_sql_prompt = ai_explain_sql_messages[-1]["content"]
+    if "Explain the DuckDB SQL query" not in ai_explain_sql_system:
+        raise AssertionError(f"unexpected ai_explain_sql system prompt: {ai_explain_sql_system}")
     if "SELECT 42" not in ai_explain_sql_prompt:
         raise AssertionError(f"ai_explain_sql prompt missing SQL: {ai_explain_sql_prompt}")
-    ai_fix_sql_prompt = MockProviderHandler.completion_requests[19]["messages"][-1]["content"]
-    if "Correct the DuckDB SQL query" not in ai_fix_sql_prompt:
-        raise AssertionError(f"unexpected ai_fix_sql prompt: {ai_fix_sql_prompt}")
+    ai_fix_sql_messages = MockProviderHandler.completion_requests[20]["messages"]
+    ai_fix_sql_system = ai_fix_sql_messages[0]["content"]
+    ai_fix_sql_prompt = ai_fix_sql_messages[-1]["content"]
+    if "Correct the DuckDB SQL query" not in ai_fix_sql_system:
+        raise AssertionError(f"unexpected ai_fix_sql system prompt: {ai_fix_sql_system}")
     if "SEELECT 42" not in ai_fix_sql_prompt:
         raise AssertionError(f"ai_fix_sql prompt missing broken SQL: {ai_fix_sql_prompt}")
-    ai_fix_sql_line_prompt = MockProviderHandler.completion_requests[20]["messages"][-1]["content"]
-    if "Correct one line in the DuckDB SQL query" not in ai_fix_sql_line_prompt:
-        raise AssertionError(f"unexpected ai_fix_sql_line prompt: {ai_fix_sql_line_prompt}")
-    if "Line to correct: 1" not in ai_fix_sql_line_prompt:
-        raise AssertionError(f"ai_fix_sql_line prompt missing line number: {ai_fix_sql_line_prompt}")
-    summarize_agg_prompt = MockProviderHandler.completion_requests[21]["messages"][-1]["content"]
+    ai_fix_sql_line_mode_messages = MockProviderHandler.completion_requests[21]["messages"]
+    ai_fix_sql_line_mode_system = ai_fix_sql_line_mode_messages[0]["content"]
+    ai_fix_sql_line_mode_prompt = ai_fix_sql_line_mode_messages[-1]["content"]
+    if "Correct one line in the DuckDB SQL query" not in ai_fix_sql_line_mode_system:
+        raise AssertionError(f"unexpected ai_fix_sql line-mode system prompt: {ai_fix_sql_line_mode_system}")
+    if "Line to correct: 1" not in ai_fix_sql_line_mode_prompt:
+        raise AssertionError(f"ai_fix_sql line-mode prompt missing line number: {ai_fix_sql_line_mode_prompt}")
+    summarize_agg_prompt = MockProviderHandler.completion_requests[22]["messages"][-1]["content"]
     if "Summarize the following SQL aggregate input values" not in summarize_agg_prompt:
         raise AssertionError(f"unexpected ai_summarize_agg prompt: {summarize_agg_prompt}")
     if "first row" not in summarize_agg_prompt or "second row" not in summarize_agg_prompt:
         raise AssertionError(f"ai_summarize_agg prompt missing aggregate values: {summarize_agg_prompt}")
-    agg_prompt = MockProviderHandler.completion_requests[22]["messages"][-1]["content"]
+    agg_prompt = MockProviderHandler.completion_requests[23]["messages"][-1]["content"]
     if "Return the most important word" not in agg_prompt:
         raise AssertionError(f"unexpected ai_agg prompt: {agg_prompt}")
     if "duck" not in agg_prompt or "database" not in agg_prompt:
         raise AssertionError(f"ai_agg prompt missing aggregate values: {agg_prompt}")
-    suppressed_prompt = MockProviderHandler.completion_requests[23]["messages"][-1]["content"]
+    suppressed_prompt = MockProviderHandler.completion_requests[24]["messages"][-1]["content"]
     if suppressed_prompt != "sample suppressed":
         raise AssertionError(f"unexpected suppressed completion prompt: {suppressed_prompt}")
-    retry_prompts = [request["messages"][-1]["content"] for request in MockProviderHandler.completion_requests[24:26]]
+    retry_prompts = [request["messages"][-1]["content"] for request in MockProviderHandler.completion_requests[25:27]]
     if retry_prompts != ["retry once", "retry once"]:
         raise AssertionError(f"unexpected retry prompts: {retry_prompts}")
     if MockProviderHandler.retry_completion_attempts != 2:
         raise AssertionError(f"expected 2 retry attempts, got {MockProviderHandler.retry_completion_attempts}")
-    otlp_prompt = MockProviderHandler.completion_requests[26]["messages"][-1]["content"]
+    otlp_prompt = MockProviderHandler.completion_requests[27]["messages"][-1]["content"]
     if otlp_prompt != "otlp log smoke":
         raise AssertionError(f"unexpected OTLP completion prompt: {otlp_prompt}")
-    builtin_price_request = MockProviderHandler.completion_requests[27]
+    builtin_price_request = MockProviderHandler.completion_requests[28]
     if builtin_price_request.get("model") != "gpt-5.4-mini":
         raise AssertionError(f"unexpected builtin pricing model: {builtin_price_request}")
     if builtin_price_request["messages"][-1]["content"] != "builtin pricing smoke":
         raise AssertionError(f"unexpected builtin pricing prompt: {builtin_price_request}")
-    databricks_request = MockProviderHandler.completion_requests[28]
+    databricks_request = MockProviderHandler.completion_requests[29]
     if databricks_request.get("model") != "databricks-llama-4-maverick":
         raise AssertionError(f"unexpected Databricks model: {databricks_request}")
     if databricks_request["messages"][-1]["content"] != "hello databricks":
         raise AssertionError(f"unexpected Databricks prompt: {databricks_request}")
-    snowflake_request = MockProviderHandler.completion_requests[29]
+    snowflake_request = MockProviderHandler.completion_requests[30]
     if snowflake_request.get("model") != "snowflake-llama-3.3-70b":
         raise AssertionError(f"unexpected Snowflake model: {snowflake_request}")
     if snowflake_request["messages"][-1]["content"] != "hello snowflake":
         raise AssertionError(f"unexpected Snowflake prompt: {snowflake_request}")
-    try_complete_request = MockProviderHandler.completion_requests[30]
+    try_complete_request = MockProviderHandler.completion_requests[31]
     if try_complete_request["messages"][-1]["content"] != "try complete smoke":
         raise AssertionError(f"unexpected try completion prompt: {try_complete_request}")
     if try_complete_request.get("max_tokens") != 5:
         raise AssertionError(f"unexpected try completion max tokens: {try_complete_request}")
+    extract_record_request = MockProviderHandler.completion_requests[32]
+    if extract_record_request["messages"][-1]["content"] != "return scalar record JSON object":
+        raise AssertionError(f"unexpected extract record prompt: {extract_record_request}")
+    if "Return only valid JSON" not in extract_record_request["messages"][0]["content"]:
+        raise AssertionError(f"unexpected extract record system prompt: {extract_record_request}")
+    rerank_request = MockProviderHandler.completion_requests[33]
+    if "Score candidate relevance" not in rerank_request["messages"][0]["content"]:
+        raise AssertionError(f"unexpected rerank system prompt: {rerank_request}")
+    if (
+        rerank_request["messages"][-1]["content"]
+        != "Query:\nanalytics database\n\nCandidate:\nDuckDB runs analytical SQL"
+    ):
+        raise AssertionError(f"unexpected rerank prompt: {rerank_request}")
     if len(MockProviderHandler.privacy_filter_requests) != 1:
         raise AssertionError(
             f"expected 1 Privacy Filter request, got {len(MockProviderHandler.privacy_filter_requests)}"
@@ -741,33 +885,44 @@ def assert_smoke_result(output: str):
     if MockProviderHandler.claude_versions != ["2023-06-01"]:
         raise AssertionError(f"unexpected Claude version headers: {MockProviderHandler.claude_versions}")
 
-    if len(MockProviderHandler.embedding_requests) != 3:
-        raise AssertionError(f"expected 3 embedding requests, got {len(MockProviderHandler.embedding_requests)}")
+    if len(MockProviderHandler.embedding_requests) != 8:
+        raise AssertionError(f"expected 8 embedding requests, got {len(MockProviderHandler.embedding_requests)}")
     embedding_request = MockProviderHandler.embedding_requests[0]
     if embedding_request["model"] != "mock-embedding-default":
         raise AssertionError(f"unexpected embedding model: {embedding_request}")
     if embedding_request["input"] != "embed smoke":
         raise AssertionError(f"unexpected embedding input: {embedding_request}")
-    similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[1:]]
+    batched_embedding_request = MockProviderHandler.embedding_requests[1]
+    if batched_embedding_request["input"] != ["embed batch one", "embed batch two", "embed batch three"]:
+        raise AssertionError(f"unexpected batched embedding input: {batched_embedding_request}")
+    similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[2:4]]
     if similarity_inputs != ["same left", "same right"]:
         raise AssertionError(f"unexpected similarity embedding inputs: {similarity_inputs}")
-    similarity_models = [request["model"] for request in MockProviderHandler.embedding_requests[1:]]
+    similarity_models = [request["model"] for request in MockProviderHandler.embedding_requests[2:4]]
     if similarity_models != ["mock-embedding-default", "mock-embedding-default"]:
         raise AssertionError(f"unexpected similarity embedding models: {similarity_models}")
+    constant_similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[4:]]
+    if constant_similarity_inputs.count("constant query") != 1:
+        raise AssertionError(f"expected one constant-side embedding, got {constant_similarity_inputs}")
+    if set(constant_similarity_inputs) != {"constant query", "candidate one", "candidate two", "candidate three"}:
+        raise AssertionError(f"unexpected constant similarity embedding inputs: {constant_similarity_inputs}")
 
-    if len(MockProviderHandler.log_requests) != 35:
-        raise AssertionError(f"expected 35 log requests, got {len(MockProviderHandler.log_requests)}")
+    log_deadline = time.time() + 5
+    while len(MockProviderHandler.log_requests) < 45 and time.time() < log_deadline:
+        time.sleep(0.05)
+    if len(MockProviderHandler.log_requests) != 45:
+        raise AssertionError(f"expected 45 log requests, got {len(MockProviderHandler.log_requests)}")
     completion_logs = [
         request for request in MockProviderHandler.log_requests if request.get("event") == "ai_completion"
     ]
     embedding_logs = [request for request in MockProviderHandler.log_requests if request.get("event") == "ai_embedding"]
     otlp_logs = [request for request in MockProviderHandler.log_requests if "resourceLogs" in request]
-    if len(completion_logs) != 31 or len(embedding_logs) != 3:
+    if len(completion_logs) != 34 or len(embedding_logs) != 10:
         raise AssertionError(f"unexpected log events: {MockProviderHandler.log_requests}")
     if len(otlp_logs) != 1:
         raise AssertionError(f"expected 1 OTLP log request, got {otlp_logs}")
     logged_providers = {request.get("provider") for request in completion_logs}
-    if not {"openai", "ollama", "claude", "databricks", "snowflake", "openai_privacy_filter"}.issubset(
+    if not {"openai", "ollama", "anthropic", "databricks", "snowflake", "openai_privacy_filter"}.issubset(
         logged_providers
     ):
         raise AssertionError(f"missing provider logs: {completion_logs}")
@@ -789,6 +944,7 @@ def assert_smoke_result(output: str):
         otlp_attrs[attribute["key"]] = value.get("stringValue", value.get("intValue"))
     expected_otlp_attrs = {
         "ai.event": "ai_completion",
+        "ai.function_name": "ai_complete",
         "ai.provider": "openai",
         "ai.protocol": "openai_chat",
         "ai.model": "mock-completion-model",
@@ -803,11 +959,14 @@ def assert_smoke_result(output: str):
             raise AssertionError(f"unexpected OTLP attribute {key}: expected {expected!r}, got {actual!r}")
     if "ai.prompt" in otlp_attrs or "ai.response" in otlp_attrs:
         raise AssertionError(f"OTLP log unexpectedly included prompt/response text: {otlp_attrs}")
+    if not otlp_attrs.get("ai.query_id", "").startswith("duckdb_ai_query_"):
+        raise AssertionError(f"OTLP log missing query id: {otlp_attrs}")
 
     log_request = completion_logs[0]
     expected_log_fields = {
         "extension": "duckdb_ai",
         "event": "ai_completion",
+        "function_name": "ai_complete",
         "provider": "openai",
         "protocol": "openai_chat",
         "model": "mock-completion-model",
@@ -823,6 +982,8 @@ def assert_smoke_result(output: str):
         actual = log_request.get(key)
         if actual != expected:
             raise AssertionError(f"unexpected log field {key}: expected {expected!r}, got {actual!r}")
+    if not log_request.get("query_id", "").startswith("duckdb_ai_query_"):
+        raise AssertionError(f"log request missing query id: {log_request}")
     estimated_cost = log_request.get("estimated_cost_usd")
     if estimated_cost is None or abs(estimated_cost - 0.000013) > 0.000000001:
         raise AssertionError(f"unexpected estimated cost: {log_request}")
@@ -855,6 +1016,7 @@ def assert_smoke_result(output: str):
     expected_embedding_log_fields = {
         "extension": "duckdb_ai",
         "event": "ai_embedding",
+        "function_name": "ai_embed",
         "provider": "openai",
         "protocol": "openai_embeddings",
         "model": "mock-embedding-default",
@@ -868,6 +1030,8 @@ def assert_smoke_result(output: str):
         actual = embedding_log_request.get(key)
         if actual != expected:
             raise AssertionError(f"unexpected embedding log field {key}: expected {expected!r}, got {actual!r}")
+    if not embedding_log_request.get("query_id", "").startswith("duckdb_ai_query_"):
+        raise AssertionError(f"embedding log missing query id: {embedding_log_request}")
     if "input" in embedding_log_request:
         raise AssertionError(f"embedding log request unexpectedly included input text: {embedding_log_request}")
 
@@ -899,6 +1063,9 @@ def main():
         MockProviderHandler.reset()
         allowlist_error_output = run_duckdb_allowlist_error(args.duckdb, f"http://127.0.0.1:{port}")
         assert_allowlist_error(allowlist_error_output)
+        MockProviderHandler.reset()
+        strict_log_error_output = run_duckdb_strict_log_error(args.duckdb, f"http://127.0.0.1:{port}", port)
+        assert_strict_log_error(strict_log_error_output)
     finally:
         server.shutdown()
         thread.join(timeout=5)

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -4,9 +4,9 @@
 
 # Before we load the extension, this will fail
 statement error
-SELECT ai_request_json('hello');
+SELECT ai_completion_request_json('hello');
 ----
-Catalog Error: Scalar Function with name ai_request_json does not exist!
+Catalog Error: Scalar Function with name ai_completion_request_json does not exist!
 
 # Require statement will ensure this test is run with this extension loaded
 require duckdb_ai
@@ -28,17 +28,17 @@ SELECT count(*) FROM ai_usage();
 0
 
 query I
-SELECT count(*) >= 8 FROM ai_models();
+SELECT count(*) >= 8 FROM ai_model_prices();
 ----
 true
 
 query IIIII
-SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_models() WHERE provider = 'openrouter' AND model = 'openai/gpt-4o-mini';
+SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'openrouter' AND model = 'openai/gpt-4o-mini';
 ----
 openrouter	openai/gpt-4o-mini	completion	0.15	0.60
 
 query I
-SELECT contains(source_url, 'openrouter.ai') FROM ai_models() WHERE provider = 'openrouter' AND model = 'openai/gpt-4o-mini';
+SELECT contains(source_url, 'openrouter.ai') FROM ai_model_prices() WHERE provider = 'openrouter' AND model = 'openai/gpt-4o-mini';
 ----
 true
 
@@ -171,43 +171,58 @@ SELECT summary FROM ai_schema_prompt(sample_rows := 101);
 ----
 Binder Error: ai_schema_prompt sample_rows must be between 0 and 100
 
-query I
-SELECT event FROM ai_usage() ORDER BY event_id DESC LIMIT 1;
+query II
+SELECT event, function_name FROM ai_usage() ORDER BY event_id DESC LIMIT 1;
 ----
-ai_schema_prompt
+ai_schema_prompt	ai_schema_prompt
 
 query I
-SELECT ai_request_json('hello', 'gpt-test', 'openai') LIKE '%"model":"gpt-test"%';
-----
-true
-
-query I
-SELECT ai_request_json('hello', provider := 'openai', model := 'gpt-test') LIKE '%"model":"gpt-test"%';
+SELECT ai_completion_request_json('hello', 'gpt-test', 'openai') LIKE '%"model":"gpt-test"%';
 ----
 true
 
 query I
-SELECT contains(ai_request_json(x, provider := 'openai', model := 'gpt-test'), '"content":"hello"') FROM (VALUES ('hello')) t(x);
+SELECT ai_completion_request_json('hello', provider := 'openai', model := 'gpt-test') LIKE '%"model":"gpt-test"%';
 ----
 true
 
 query I
-SELECT contains(ai_request_json('hello', provider := 'openai', system_prompt := 'system'), '"role":"system"');
+SELECT contains(ai_completion_request_json(x, provider := 'openai', model := 'gpt-test'), '"content":"hello"') FROM (VALUES ('hello')) t(x);
 ----
 true
 
 query I
-SELECT contains(ai_request_json('hello', provider := 'openai', temperature := 0.7, max_tokens := 42), '"temperature":0.7,"max_tokens":42');
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', system_prompt := 'system'), '"role":"system"');
 ----
 true
 
 query I
-SELECT contains(ai_request_json('hello', provider := 'openai', model := 'gpt-test', use_builtin_model_prices := true), '"model":"gpt-test"');
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', system_prompt := 'system', prompt_cache := true), '"prompt_cache_key":"duckdb-ai-');
 ----
 true
 
 query I
-SELECT contains(ai_request_json('hello', provider := 'openai', model := 'gpt-test', cache := true, allowed_hosts := 'api.openai.com:443'), '"model":"gpt-test"');
+SELECT contains(ai_completion_request_json('hello', provider := 'anthropic', system_prompt := 'system', prompt_cache := true), '"cache_control":{"type":"ephemeral"}');
+----
+true
+
+query I
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', temperature := 0.7, max_tokens := 42), '"temperature":0.7,"max_tokens":42');
+----
+true
+
+query I
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', model := 'gpt-test', use_builtin_model_prices := true), '"model":"gpt-test"');
+----
+true
+
+query I
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', model := 'gpt-test', cache := true, allowed_hosts := 'api.openai.com:443'), '"model":"gpt-test"');
+----
+true
+
+query I
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', model := 'gpt-test', cache_ttl_seconds := 60), '"model":"gpt-test"');
 ----
 true
 
@@ -218,7 +233,7 @@ statement ok
 SET duckdb_ai_allowed_hosts = 'https://api.openai.com/v1';
 
 query I
-SELECT contains(ai_request_json('hello from guarded settings', provider := 'openai', model := 'gpt-test'), '"model":"gpt-test"');
+SELECT contains(ai_completion_request_json('hello from guarded settings', provider := 'openai', model := 'gpt-test'), '"model":"gpt-test"');
 ----
 true
 
@@ -229,37 +244,37 @@ statement ok
 RESET duckdb_ai_allowed_hosts;
 
 query I
-SELECT contains(ai_request_json('json please', provider := 'openai', model := 'gpt-test', response_format := 'json_object'), '"response_format":{"type":"json_object"}');
+SELECT contains(ai_completion_request_json('json please', provider := 'openai', model := 'gpt-test', response_format := 'json_object'), '"response_format":{"type":"json_object"}');
 ----
 true
 
 query I
-SELECT contains(request, '"response_format":{"type":"json_schema"') AND contains(request, '"schema":{"type":"object","properties"') AND contains(request, '"strict":true') FROM (SELECT ai_request_json('extract', provider := 'openai', model := 'gpt-test', response_schema := '{"type":"object","properties":{"summary":{"type":"string"}}}') AS request);
+SELECT contains(request, '"response_format":{"type":"json_schema"') AND contains(request, '"schema":{"type":"object","properties"') AND contains(request, '"strict":true') FROM (SELECT ai_completion_request_json('extract', provider := 'openai', model := 'gpt-test', response_schema := '{"type":"object","properties":{"summary":{"type":"string"}}}') AS request);
 ----
 true
 
 query I
-SELECT contains(request, '"type":"array"') AND contains(request, '"type":"boolean"') FROM (SELECT ai_request_json('extract', provider := 'openai', model := 'gpt-test', response_schema := '{"type":"object","properties":{"items":{"type":"array","items":{"type":"string"}},"ok":{"type":"boolean"}}}') AS request);
+SELECT contains(request, '"type":"array"') AND contains(request, '"type":"boolean"') FROM (SELECT ai_completion_request_json('extract', provider := 'openai', model := 'gpt-test', response_schema := '{"type":"object","properties":{"items":{"type":"array","items":{"type":"string"}},"ok":{"type":"boolean"}}}') AS request);
 ----
 true
 
 query I
-SELECT contains(ai_request_json('json please', 'llama3', 'ollama', response_format := 'json_object'), '"format":"json"');
+SELECT contains(ai_completion_request_json('json please', 'llama3', 'ollama', response_format := 'json_object'), '"format":"json"');
 ----
 true
 
 query I
-SELECT ai_request_json('redact email alice@example.com', provider := 'openai_privacy_filter');
+SELECT ai_completion_request_json('redact email alice@example.com', provider := 'openai_privacy_filter');
 ----
 {"text":"redact email alice@example.com","model":"openai/privacy-filter"}
 
 query I
-SELECT ai_request_json('hello databricks', provider := 'databricks');
+SELECT ai_completion_request_json('hello databricks', provider := 'databricks');
 ----
 {"model":"databricks-llama-4-maverick","messages":[{"role":"user","content":"hello databricks"}],"temperature":0.1}
 
 query I
-SELECT ai_request_json('hello snowflake', provider := 'snowflake');
+SELECT ai_completion_request_json('hello snowflake', provider := 'snowflake');
 ----
 {"model":"snowflake-llama-3.3-70b","messages":[{"role":"user","content":"hello snowflake"}],"temperature":0.1}
 
@@ -270,7 +285,7 @@ statement ok
 SET duckdb_ai_model = 'settings-model';
 
 query I
-SELECT contains(ai_request_json('hello from settings'), '"model":"settings-model"');
+SELECT contains(ai_completion_request_json('hello from settings'), '"model":"settings-model"');
 ----
 true
 
@@ -278,12 +293,12 @@ statement ok
 SET duckdb_ai_completion_model = 'completion-settings-model';
 
 query I
-SELECT contains(ai_request_json('hello from completion settings'), '"model":"completion-settings-model"');
+SELECT contains(ai_completion_request_json('hello from completion settings'), '"model":"completion-settings-model"');
 ----
 true
 
 query I
-SELECT contains(ai_request_json('hello with explicit model', model := 'explicit-model'), '"model":"explicit-model"');
+SELECT contains(ai_completion_request_json('hello with explicit model', model := 'explicit-model'), '"model":"explicit-model"');
 ----
 true
 
@@ -326,7 +341,7 @@ SELECT provider, has_api_key FROM ai_secrets() WHERE name = 'ai_test_openai';
 openai	true
 
 query I
-SELECT contains(ai_request_json('hello from scoped secret', provider := 'openai'), '"model":"secret-model"');
+SELECT contains(ai_completion_request_json('hello from scoped secret', provider := 'openai'), '"model":"secret-model"');
 ----
 true
 
@@ -334,22 +349,22 @@ statement ok
 CREATE OR REPLACE SECRET ai_named_gemini (TYPE duckdb_ai, AI_PROVIDER 'gcp', API_KEY 'gemini-key', MODEL 'gemini-secret-model');
 
 query I
-SELECT contains(ai_request_json('hello from named secret', secret := 'ai_named_gemini'), '"model":"gemini-secret-model"');
+SELECT contains(ai_completion_request_json('hello from named secret', secret := 'ai_named_gemini'), '"model":"gemini-secret-model"');
 ----
 true
 
 query I
-SELECT ai_request_json('hello', secret := 'missing_secret', fail_on_error := false) IS NULL;
+SELECT ai_completion_request_json('hello', secret := 'missing_secret', fail_on_error := false) IS NULL;
 ----
 true
 
 query I
-SELECT contains(ai_request_json('hello "duck"', 'llama3', 'ollama'), chr(92) || chr(34) || 'duck' || chr(92) || chr(34));
+SELECT contains(ai_completion_request_json('hello "duck"', 'llama3', 'ollama'), chr(92) || chr(34) || 'duck' || chr(92) || chr(34));
 ----
 true
 
 query I
-SELECT contains(ai_request_json('line1' || chr(10) || 'line2' || chr(9) || 'tab' || chr(92) || 'slash', provider := 'openai', model := 'gpt-test'), 'line1' || chr(92) || 'nline2' || chr(92) || 'ttab' || chr(92) || chr(92) || 'slash');
+SELECT contains(ai_completion_request_json('line1' || chr(10) || 'line2' || chr(9) || 'tab' || chr(92) || 'slash', provider := 'openai', model := 'gpt-test'), 'line1' || chr(92) || 'nline2' || chr(92) || 'ttab' || chr(92) || chr(92) || 'slash');
 ----
 true
 
@@ -369,7 +384,17 @@ SELECT ai_similarity('duck', 'db', provider := 'claude', fail_on_error := false)
 true
 
 query I
+SELECT ai_rerank('duck', 'analytical database', provider := 'not-a-provider', fail_on_error := false) IS NULL;
+----
+true
+
+query I
 SELECT ai_complete('hello', provider := 'not-a-provider', fail_on_error := false) IS NULL;
+----
+true
+
+query I
+SELECT ai_complete('hello', provider := 'not-a-provider', on_error := 'null') IS NULL;
 ----
 true
 
@@ -424,6 +449,16 @@ SELECT ai_classify('great', 'positive, negative', provider := 'not-a-provider', 
 true
 
 query I
+SELECT ai_classify('great', ['positive, favorable', 'negative'], provider := 'not-a-provider', fail_on_error := false) IS NULL;
+----
+true
+
+query I
+SELECT ai_classify_labels('great', ['positive, favorable', 'negative'], provider := 'not-a-provider', fail_on_error := false) IS NULL;
+----
+true
+
+query I
 SELECT ai_extract('name: DuckDB', 'name', provider := 'not-a-provider', fail_on_error := false) IS NULL;
 ----
 true
@@ -459,7 +494,7 @@ SELECT sql IS NULL FROM ai_fix_sql('SEELECT 42', provider := 'not-a-provider', f
 true
 
 query I
-SELECT line_number IS NULL AND replacement_line IS NULL FROM ai_fix_sql_line('SEELECT 42', error := 'Parser Error: syntax error at or near "SEELECT" LINE 1: SEELECT 42', provider := 'not-a-provider', fail_on_error := false);
+SELECT line_number IS NULL AND replacement_line IS NULL FROM ai_fix_sql('SEELECT 42', mode := 'line', error := 'Parser Error: syntax error at or near "SEELECT" LINE 1: SEELECT 42', provider := 'not-a-provider', fail_on_error := false);
 ----
 true
 
@@ -474,57 +509,67 @@ SELECT * FROM ai_query_data('count rows', sample_rows := 101);
 Binder Error: ai_query_data sample_rows must be between 0 and 100
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', temperature := 3.0);
+SELECT ai_completion_request_json('hello', provider := 'openai', temperature := 3.0);
 ----
 Binder Error: AI option "temperature" must be between 0 and 2
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', log_sample_rate := 1.5);
+SELECT ai_completion_request_json('hello', provider := 'openai', log_sample_rate := 1.5);
 ----
 Binder Error: AI option "log_sample_rate" must be between 0 and 1
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', log_format := 'xml');
+SELECT ai_completion_request_json('hello', provider := 'openai', log_format := 'xml');
 ----
-Binder Error: AI option "log_format" must be one of: generic_json, otlp_json
+Binder Error: AI option "log_format" must be one of: generic, json, generic_json, otlp, otlp_json
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', retry_count := 11);
+SELECT ai_completion_request_json('hello', provider := 'openai', on_error := 'ignore');
+----
+Binder Error: AI option "on_error" must be one of: fail, null, capture
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai', retry_count := 11);
 ----
 Binder Error: AI option "retry_count" must be between 0 and 10
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', retry_backoff_ms := 60001);
+SELECT ai_completion_request_json('hello', provider := 'openai', retry_backoff_ms := 60001);
 ----
 Binder Error: AI option "retry_backoff_ms" must be between 0 and 60000
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', max_concurrent_requests := -1);
+SELECT ai_completion_request_json('hello', provider := 'openai', max_concurrent_requests := -1);
 ----
-Binder Error: AI option "max_concurrent_requests" must be between 0 and 1024
+Binder Error: AI option "max_concurrent_requests" must be between 0 and 64
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', min_request_interval_ms := 60001);
+SELECT ai_completion_request_json('hello', provider := 'openai', min_request_interval_ms := 60001);
 ----
 Binder Error: AI option "min_request_interval_ms" must be between 0 and 60000
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', token_limit_per_minute := -1);
+SELECT ai_completion_request_json('hello', provider := 'openai', token_limit_per_minute := -1);
 ----
 Binder Error: AI option "token_limit_per_minute" must be between 0 and 10000000000
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', token_limit_per_minute := 10000000001);
+SELECT ai_completion_request_json('hello', provider := 'openai', token_limit_per_minute := 10000000001);
 ----
 Binder Error: AI option "token_limit_per_minute" must be between 0 and 10000000000
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', input_token_price_per_million := -0.1);
+SELECT ai_completion_request_json('hello', provider := 'openai', cache_ttl_seconds := -1);
+----
+Binder Error: AI option "cache_ttl_seconds" must be between 0 and 31536000
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai', input_token_price_per_million := -0.1);
 ----
 Binder Error: AI option "input_token_price_per_million" must be greater than or equal to 0
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', output_token_price_per_million := -0.1);
+SELECT ai_completion_request_json('hello', provider := 'openai', output_token_price_per_million := -0.1);
 ----
 Binder Error: AI option "output_token_price_per_million" must be greater than or equal to 0
 
@@ -532,7 +577,7 @@ statement ok
 SET duckdb_ai_log_sample_rate = 2.0;
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai');
+SELECT ai_completion_request_json('hello', provider := 'openai');
 ----
 Binder Error: Setting duckdb_ai_log_sample_rate must be between 0 and 1
 
@@ -543,9 +588,9 @@ statement ok
 SET duckdb_ai_log_format = 'xml';
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai');
+SELECT ai_completion_request_json('hello', provider := 'openai');
 ----
-Binder Error: Setting duckdb_ai_log_format must be one of: generic_json, otlp_json
+Binder Error: Setting duckdb_ai_log_format must be one of: generic, json, generic_json, otlp, otlp_json
 
 statement ok
 RESET duckdb_ai_log_format;
@@ -554,7 +599,7 @@ statement ok
 SET duckdb_ai_retry_count = 11;
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai');
+SELECT ai_completion_request_json('hello', provider := 'openai');
 ----
 Binder Error: Setting duckdb_ai_retry_count must be between 0 and 10
 
@@ -562,12 +607,12 @@ statement ok
 RESET duckdb_ai_retry_count;
 
 statement ok
-SET duckdb_ai_max_concurrent_requests = 1025;
+SET duckdb_ai_max_concurrent_requests = 65;
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai');
+SELECT ai_completion_request_json('hello', provider := 'openai');
 ----
-Binder Error: Setting duckdb_ai_max_concurrent_requests must be between 0 and 1024, or -1 to disable
+Binder Error: Setting duckdb_ai_max_concurrent_requests must be between 0 and 64, or -1 to disable
 
 statement ok
 RESET duckdb_ai_max_concurrent_requests;
@@ -576,7 +621,7 @@ statement ok
 SET duckdb_ai_min_request_interval_ms = 60001;
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai');
+SELECT ai_completion_request_json('hello', provider := 'openai');
 ----
 Binder Error: Setting duckdb_ai_min_request_interval_ms must be between 0 and 60000, or -1 to disable
 
@@ -587,7 +632,7 @@ statement ok
 SET duckdb_ai_token_limit_per_minute = 10000000001;
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai');
+SELECT ai_completion_request_json('hello', provider := 'openai');
 ----
 Binder Error: Setting duckdb_ai_token_limit_per_minute must be between 0 and 10000000000, or -1 to disable
 
@@ -598,7 +643,7 @@ statement ok
 SET duckdb_ai_input_token_price_per_million = -2.0;
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai');
+SELECT ai_completion_request_json('hello', provider := 'openai');
 ----
 Binder Error: Setting duckdb_ai_input_token_price_per_million must be greater than or equal to 0, or -1 to disable
 
@@ -606,17 +651,17 @@ statement ok
 RESET duckdb_ai_input_token_price_per_million;
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', response_format := 'xml');
+SELECT ai_completion_request_json('hello', provider := 'openai', response_format := 'xml');
 ----
 Binder Error: AI option "response_format" must be one of: text, json_object, json_schema
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', response_schema := 'not-json');
+SELECT ai_completion_request_json('hello', provider := 'openai', response_schema := 'not-json');
 ----
 Binder Error: AI option "response_schema" must be valid JSON:
 
 statement error
-SELECT ai_request_json('hello', provider := 'openai', response_schema := '{"type":"object"} trailing');
+SELECT ai_completion_request_json('hello', provider := 'openai', response_schema := '{"type":"object"} trailing');
 ----
 Binder Error: AI option "response_schema" must be valid JSON:
 


### PR DESCRIPTION
## Summary

Implements the duckdb_ai review pass across provider caching, runtime hardening, function surface gaps, and public docs.

## Why

The review identified cost, latency, observability, and API-shape issues that matter for row-wise AI enrichment workloads: provider-side prompt caching, cache visibility, batching, failed-request visibility, and missing scalar primitives. This PR tightens those paths before the SQL surface settles further.

## Changes

- Add prompt-cache controls and cached-token accounting for OpenAI-compatible and Anthropic providers, plus structural completion parsing and targeted truncation errors.
- Harden runtime behavior with response-cache LRU/TTL/dogpile protection, async usage logging, failed usage events, query/function IDs, connect timeouts, User-Agent headers, shared libcurl connections, env option snapshots, and stricter concurrency handling.
- Expand and rationalize SQL surface with ai_extract_record, batched embeddings, constant-side ai_similarity reuse, ai_classify_labels, ai_rerank, on_error, ai_fix_sql mode := 'line', generated-SQL caching, and naming/docs updates.
- Update README and docs for provider guides, runtime behavior, best practices, function reference, data-flow notes, provider-native batch export, prompt caching, and multi-turn scope.

## Validation

```sh
PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
GEN=ninja make release
GEN=ninja make test
python3 test/smoke/mock_provider_smoke.py
(cd website && npm run typecheck)
(cd website && npm run build)
git diff --check
```

## Notes

No live provider smoke tests were run; deterministic coverage uses SQLLogic and the mock provider smoke test.
