### PR TITLE
fix: define NOMINMAX on Windows so MSVC builds compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ set(EXTENSION_SOURCES
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
+if(WIN32)
+  # curl.h pulls in windows.h, whose min/max macros break std::min/std::max and
+  # std::numeric_limits<T>::max() under MSVC.
+  target_compile_definitions(${EXTENSION_NAME} PRIVATE NOMINMAX)
+  target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE NOMINMAX)
+endif()
+
 if(TARGET CURL::libcurl)
   target_link_libraries(${EXTENSION_NAME} CURL::libcurl)
   target_link_libraries(${LOADABLE_EXTENSION_NAME} CURL::libcurl)


### PR DESCRIPTION
## What changed
- `CMakeLists.txt`: define `NOMINMAX` on the extension targets for Windows builds.

## Motivation
The `windows_amd64` build in duckdb/community-extensions#2169 fails with `C2589: '(': illegal token on right side of '::'` in `src/duckdb_ai_provider.cpp`. `curl.h` includes `windows.h`, whose `min`/`max` macros break `std::min`/`std::max` and `std::numeric_limits<T>::max()` under MSVC. `NOMINMAX` disables those macros.

Verified locally: `GEN=ninja make release`, `make test` (164 assertions), mock provider smoke test, and format-check all pass.