### PR TITLE
release: prepare 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.3.1 - 2026-07-02
+
+### Fixed
+
+- Defined `NOMINMAX` for Windows builds so the `windows_amd64` MSVC build
+  compiles: `windows.h` (included via curl) defines `min`/`max` macros that
+  broke `std::min`/`std::max` and `std::numeric_limits<T>::max()`.
+
 ## 0.3.0 - 2026-07-02
 
 ### SQL API changes

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.3.0
+    EXTENSION_VERSION 0.3.1
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
Patch release for the Windows amd64 build fix (#20).

- Bump `EXTENSION_VERSION` to 0.3.1
- Changelog entry for the `NOMINMAX` fix