### PR TITLE
release: prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.2.0 - 2026-07-02
+
+### SQL API changes
+
+- Renamed `ai_request_json` to `ai_completion_request_json` and `ai_models` to
+  `ai_model_prices`.
+- Merged `ai_fix_sql_line` into `ai_fix_sql` behind `mode := 'line'`; passing
+  `error := ...` also selects line mode.
+- Renamed the `duckdb_ai_sql_model` setting to `duckdb_ai_sql_assistant_model`.
+- The canonical Anthropic provider name is now `anthropic`; `claude` remains an
+  accepted alias. The Anthropic default model is now `claude-haiku-4-5`.
+- `response_schema` now raises an explicit error on the Anthropic protocol
+  instead of being silently ignored.
+
+### Added
+
+- `ai_extract_record(text, response_schema)` scalar function returning typed
+  per-row `STRUCT` values.
+- `ai_rerank(query, candidate)` and `ai_classify_labels(text, labels)`
+  (multi-label classification returning `VARCHAR[]`); `ai_classify` also
+  accepts a `VARCHAR[]` label list.
+- `on_error := 'fail' | 'null' | 'capture'` across function families,
+  subsuming `fail_on_error` (kept as a compatibility alias).
+- Provider-side prompt caching hints behind `prompt_cache := true` /
+  `duckdb_ai_prompt_cache`: `prompt_cache_key` for OpenAI and
+  `cache_control` breakpoints for Anthropic, with cached token counts parsed
+  into usage and cost estimation.
+- Batched embedding requests: `ai_embed` sends chunk inputs in batched provider
+  requests (up to 512 inputs per request), including when the response cache is
+  enabled.
+- Response-cache TTL (`cache_ttl_seconds` / `duckdb_ai_cache_ttl_seconds`),
+  LRU eviction, and in-flight coalescing of identical requests.
+- Failed provider calls are recorded in `ai_usage()` with new `function_name`,
+  `query_id`, `cached_prompt_tokens`, `cache_creation_prompt_tokens`,
+  `retries`, `cache_hit`, `status`, and `error` columns.
+- Task-wrapper, JSON, and SQL-assistant instructions moved into provider
+  system prompts to form stable cacheable prefixes.
+- Connect timeouts (`DUCKDB_AI_CONNECT_TIMEOUT_SECONDS`), a `User-Agent`
+  header, and truncation detection that raises when responses stop at
+  `max_tokens`.
+
+### Fixed and performance
+
+- Structural response parsing per provider protocol (single JSON parse per
+  response) instead of recursive first-match field scans.
+- Shared libcurl connection, DNS, and TLS-session caches across worker threads
+  with per-lock-class mutexes.
+- Response-cache LRU updates are O(1); entries whose responses fail parsing
+  (for example truncated output) are evicted instead of poisoning later hits.
+- Coalesced duplicate requests are interruptible and no longer double-count
+  tokens and cost in usage events.
+- Queued best-effort usage logs are posted from a background worker and dropped
+  on shutdown instead of blocking database close.
+- Retry backoff no longer holds a concurrency slot while sleeping; secrets and
+  environment configuration are resolved once per chunk/bind instead of per
+  row; query interrupts are no longer recorded as provider errors.
+
+### Runtime hardening (shipped after the 0.1.0 tag)
+
 - Added per-database runtime state for usage events, response caching, and rate
   limiting.
 - Added opt-in response caching through `cache := true`, `duckdb_ai_cache`, and
@@ -25,3 +84,11 @@ include SQL API changes and patch versions should preserve the SQL API.
 - Added security/data-flow documentation and a root security policy.
 - Updated CI so pull requests run release build, SQLLogic tests, and the
   deterministic mock-provider smoke test.
+
+## 0.1.0 - 2026-07-01
+
+- Initial release: completion, task, embedding, aggregate, and SQL-assistant
+  functions across Ollama, OpenAI, Azure, Anthropic, Gemini, Mistral,
+  DeepSeek, OpenRouter, Databricks, Snowflake, Z.ai, Privacy Filter, and
+  OpenAI-compatible providers, with DuckDB secrets, request-preview functions,
+  usage tracking, and batch rate controls.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 
 # duckdb-ai
 
-duckdb-ai is a DuckDB extension for model-backed analytical workflows inside
-SQL. It adds functions for completions, structured JSON extraction, embeddings,
-natural-language filters, read-only SQL generation, and usage tracking.
+[![CI](https://github.com/leonardovida/duckdb-ai/actions/workflows/MainDistributionPipeline.yml/badge.svg)](https://github.com/leonardovida/duckdb-ai/actions/workflows/MainDistributionPipeline.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-The extension is intended for local analytics work where data already lives in
-DuckDB. You can enrich table columns with model output, project JSON responses
-into typed DuckDB values, compare text with embeddings, and ask questions over a
-bounded schema prompt without moving the workflow into a separate application.
+Run language models on the data you already have in DuckDB — summarize,
+classify, extract, embed, redact, and generate SQL, all from plain SQL
+functions. No pipeline to a separate application, no data leaving your
+machine unless you choose a hosted provider.
 
 ```sql
--- From a local source build.
 LOAD duckdb_ai;
 
 SELECT ai_summarize(
@@ -24,29 +22,42 @@ SELECT ai_summarize(
 );
 ```
 
-The public API keeps provider credentials out of SQL arguments, supports DuckDB
-`TYPE duckdb_ai` secrets, and validates generated SQL as a single read-only
-DuckDB `SELECT` before returning or executing it.
+One extension covers both ends of the spectrum:
+
+- **Working on your laptop?** Point it at [Ollama](https://ollama.com) or any
+  OpenAI-compatible local server and enrich tables with a free local model —
+  nothing ever leaves your machine.
+- **Running this for a team or company?** Route calls through your own gateway
+  (Azure OpenAI, Databricks, Snowflake Cortex, vLLM, LiteLLM), keep credentials
+  in DuckDB secrets or environment variables, restrict network egress to an
+  allowlist, track per-call tokens and estimated cost in `ai_usage()`, and ship
+  privacy-minimized usage logs to your own collector.
 
 ## What You Can Do
 
 - Summarize, translate, redact, classify, and extract text from SQL queries.
-- Generate valid JSON or typed DuckDB columns from model output.
-- Create embeddings and compare text with cosine similarity.
+- Generate valid JSON, typed DuckDB columns, or per-row `STRUCT` values from
+  model output, validated against a JSON Schema.
+- Create embeddings (batched automatically per chunk), compare text with cosine
+  similarity, and rerank candidates.
 - Ask questions about local tables and generate read-only DuckDB `SELECT`
-  statements.
+  statements — generated SQL is parser-validated before it runs.
 - Route model calls across local Ollama, hosted providers, and
-  OpenAI-compatible gateways.
+  OpenAI-compatible gateways, with per-call, per-session, or secret-based
+  configuration.
 - Store credentials in DuckDB secrets instead of passing API keys through SQL
   function arguments.
-- Inspect local usage events and optionally send privacy-minimized usage logs to
-  your own collector.
+- Control throughput with concurrency caps, request pacing, token-per-minute
+  budgets, retries with backoff, and opt-in response and prompt caching.
+- Inspect local usage events — including failures, retries, cache hits, and
+  estimated cost — and optionally send privacy-minimized usage logs to your own
+  collector.
 
 ## Quick Start
 
-`duckdb_ai` is not published in the DuckDB community extension repository yet.
-Until the manual community submission is accepted, build and load it from this
-source tree:
+`duckdb_ai` is not published in the DuckDB community extension repository yet
+(submission in progress). Until then, build and load it from this source tree
+(requires a C++ toolchain, CMake, and ninja):
 
 ```sh
 GEN=ninja make release
@@ -412,9 +423,10 @@ instead of a bare `NULL`.
 
 ## Usage And Cost Visibility
 
-Successful completions, embeddings, and local `ai_schema_prompt` calls are kept
-in a local in-process ring buffer with function name, query id, provider,
-latency, token, cache, status, error, and cost metadata:
+Completions, embeddings, and local `ai_schema_prompt` calls — including failed
+provider calls — are kept in a local in-process ring buffer with function name,
+query id, provider, latency, token, cache, retry, status, error, and cost
+metadata:
 
 ```sql
 SELECT * FROM ai_usage();
@@ -470,13 +482,20 @@ calls. The token limit uses the local `ai_count_tokens` estimate plus
 Set `max_tokens` for large jobs so the runtime can pace requests against your
 provider's current tokens-per-minute limit.
 
-Response caching is opt-in and in-memory:
+Response caching is opt-in and in-memory. Identical in-flight requests are
+coalesced into one provider call, and cached entries can expire with a TTL:
 
 ```sql
 SET duckdb_ai_cache = true;
+SET duckdb_ai_cache_ttl_seconds = 3600;
 SELECT ai_complete('Summarize this repeated prompt.');
 SELECT * FROM ai_clear_cache();
 ```
+
+Provider-side prompt caching is separate and reduces cost on repeated static
+prefixes (system prompts, schemas). Enable it with `prompt_cache := true` or
+`SET duckdb_ai_prompt_cache = true`; the extension sends the matching cache
+hints for OpenAI and Anthropic and reports cached token counts in `ai_usage()`.
 
 Use `ai_recommended_batch_size` with a small provider-limit table to pick a
 starting batch size before running a large enrichment:

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(duckdb_ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.1.0
+    EXTENSION_VERSION 0.2.0
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
Prepares the 0.2.0 release.

- Bumps `EXTENSION_VERSION` to 0.2.0.
- Adds the 0.2.0 changelog section: SQL API renames from the hardening pass (`ai_completion_request_json`, `ai_model_prices`, merged `ai_fix_sql` modes, `anthropic` canonical provider), new functions (`ai_extract_record`, `ai_rerank`, `ai_classify_labels`), prompt caching, batched embeddings, usage/observability columns, and the performance/correctness fixes from #17. Reattributes the stale Unreleased entries (shipped after the 0.1.0 tag) to 0.2.0.
- README: leads with a value-focused intro addressing both individual and team/enterprise use, adds CI/license badges, and updates the caching and usage-visibility sections to match 0.2.0 behavior.

Validation: `make release`, `make test` (164 assertions), mock-provider smoke, `format-check` all pass.