### PR TITLE
[codex] fix embedding cache option binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.3.2 - 2026-07-03
+
+### Fixed
+
+- Allowed embedding functions to use the documented `cache_ttl_seconds`,
+  `cache_max_entries`, and `connect_timeout_seconds` per-call options.
+
 ## 0.3.1 - 2026-07-02
 
 ### Fixed

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.3.1
+    EXTENSION_VERSION 0.3.2
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -2110,6 +2110,7 @@ bool IsEmbeddingOption(const std::string &name) {
 	return name == "model" || name == "provider" || name == "profile" || name == "secret" || name == "secret_name" ||
 	       name == "base_url" || name == "timeout_seconds" || name == "retry_count" || name == "retry_backoff_ms" ||
 	       name == "max_concurrent_requests" || name == "min_request_interval_ms" || name == "token_limit_per_minute" ||
+	       name == "cache_ttl_seconds" || name == "cache_max_entries" || name == "connect_timeout_seconds" ||
 	       name == "input_token_price_per_million" || name == "output_token_price_per_million" ||
 	       name == "use_builtin_model_prices" || name == "cache" || name == "allowed_hosts" ||
 	       name == "fail_on_error" || name == "on_error" || name == "log_format" || name == "log_tags" ||
@@ -2149,8 +2150,9 @@ unique_ptr<FunctionData> AiEmbeddingBindInternal(ClientContext &context, ScalarF
 			    "Unsupported AI embedding option \"%s\". Supported options: model, provider, "
 			    "profile, secret, base_url, timeout_seconds, retry_count, retry_backoff_ms, fail_on_error, "
 			    "on_error, max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, "
-			    "cache, allowed_hosts, input_token_price_per_million, output_token_price_per_million, "
-			    "use_builtin_model_prices, log_format, log_tags, log_sample_rate",
+			    "cache, cache_ttl_seconds, cache_max_entries, allowed_hosts, connect_timeout_seconds, "
+			    "input_token_price_per_million, output_token_price_per_million, use_builtin_model_prices, "
+			    "log_format, log_tags, log_sample_rate",
 			    alias);
 		}
 		ApplyNamedOption(context, bind_data->options, *arguments[i], alias);
@@ -2203,8 +2205,9 @@ unique_ptr<FunctionData> AiSimilarityBind(ClientContext &context, ScalarFunction
 			    "Unsupported AI similarity option \"%s\". Supported options: model, provider, "
 			    "profile, secret, base_url, timeout_seconds, retry_count, retry_backoff_ms, fail_on_error, "
 			    "on_error, max_concurrent_requests, min_request_interval_ms, token_limit_per_minute, cache, "
-			    "allowed_hosts, input_token_price_per_million, output_token_price_per_million, "
-			    "use_builtin_model_prices, log_format, log_tags, log_sample_rate",
+			    "cache_ttl_seconds, cache_max_entries, allowed_hosts, connect_timeout_seconds, "
+			    "input_token_price_per_million, output_token_price_per_million, use_builtin_model_prices, "
+			    "log_format, log_tags, log_sample_rate",
 			    alias);
 		}
 		ApplyNamedOption(context, bind_data->options, *arguments[i], alias);

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -375,6 +375,20 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             model := 'openai/privacy-filter'
         ) AS privacy_filter_redaction;
         SELECT ai_embed('embed smoke')[1] AS first_embedding_value;
+        SELECT ai_embed(
+            'embed cache controls',
+            cache := true,
+            cache_ttl_seconds := 60,
+            cache_max_entries := 2,
+            connect_timeout_seconds := 1
+        )[1] AS controlled_embedding_value;
+        SELECT ai_embed(
+            'embed cache controls',
+            cache := true,
+            cache_ttl_seconds := 60,
+            cache_max_entries := 2,
+            connect_timeout_seconds := 1
+        )[1] AS cached_controlled_embedding_value;
         SELECT sum(embedding[1]) AS batched_embedding_sum
         FROM (
             SELECT ai_embed(value) AS embedding
@@ -658,8 +672,8 @@ def assert_smoke_result(output: str):
 
     if len(MockProviderHandler.completion_requests) != 34:
         raise AssertionError(f"expected 34 completion requests, got {len(MockProviderHandler.completion_requests)}")
-    if len(MockProviderHandler.authorization_headers) != 43:
-        raise AssertionError(f"expected 43 auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if len(MockProviderHandler.authorization_headers) != 44:
+        raise AssertionError(f"expected 44 auth headers, got {len(MockProviderHandler.authorization_headers)}")
     for header in MockProviderHandler.authorization_headers:
         if header != "Bearer test-key":
             raise AssertionError(f"unexpected authorization header: {header}")
@@ -889,39 +903,42 @@ def assert_smoke_result(output: str):
     if MockProviderHandler.claude_versions != ["2023-06-01"]:
         raise AssertionError(f"unexpected Claude version headers: {MockProviderHandler.claude_versions}")
 
-    if len(MockProviderHandler.embedding_requests) != 8:
-        raise AssertionError(f"expected 8 embedding requests, got {len(MockProviderHandler.embedding_requests)}")
+    if len(MockProviderHandler.embedding_requests) != 9:
+        raise AssertionError(f"expected 9 embedding requests, got {len(MockProviderHandler.embedding_requests)}")
     embedding_request = MockProviderHandler.embedding_requests[0]
     if embedding_request["model"] != "mock-embedding-default":
         raise AssertionError(f"unexpected embedding model: {embedding_request}")
     if embedding_request["input"] != "embed smoke":
         raise AssertionError(f"unexpected embedding input: {embedding_request}")
-    batched_embedding_request = MockProviderHandler.embedding_requests[1]
+    controlled_embedding_request = MockProviderHandler.embedding_requests[1]
+    if controlled_embedding_request["input"] != "embed cache controls":
+        raise AssertionError(f"unexpected controlled embedding input: {controlled_embedding_request}")
+    batched_embedding_request = MockProviderHandler.embedding_requests[2]
     if batched_embedding_request["input"] != ["embed batch one", "embed batch two", "embed batch three"]:
         raise AssertionError(f"unexpected batched embedding input: {batched_embedding_request}")
-    similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[2:4]]
+    similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[3:5]]
     if similarity_inputs != ["same left", "same right"]:
         raise AssertionError(f"unexpected similarity embedding inputs: {similarity_inputs}")
-    similarity_models = [request["model"] for request in MockProviderHandler.embedding_requests[2:4]]
+    similarity_models = [request["model"] for request in MockProviderHandler.embedding_requests[3:5]]
     if similarity_models != ["mock-embedding-default", "mock-embedding-default"]:
         raise AssertionError(f"unexpected similarity embedding models: {similarity_models}")
-    constant_similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[4:]]
+    constant_similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[5:]]
     if constant_similarity_inputs.count("constant query") != 1:
         raise AssertionError(f"expected one constant-side embedding, got {constant_similarity_inputs}")
     if set(constant_similarity_inputs) != {"constant query", "candidate one", "candidate two", "candidate three"}:
         raise AssertionError(f"unexpected constant similarity embedding inputs: {constant_similarity_inputs}")
 
     log_deadline = time.time() + 5
-    while len(MockProviderHandler.log_requests) < 45 and time.time() < log_deadline:
+    while len(MockProviderHandler.log_requests) < 47 and time.time() < log_deadline:
         time.sleep(0.05)
-    if len(MockProviderHandler.log_requests) != 45:
-        raise AssertionError(f"expected 45 log requests, got {len(MockProviderHandler.log_requests)}")
+    if len(MockProviderHandler.log_requests) != 47:
+        raise AssertionError(f"expected 47 log requests, got {len(MockProviderHandler.log_requests)}")
     completion_logs = [
         request for request in MockProviderHandler.log_requests if request.get("event") == "ai_completion"
     ]
     embedding_logs = [request for request in MockProviderHandler.log_requests if request.get("event") == "ai_embedding"]
     otlp_logs = [request for request in MockProviderHandler.log_requests if "resourceLogs" in request]
-    if len(completion_logs) != 34 or len(embedding_logs) != 10:
+    if len(completion_logs) != 34 or len(embedding_logs) != 12:
         raise AssertionError(f"unexpected log events: {MockProviderHandler.log_requests}")
     if len(otlp_logs) != 1:
         raise AssertionError(f"expected 1 OTLP log request, got {otlp_logs}")
@@ -1038,6 +1055,11 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"embedding log missing query id: {embedding_log_request}")
     if "input" in embedding_log_request:
         raise AssertionError(f"embedding log request unexpectedly included input text: {embedding_log_request}")
+    controlled_embedding_logs = [request for request in embedding_logs if request.get("input_chars") == 20]
+    if len(controlled_embedding_logs) != 2:
+        raise AssertionError(f"expected two controlled embedding logs, got {controlled_embedding_logs}")
+    if sorted(request.get("cache_hit") for request in controlled_embedding_logs) != [False, True]:
+        raise AssertionError(f"expected controlled embedding cache miss and hit, got {controlled_embedding_logs}")
 
 
 def main():

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -379,6 +379,11 @@ SELECT ai_embedding_request_json('duck', provider := 'openai', model := 'embed-t
 true
 
 query I
+SELECT ai_embedding_request_json('duck', provider := 'openai', model := 'embed-test', cache_ttl_seconds := 60, cache_max_entries := 1, connect_timeout_seconds := 1) = '{"model":"embed-test","input":"duck"}';
+----
+true
+
+query I
 SELECT ai_embed('duck', provider := 'claude', fail_on_error := false) IS NULL;
 ----
 true
@@ -580,6 +585,21 @@ Binder Error: AI option "cache_max_entries" must be between 0 and 1000000
 
 statement error
 SELECT ai_completion_request_json('hello', provider := 'openai', connect_timeout_seconds := 0);
+----
+Binder Error: AI option "connect_timeout_seconds" must be between 1 and 31536000
+
+statement error
+SELECT ai_embedding_request_json('duck', provider := 'openai', cache_ttl_seconds := -1);
+----
+Binder Error: AI option "cache_ttl_seconds" must be between 0 and 31536000
+
+statement error
+SELECT ai_embedding_request_json('duck', provider := 'openai', cache_max_entries := -1);
+----
+Binder Error: AI option "cache_max_entries" must be between 0 and 1000000
+
+statement error
+SELECT ai_embedding_request_json('duck', provider := 'openai', connect_timeout_seconds := 0);
 ----
 Binder Error: AI option "connect_timeout_seconds" must be between 1 and 31536000
 


### PR DESCRIPTION
## Summary

This fixes a documented SQL option bug in the embedding function family. `cache_ttl_seconds`, `cache_max_entries`, and `connect_timeout_seconds` were added to the shared provider option model and documented for embeddings, but the embedding bind-time allowlist still rejected those options before `ApplyNamedOption` could process them.

Users calling `ai_embed`, `ai_embedding_request_json`, or `ai_similarity` with those per-call controls would get an unsupported embedding/similarity option error even though completion functions and global settings accepted the same controls.

## Root Cause

The completion option parser already knew how to validate and apply the cache/connect controls, but `IsEmbeddingOption()` had not been updated when the controls were exposed. The provider runtime therefore supported the behavior, while the embedding SQL binder blocked it.

## Fix

- Allows embedding and similarity binders to accept `cache_ttl_seconds`, `cache_max_entries`, and `connect_timeout_seconds`.
- Extends SQLLogic coverage for successful embedding request JSON binding and validation errors for invalid values.
- Extends the mock-provider smoke test to run real `ai_embed` calls with per-call cache/connect controls and assert one provider request plus a cache-hit usage log for the repeated input.
- Prepares preview release metadata for `0.3.2` because this is a public documented SQL bug fix.

## Validation

- `git diff --check`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release`
- `GEN=ninja make test`
- `python3 test/smoke/mock_provider_smoke.py`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make tidy-check`
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm audit --audit-level=moderate`
- `npm outdated --json`
