### PR TITLE
release: rename extension to ai and prepare 0.3.0

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -169,4 +169,4 @@ jobs:
     with:
       duckdb_version: v1.5.4
       ci_tools_version: v1.5-variegata
-      extension_name: duckdb_ai
+      extension_name: ai

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Instructions
 
-This repository contains the `duckdb_ai` DuckDB extension. Keep changes scoped,
+This repository contains the `ai` DuckDB extension (repository name duckdb-ai). Keep changes scoped,
 source-backed, and validated against the local DuckDB extension tooling.
 
 ## Project Layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.3.0 - 2026-07-02
+
+### SQL API changes
+
+- Renamed the extension from `duckdb_ai` to `ai` ahead of the community
+  extension submission: use `INSTALL ai FROM community; LOAD ai;`. Function
+  names, `TYPE duckdb_ai` secrets, `duckdb_ai_*` settings, and `DUCKDB_AI_*`
+  environment variables are unchanged.
+
 ## 0.2.0 - 2026-07-02
 
 ### SQL API changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,67 @@
-AGENTS.md
+# Repository Instructions
+
+This repository contains the `ai` DuckDB extension (repository name duckdb-ai). Keep changes scoped,
+source-backed, and validated against the local DuckDB extension tooling.
+
+## Project Layout
+
+- `src/` contains the C++ extension implementation and public headers.
+- `test/sql/duckdb_ai.test` contains deterministic SQLLogic coverage.
+- `test/smoke/mock_provider_smoke.py` covers mock HTTP provider behavior without
+  external network calls.
+- `docs/` is the Docusaurus docs source.
+- `website/` contains the Docusaurus site configuration and frontend.
+- `duckdb/` and `extension-ci-tools/` are submodules/vendor tooling; avoid
+  editing them unless the task explicitly requires it.
+- `local-docs/` is an ignored local research corpus and should stay out of git.
+
+## Build And Test
+
+Use the repo Makefile from the root:
+
+```sh
+GEN=ninja make release
+GEN=ninja make test
+python3 test/smoke/mock_provider_smoke.py
+```
+
+The formatter gate uses DuckDB's formatter. On this machine, the formatter tools
+are available in `/tmp/duckdb_ai_format_venv/bin`:
+
+```sh
+PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
+PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-fix
+```
+
+For docs changes, also run from `website/`:
+
+```sh
+npm run typecheck
+npm run build
+```
+
+## Implementation Guidance
+
+- Prefer DuckDB extension patterns already used in `src/duckdb_ai_extension.cpp`
+  and `src/duckdb_ai_provider.cpp`.
+- Keep SQL function names, argument order, named options, table result schemas,
+  and usage-log fields stable unless the task explicitly changes the public API.
+- Keep provider credentials out of SQL arguments. Use environment variables or
+  `TYPE duckdb_ai` DuckDB secrets.
+- Keep deterministic tests free of live network calls. Use
+  `ai_request_json(...)` and mock-provider tests for request-shape and provider
+  behavior.
+- Only run live Ollama or remote-provider smoke tests when the task explicitly
+  asks for them or provides credentials/context.
+- If Linux container validation is needed on this machine, prefer a copy under
+  `/Users/leov/Documents/...` and set `CMAKE_BUILD_PARALLEL_LEVEL=1` to avoid
+  local Docker/Colima memory pressure.
+
+## Documentation Guidance
+
+- Document public SQL functions in `docs/functions.md` using DuckDB-style
+  reference sections: overview table, description, example, and result shape.
+- Keep `README.md` as the high-level usage entry point and link to deeper docs
+  instead of duplicating the full function reference.
+- When adding a Docusaurus page, wire it through `website/sidebars.ts` and run
+  the website typecheck/build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # Set extension name here
-set(TARGET_NAME duckdb_ai)
+set(TARGET_NAME ai)
 
 # DuckDB's extension distribution supports vcpkg. Dependencies can be added in
 # ./vcpkg.json and then used in cmake with find_package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for improving `duckdb_ai`. This repository follows DuckDB extension
+Thanks for improving the `ai` extension. This repository follows DuckDB extension
 tooling, keeps public SQL behavior stable, and makes provider interactions
 deterministic in the default test suite.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Configuration of extension
-EXT_NAME=duckdb_ai
+EXT_NAME=ai
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
 # Include the Makefile from extension-ci-tools

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ functions. No pipeline to a separate application, no data leaving your
 machine unless you choose a hosted provider.
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 SELECT ai_summarize(
     'DuckDB is an analytical database built for fast local queries.',
@@ -55,7 +55,7 @@ One extension covers both ends of the spectrum:
 
 ## Quick Start
 
-`duckdb_ai` is not published in the DuckDB community extension repository yet
+The `ai` extension is not published in the DuckDB community extension repository yet
 (submission in progress). Until then, build and load it from this source tree
 (requires a C++ toolchain, CMake, and ninja):
 
@@ -67,7 +67,7 @@ GEN=ninja make release
 Then load the extension:
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 ```
 
 Confirm that the extension loaded:
@@ -86,7 +86,7 @@ ollama pull gemma4:e4b
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 SET duckdb_ai_provider = 'ollama';
 SET duckdb_ai_model = 'gemma4:e4b';
@@ -97,7 +97,7 @@ SELECT ai_complete('Write one sentence about DuckDB.');
 For OpenAI, store the API key in a DuckDB secret:
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET openai_ai (
     TYPE duckdb_ai,

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -325,7 +325,7 @@ or an `s3://...` target when failures should live outside the DuckDB database.
 
 ## Export provider-native batch requests for offline jobs
 
-`duckdb_ai` runs provider calls synchronously inside the DuckDB query. For
+The `ai` extension runs provider calls synchronously inside the DuckDB query. For
 overnight jobs that should use provider-native Batch APIs, materialize request
 bodies with the request-preview functions, then submit and poll them with your
 job runner or provider SDK:

--- a/docs/cookbooks/support-ticket-data.md
+++ b/docs/cookbooks/support-ticket-data.md
@@ -9,7 +9,7 @@ metadata, timestamps, free-text ticket fields, numeric account context, and an
 internal note column with realistic content for redaction tests.
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE TABLE support_tickets AS
 SELECT *

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # SQL function reference
 
-This page documents the public SQL surface registered by the `duckdb_ai`
+This page documents the public SQL surface registered by the `ai`
 extension. The layout follows the DuckDB function reference style: a compact
 overview table first, then each function with description, example, and result
 shape.

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -60,7 +60,7 @@ ollama pull nomic-embed-text
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET ollama_ai (
     TYPE duckdb_ai,
@@ -92,7 +92,7 @@ export OPENAI_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET openai_ai (
     TYPE duckdb_ai,
@@ -136,7 +136,7 @@ export AZURE_OPENAI_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET azure_ai (
     TYPE duckdb_ai,
@@ -168,7 +168,7 @@ export ANTHROPIC_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET claude_ai (
     TYPE duckdb_ai,
@@ -202,7 +202,7 @@ export GEMINI_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET gemini_ai (
     TYPE duckdb_ai,
@@ -232,7 +232,7 @@ export MISTRAL_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET mistral_ai (
     TYPE duckdb_ai,
@@ -260,7 +260,7 @@ export ZAI_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET zai_ai (
     TYPE duckdb_ai,
@@ -290,7 +290,7 @@ export DEEPSEEK_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET deepseek_ai (
     TYPE duckdb_ai,
@@ -321,7 +321,7 @@ export OPENROUTER_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET openrouter_ai (
     TYPE duckdb_ai,
@@ -357,7 +357,7 @@ export DATABRICKS_HOST='https://<workspace>.cloud.databricks.com'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET databricks_ai (
     TYPE duckdb_ai,
@@ -390,7 +390,7 @@ export SNOWFLAKE_ACCOUNT_URL='https://<account-identifier>.snowflakecomputing.co
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET snowflake_ai (
     TYPE duckdb_ai,
@@ -430,7 +430,7 @@ export OPF_CHECKPOINT="$HOME/.opf/privacy_filter"
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET privacy_filter_local (
     TYPE duckdb_ai,
@@ -500,7 +500,7 @@ ollama pull llama3.2
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET local_openai_ai (
     TYPE duckdb_ai,
@@ -523,7 +523,7 @@ export OPENAI_COMPATIBLE_API_KEY='...'
 ```
 
 ```sql
-LOAD duckdb_ai;
+LOAD ai;
 
 CREATE OR REPLACE SECRET gateway_ai (
     TYPE duckdb_ai,

--- a/docs/runtime-behavior.md
+++ b/docs/runtime-behavior.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Runtime behavior
 
-This page documents how `duckdb_ai` executes provider calls at runtime. It is
+This page documents how the `ai` extension executes provider calls at runtime. It is
 the operational reference for the provider hardening, caching, concurrency, and
 egress controls used by the SQL functions.
 

--- a/docs/security-data-flow.md
+++ b/docs/security-data-flow.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # Security and data flow
 
-`duckdb_ai` is a network-calling DuckDB extension. Treat every provider call as
+The `ai` extension is a network-calling DuckDB extension. Treat every provider call as
 an explicit data egress path from DuckDB to the configured provider or gateway.
 
 ## Defaults

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,9 +1,9 @@
 # This file is included by DuckDB's build system. It specifies which extension to load
 
 # Extension from this repo
-duckdb_extension_load(duckdb_ai
+duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.2.0
+    EXTENSION_VERSION 0.3.0
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -1,6 +1,6 @@
 #define DUCKDB_EXTENSION_MAIN
 
-#include "duckdb_ai_extension.hpp"
+#include "ai_extension.hpp"
 #include "duckdb_ai_provider.hpp"
 
 #include "duckdb.hpp"
@@ -5407,16 +5407,16 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    TableFunction("ai_model_prices", {}, AiModelPricesFunction, AiModelPricesBind, AiModelPricesInit));
 }
 
-void DuckdbAiExtension::Load(ExtensionLoader &loader) {
+void AiExtension::Load(ExtensionLoader &loader) {
 	LoadInternal(loader);
 }
-std::string DuckdbAiExtension::Name() {
-	return "duckdb_ai";
+std::string AiExtension::Name() {
+	return "ai";
 }
 
-std::string DuckdbAiExtension::Version() const {
-#ifdef EXT_VERSION_DUCKDB_AI
-	return EXT_VERSION_DUCKDB_AI;
+std::string AiExtension::Version() const {
+#ifdef EXT_VERSION_AI
+	return EXT_VERSION_AI;
 #else
 	return "";
 #endif
@@ -5426,7 +5426,7 @@ std::string DuckdbAiExtension::Version() const {
 
 extern "C" {
 
-DUCKDB_CPP_EXTENSION_ENTRY(duckdb_ai, loader) {
+DUCKDB_CPP_EXTENSION_ENTRY(ai, loader) {
 	duckdb::LoadInternal(loader);
 }
 }

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -579,10 +579,10 @@ std::string JsonDouble(double input) {
 uint64_t StableHash(const std::string &input);
 
 std::string ExtensionUserAgent() {
-#ifdef EXT_VERSION_DUCKDB_AI
-	return std::string("duckdb_ai/") + EXT_VERSION_DUCKDB_AI;
+#ifdef EXT_VERSION_AI
+	return std::string("duckdb-ai/") + EXT_VERSION_AI;
 #else
-	return "duckdb_ai/dev";
+	return "duckdb-ai/dev";
 #endif
 }
 

--- a/src/include/ai_extension.hpp
+++ b/src/include/ai_extension.hpp
@@ -4,8 +4,8 @@
 
 namespace duckdb {
 
-//! DuckDB extension entry point for registering the duckdb_ai SQL surface.
-class DuckdbAiExtension : public Extension {
+//! DuckDB extension entry point for registering the ai extension SQL surface.
+class AiExtension : public Extension {
 public:
 	//! Register settings, secrets, scalar functions, aggregate functions, and table functions.
 	void Load(ExtensionLoader &db) override;

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -9,7 +9,7 @@ SELECT ai_completion_request_json('hello');
 Catalog Error: Scalar Function with name ai_completion_request_json does not exist!
 
 # Require statement will ensure this test is run with this extension loaded
-require duckdb_ai
+require ai
 
 # Provider metadata is deterministic and does not perform network calls.
 query I


### PR DESCRIPTION
Renames the extension from `duckdb_ai` to `ai` ahead of the community-extensions submission, and prepares the 0.3.0 release.

- `INSTALL ai FROM community; LOAD ai;` — matches the `ai_*` function prefix and the unprefixed naming convention used by 263 of 268 community extensions.
- Renamed: `DUCKDB_CPP_EXTENSION_ENTRY`, extension class/header (`AiExtension` / `ai_extension.hpp`), CMake `TARGET_NAME`, Makefile `EXT_NAME`, CI `extension_name`, `EXT_VERSION_AI` macro.
- Unchanged (deliberately): `ai_*` SQL functions, `TYPE duckdb_ai` secrets, `duckdb_ai_*` settings, `DUCKDB_AI_*` env vars, C++ namespace, and the repository name.
- Docs/tests updated; `EXTENSION_VERSION` bumped to 0.3.0 with a changelog entry.

Validation: `make release`, `make test` (164 assertions), mock smoke, `format-check`, and website typecheck+build all pass. `duckdb_extensions()` reports `ai / 0.3.0`.