### PR TITLE
[codex] expose cache and timeout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ errors:
 ```sql
 SELECT ai_complete(
     'Summarize this.',
+    connect_timeout_seconds := 5,
     retry_count := 2,
     retry_backoff_ms := 1000
 );
@@ -488,6 +489,7 @@ coalesced into one provider call, and cached entries can expire with a TTL:
 ```sql
 SET duckdb_ai_cache = true;
 SET duckdb_ai_cache_ttl_seconds = 3600;
+SET duckdb_ai_cache_max_entries = 1024;
 SELECT ai_complete('Summarize this repeated prompt.');
 SELECT * FROM ai_clear_cache();
 ```

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -705,6 +705,7 @@ not from direct API key arguments.
 | `max_tokens` | `BIGINT` | Completion, SQL assistant, aggregate | Maximum provider output tokens. Must be greater than 0. |
 | `base_url` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider or gateway base URL override. |
 | `timeout_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | HTTP timeout. Must be greater than 0. |
+| `connect_timeout_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | HTTP connection timeout from 1 to 31536000 seconds. It must be less than or equal to the total timeout when a provider call runs. |
 | `retry_count` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Retry count from 0 to 10 for curl failures and retryable HTTP status codes. Retries honor `Retry-After` on 429/5xx responses when present. |
 | `retry_backoff_ms` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Base retry backoff from 0 to 60000 milliseconds; exponential jitter is added per retry. |
 | `max_concurrent_requests` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Per-database request concurrency cap from 0 to 64. |
@@ -712,6 +713,7 @@ not from direct API key arguments.
 | `token_limit_per_minute` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Per-database estimated token cap per rolling minute. `0` disables the token cap. |
 | `cache` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Enables the current database instance's in-memory response cache for successful provider responses. |
 | `cache_ttl_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Optional response-cache expiration from 0 to 31536000 seconds. `0` means entries do not expire by age. The `DUCKDB_AI_CACHE_TTL_SECONDS` environment variable sets the default. |
+| `cache_max_entries` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Maximum in-memory response-cache entries from 0 to 1000000. `0` disables response-cache storage. The `DUCKDB_AI_CACHE_MAX_ENTRIES` environment variable sets the default. |
 | `prompt_cache` | `BOOLEAN` | Completion, task wrappers, and SQL assistant | Emits provider-side prompt-cache controls where supported. OpenAI requests include a stable `prompt_cache_key`; Anthropic requests attach ephemeral cache control to the system prompt. The `DUCKDB_AI_PROMPT_CACHE` environment variable enables this by default. |
 | `allowed_hosts` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Comma-separated provider/logging host allowlist. Entries may be hostnames, `host:port`, full URLs, `*.example.com`, or `*`. |
 | `on_error` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Error handling mode: `fail`, `null`, or `capture`. `capture` is used by `ai_try_complete`; scalar/table functions that cannot return an error field use `NULL` behavior. |

--- a/docs/runtime-behavior.md
+++ b/docs/runtime-behavior.md
@@ -90,7 +90,8 @@ connection cache. This allows libcurl to reuse connections across provider
 worker threads where the provider and libcurl build support it.
 
 Provider calls use the configured `timeout_seconds` for the total request. The
-connect timeout defaults to the smaller of 10 seconds and the total timeout; set
+connect timeout defaults to the smaller of 10 seconds and the total timeout. Set
+`connect_timeout_seconds := ...`, `duckdb_ai_connect_timeout_seconds`, or
 `DUCKDB_AI_CONNECT_TIMEOUT_SECONDS` to override it for provider requests.
 
 Provider redirects are not followed. This avoids forwarding authorization or
@@ -120,8 +121,9 @@ Cached responses still record usage events, but their elapsed time is reported
 as `0` because no provider HTTP request was made.
 
 The maximum number of cached entries defaults to `1024`. Set
-`DUCKDB_AI_CACHE_MAX_ENTRIES=0` to disable storage, or use a positive integer to
-change the bound.
+`cache_max_entries := ...`, `duckdb_ai_cache_max_entries`, or
+`DUCKDB_AI_CACHE_MAX_ENTRIES` to change the bound. Use `0` to disable
+response-cache storage.
 
 `ai_query_data()` also keeps a small in-memory generated-SQL cache for successful
 binds. `ai_clear_cache()` clears both caches.

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -524,7 +524,8 @@ bool TryGetOptionType(const std::string &name, LogicalType &type) {
 		return true;
 	}
 	if (name == "max_tokens" || name == "retry_count" || name == "retry_backoff_ms" ||
-	    name == "max_concurrent_requests" || name == "min_request_interval_ms" || name == "token_limit_per_minute") {
+	    name == "max_concurrent_requests" || name == "min_request_interval_ms" || name == "token_limit_per_minute" ||
+	    name == "connect_timeout_seconds" || name == "cache_max_entries") {
 		type = LogicalType::BIGINT;
 		return true;
 	}
@@ -547,7 +548,7 @@ LogicalType OptionType(const std::string &name) {
 	throw BinderException("Unsupported AI option \"%s\". Supported options: model, provider, temperature, "
 	                      "system_prompt, max_tokens, base_url, timeout_seconds, retry_count, retry_backoff_ms, "
 	                      "max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, cache, "
-	                      "cache_ttl_seconds, prompt_cache, "
+	                      "cache_ttl_seconds, cache_max_entries, prompt_cache, connect_timeout_seconds, "
 	                      "allowed_hosts, "
 	                      "input_token_price_per_million, output_token_price_per_million, use_builtin_model_prices, "
 	                      "fail_on_error, on_error, profile, secret, response_format, response_schema, json_schema, "
@@ -725,6 +726,14 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 		options.has_cache_ttl_seconds = true;
 		return true;
 	}
+	if (name == "cache_max_entries") {
+		options.response_cache_max_entries = OptionBigIntValue(value, function_name, name);
+		if (options.response_cache_max_entries < 0 || options.response_cache_max_entries > 1000000) {
+			throw BinderException("%s option \"cache_max_entries\" must be between 0 and 1000000", function_name);
+		}
+		options.has_response_cache_max_entries = true;
+		return true;
+	}
 	if (name == "prompt_cache") {
 		options.prompt_cache = OptionBoolValue(value, function_name, name);
 		options.has_prompt_cache = true;
@@ -787,6 +796,15 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 			throw BinderException("%s option \"timeout_seconds\" must be greater than 0", function_name);
 		}
 		options.has_timeout_seconds = true;
+		return true;
+	}
+	if (name == "connect_timeout_seconds") {
+		options.connect_timeout_seconds = OptionBigIntValue(value, function_name, name);
+		if (options.connect_timeout_seconds <= 0 || options.connect_timeout_seconds > 31536000) {
+			throw BinderException("%s option \"connect_timeout_seconds\" must be between 1 and 31536000",
+			                      function_name);
+		}
+		options.has_connect_timeout_seconds = true;
 		return true;
 	}
 	if (name == "fail_on_error") {
@@ -1011,7 +1029,11 @@ void ApplySettingsWithPrefix(ClientContext &context, const std::string &prefix, 
 	ApplyBoolSetting(context, prefix + "_cache", options.cache, options.has_cache);
 	ApplyOptionalBigIntRangeSetting(context, prefix + "_cache_ttl_seconds", options.cache_ttl_seconds,
 	                                options.has_cache_ttl_seconds, 0, 31536000);
+	ApplyOptionalBigIntRangeSetting(context, prefix + "_cache_max_entries", options.response_cache_max_entries,
+	                                options.has_response_cache_max_entries, 0, 1000000);
 	ApplyBoolSetting(context, prefix + "_prompt_cache", options.prompt_cache, options.has_prompt_cache);
+	ApplyOptionalBigIntRangeSetting(context, prefix + "_connect_timeout_seconds", options.connect_timeout_seconds,
+	                                options.has_connect_timeout_seconds, 1, 31536000);
 	ApplyTimeoutSetting(context, prefix + "_timeout_seconds", options);
 }
 
@@ -4962,6 +4984,10 @@ void RegisterSettingsForPrefix(DBConfig &config, const std::string &prefix, cons
 	           "Maximum response-cache entry age in seconds between 0 and 31536000; 0 disables age expiry, -1 uses "
 	           "default",
 	           LogicalType::BIGINT, Value::BIGINT(-1));
+	AddSetting(config, prefix + "_cache_max_entries",
+	           "Maximum response-cache entries between 0 and 1000000; 0 disables response-cache storage, -1 uses "
+	           "default",
+	           LogicalType::BIGINT, Value::BIGINT(-1));
 	AddSetting(config, prefix + "_prompt_cache", "Enable provider-side prompt caching hints when supported",
 	           LogicalType::BOOLEAN, Value(LogicalType::BOOLEAN));
 	AddSetting(config, prefix + "_response_format", "Default AI response format: text, json_object, or json_schema",
@@ -4970,6 +4996,9 @@ void RegisterSettingsForPrefix(DBConfig &config, const std::string &prefix, cons
 	           LogicalType::VARCHAR, Value(""));
 	AddSetting(config, prefix + "_timeout_seconds", "AI provider HTTP timeout in seconds; 0 uses the extension default",
 	           LogicalType::BIGINT, Value::BIGINT(0));
+	AddSetting(config, prefix + "_connect_timeout_seconds",
+	           "AI provider connection timeout in seconds between 1 and 31536000; -1 uses default", LogicalType::BIGINT,
+	           Value::BIGINT(-1));
 	AddSetting(config, prefix + "_retry_count", "AI provider retry count between 0 and 10; -1 uses default",
 	           LogicalType::BIGINT, Value::BIGINT(-1));
 	AddSetting(config, prefix + "_retry_backoff_ms",
@@ -5177,8 +5206,10 @@ void AddCompletionNamedParameters(TableFunction &function, bool include_response
 	                                           "token_limit_per_minute",
 	                                           "cache",
 	                                           "cache_ttl_seconds",
+	                                           "cache_max_entries",
 	                                           "prompt_cache",
 	                                           "allowed_hosts",
+	                                           "connect_timeout_seconds",
 	                                           "input_token_price_per_million",
 	                                           "output_token_price_per_million",
 	                                           "use_builtin_model_prices",

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -445,6 +445,8 @@ def run_duckdb_cache_and_allowlist(duckdb_path: Path, base_url: str) -> str:
         SET duckdb_ai_base_url = '{base_url}';
         SET duckdb_ai_allowed_hosts = '{base_url}';
         SET duckdb_ai_timeout_seconds = 5;
+        SET duckdb_ai_connect_timeout_seconds = 1;
+        SET duckdb_ai_cache_max_entries = 1;
         CREATE OR REPLACE SECRET smoke_cache_duckdb_ai (
             TYPE duckdb_ai,
             API_KEY 'test-key',
@@ -458,6 +460,7 @@ def run_duckdb_cache_and_allowlist(duckdb_path: Path, base_url: str) -> str:
             FROM range(16)
         )
         WHERE completion = 'mock dogpile completion';
+        SELECT ai_complete('cache smoke', cache := true) AS evicted_completion;
         SELECT count(*) AS usage_events FROM ai_usage();
     """
     env = os.environ.copy()
@@ -556,23 +559,24 @@ def assert_cache_and_allowlist_result(output: str):
     required = [
         "first_completion",
         "second_completion",
+        "evicted_completion",
         "mock completion",
         "dogpile_cached_rows",
         "16",
         "usage_events",
-        "18",
+        "19",
     ]
     missing = [value for value in required if value not in output]
     if missing:
         raise AssertionError(f"cache output missing {missing}\n{output}")
-    if len(MockProviderHandler.completion_requests) != 2:
+    if len(MockProviderHandler.completion_requests) != 3:
         raise AssertionError(
-            f"expected 2 cached completion requests, got {len(MockProviderHandler.completion_requests)}"
+            f"expected 3 cached completion requests, got {len(MockProviderHandler.completion_requests)}"
         )
-    if len(MockProviderHandler.authorization_headers) != 2:
-        raise AssertionError(f"expected 2 cached auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if len(MockProviderHandler.authorization_headers) != 3:
+        raise AssertionError(f"expected 3 cached auth headers, got {len(MockProviderHandler.authorization_headers)}")
     prompts = [request["messages"][-1]["content"] for request in MockProviderHandler.completion_requests]
-    if prompts != ["cache smoke", "cache dogpile"]:
+    if prompts != ["cache smoke", "cache dogpile", "cache smoke"]:
         raise AssertionError(f"unexpected cache prompts: {prompts}")
 
 

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -226,6 +226,11 @@ SELECT contains(ai_completion_request_json('hello', provider := 'openai', model 
 ----
 true
 
+query I
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', model := 'gpt-test', cache_max_entries := 1, connect_timeout_seconds := 1), '"model":"gpt-test"');
+----
+true
+
 statement ok
 SET duckdb_ai_cache = true;
 
@@ -564,6 +569,21 @@ SELECT ai_completion_request_json('hello', provider := 'openai', cache_ttl_secon
 Binder Error: AI option "cache_ttl_seconds" must be between 0 and 31536000
 
 statement error
+SELECT ai_completion_request_json('hello', provider := 'openai', cache_max_entries := -1);
+----
+Binder Error: AI option "cache_max_entries" must be between 0 and 1000000
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai', cache_max_entries := 1000001);
+----
+Binder Error: AI option "cache_max_entries" must be between 0 and 1000000
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai', connect_timeout_seconds := 0);
+----
+Binder Error: AI option "connect_timeout_seconds" must be between 1 and 31536000
+
+statement error
 SELECT ai_completion_request_json('hello', provider := 'openai', input_token_price_per_million := -0.1);
 ----
 Binder Error: AI option "input_token_price_per_million" must be greater than or equal to 0
@@ -605,6 +625,28 @@ Binder Error: Setting duckdb_ai_retry_count must be between 0 and 10
 
 statement ok
 RESET duckdb_ai_retry_count;
+
+statement ok
+SET duckdb_ai_cache_max_entries = 1000001;
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai');
+----
+Binder Error: Setting duckdb_ai_cache_max_entries must be between 0 and 1000000, or -1 to disable
+
+statement ok
+RESET duckdb_ai_cache_max_entries;
+
+statement ok
+SET duckdb_ai_connect_timeout_seconds = 0;
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai');
+----
+Binder Error: Setting duckdb_ai_connect_timeout_seconds must be between 1 and 31536000, or -1 to disable
+
+statement ok
+RESET duckdb_ai_connect_timeout_seconds;
 
 statement ok
 SET duckdb_ai_max_concurrent_requests = 65;

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16481,15 +16481,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17475,12 +17466,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -18960,13 +18951,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,10 @@
     "@types/react": "^19.0.0",
     "typescript": "~6.0.2"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5",
+    "uuid": "11.1.1"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## Issue

The provider runtime already had internal fields and environment-variable support for two reliability controls: connection timeout (`DUCKDB_AI_CONNECT_TIMEOUT_SECONDS`) and response-cache size (`DUCKDB_AI_CACHE_MAX_ENTRIES`). SQL users could not set either through the normal per-call option surface or DuckDB settings, even though related controls such as total timeout, retry count, cache enablement, and cache TTL are all exposed that way.

That made the behavior inconsistent for production SQL workloads. Users who configure DuckDB sessions entirely through SQL could tune the total request timeout and cache TTL, but still had to leave the connection timeout and cache bound to process environment variables.

## Root cause

`CompletionOptions` and the provider layer already carried `connect_timeout_seconds` and `response_cache_max_entries`, but `TryGetOptionType`, `ApplyCompletionValueOption`, `ApplySettingsWithPrefix`, and settings registration did not wire SQL names to those fields.

The Docusaurus lockfile also pulled vulnerable transitive versions of `serialize-javascript` and `uuid` through Docusaurus' webpack stack. Direct docs dependencies were already current, so the safe update was a narrow npm `overrides` entry rather than a broad Docusaurus downgrade or dependency churn.

## Fix

This PR exposes the existing runtime controls as:

- `connect_timeout_seconds := ...` and `SET duckdb_ai_connect_timeout_seconds = ...`
- `cache_max_entries := ...` and `SET duckdb_ai_cache_max_entries = ...`

The SQL bind path validates the same bounds as the environment-variable path, and the docs now describe these controls alongside the existing timeout/cache settings.

The docs package now overrides only the vulnerable transitive packages:

- `serialize-javascript` to `7.0.7`
- `uuid` to `11.1.1`

## Validation

- `git diff --check`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make tidy-check`
- `GEN=ninja make release`
- `GEN=ninja make test`
- `python3 test/smoke/mock_provider_smoke.py`
- `npm ci && npm run typecheck && npm run build && npm audit --audit-level=moderate`
- `npm outdated --json` returned `{}`
