### PR TITLE
Add llama.cpp server as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ End-to-end setup examples for each provider are in
 | --- | --- | --- |
 | `ollama` | Local Ollama chat and embedding models | `http://localhost:11434`; optional `OLLAMA_API_KEY` |
 | `openai_compatible` / `local` | vLLM, LM Studio, LiteLLM, Ollama `/v1`, or another gateway | Set `BASE_URL`; optional `OPENAI_COMPATIBLE_API_KEY` |
+| `llamacpp` / `llama.cpp` | Local llama.cpp `llama-server` | `http://localhost:8080/v1`; optional `LLAMACPP_API_KEY` |
 | `openai_privacy_filter` | OpenAI Privacy Filter PII redaction service | `http://localhost:8080`; optional `OPENAI_PRIVACY_FILTER_API_KEY` |
 
 ### Remote providers

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -16,6 +16,7 @@ Use the most constrained provider that fits the job:
 | Local development without hosted credentials | `ollama` | Keeps prompts local and avoids provider costs. |
 | Production chat, extraction, classification, and SQL assistant calls | A managed LLM provider such as `openai`, `azure`, `databricks`, `snowflake`, `anthropic`, `gemini`, `mistral`, `deepseek`, `zai`, or `openrouter` | Gives managed reliability, model access, and governance controls. |
 | OpenAI-compatible gateways, vLLM, LM Studio, LiteLLM, or local Ollama `/v1` | `openai_compatible` or `local` | Uses the common chat-completions request shape. |
+| Local llama.cpp `llama-server` | `llamacpp` or `llama.cpp` | Talks to `http://localhost:8080/v1` out of the box; the server answers with its loaded model. |
 | PII redaction where raw text should stay local | `openai_privacy_filter` with local hosting | Sends raw text to a dedicated redaction service instead of a general chat model. |
 | PII redaction shared across teams | `openai_privacy_filter` with a private cloud service | Centralizes deployment, auth, scaling, and audit controls while preserving the dedicated redaction contract. |
 
@@ -57,6 +58,7 @@ Use provider-specific environment variables for local development:
 | `snowflake` | `SNOWFLAKE_PAT` or `SNOWFLAKE_TOKEN` | `SNOWFLAKE_ACCOUNT_URL`, `SNOWFLAKE_HOST`, `SNOWFLAKE_ACCOUNT`, or `SNOWFLAKE_BASE_URL` |
 | `openai_privacy_filter` | `OPENAI_PRIVACY_FILTER_API_KEY` | `OPENAI_PRIVACY_FILTER_BASE_URL` |
 | `openai_compatible` / `local` | `OPENAI_COMPATIBLE_API_KEY` | `OPENAI_COMPATIBLE_BASE_URL` |
+| `llamacpp` / `llama.cpp` | `LLAMACPP_API_KEY` | `LLAMACPP_BASE_URL` |
 
 `DUCKDB_AI_API_KEY`, `DUCKDB_AI_BASE_URL`, and `DUCKDB_AI_MODEL` are generic
 fallbacks. Use them only when one process talks to one provider; provider-

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -771,6 +771,7 @@ Supported provider names and aliases are:
 | `snowflake` | none | Yes | No | `snowflake-llama-3.3-70b` |
 | `openai_privacy_filter` | `privacy_filter`, `pii_filter`, `opf` | Redaction only | No | `openai/privacy-filter` |
 | `openai_compatible` | `local`, `openai-compatible`, `local_openai`, `local-models`, `local_models` | Yes | Yes | `gpt-4o-mini` |
+| `llamacpp` | `llama.cpp`, `llama-cpp`, `llama_cpp`, `llama-server`, `llama_server` | Yes | Yes | `default` (llama-server answers with its loaded model) |
 
 Session defaults can be configured with DuckDB settings:
 

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -44,6 +44,7 @@ LIMIT 1;
 | `snowflake` | OpenAI-compatible chat | `snowflake-llama-3.3-70b` | `SNOWFLAKE_PAT` or `SNOWFLAKE_TOKEN` | Derives `/api/v2/cortex/v1` from Snowflake account URL, host, or account id. |
 | `openai_privacy_filter` | Dedicated redaction endpoint | `openai/privacy-filter` | Optional `OPENAI_PRIVACY_FILTER_API_KEY` | Defaults to `http://localhost:8080` and calls `POST /redact`. |
 | `openai_compatible` / `local` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | Optional `OPENAI_COMPATIBLE_API_KEY` | Requires `BASE_URL` or `OPENAI_COMPATIBLE_BASE_URL`. |
+| `llamacpp` / `llama.cpp` | OpenAI-compatible chat and embeddings | `default` (llama-server answers with its loaded model) | Optional `LLAMACPP_API_KEY` (`llama-server --api-key`) | Defaults to `http://localhost:8080/v1`. Embeddings need `llama-server --embeddings`. |
 
 For guidance on choosing providers, credentials, logging, cost, throughput, and
 PII workflows, see [Best practices](best-practices.md).
@@ -540,3 +541,35 @@ SELECT ai_complete(
 
 Aliases `local`, `openai_compatible`, `openai-compatible`, `local_openai`,
 `local-models`, and `local_models` all use the OpenAI-compatible protocol.
+
+## llama.cpp
+
+Use the `llamacpp` provider (aliases `llama.cpp`, `llama-cpp`, `llama_cpp`,
+`llama-server`, `llama_server`) for a local
+[llama.cpp](https://github.com/ggml-org/llama.cpp) `llama-server`. It uses the
+OpenAI-compatible protocol and defaults to `http://localhost:8080/v1`, so no
+base URL setup is needed for a default server:
+
+```sh
+llama-server -m model.gguf --embeddings
+./build/release/duckdb
+```
+
+```sql
+LOAD ai;
+SET duckdb_ai_provider = 'llama.cpp';
+
+SELECT ai_complete('Write one sentence about DuckDB.') AS answer;
+SELECT ai_embed('DuckDB');
+```
+
+The request `model` defaults to `default`; `llama-server` ignores it and
+answers with its loaded model, so no model configuration is needed either.
+Set `LLAMACPP_BASE_URL` for a non-default host or port, and `LLAMACPP_API_KEY`
+when the server runs with `--api-key`. Embedding calls require starting
+`llama-server` with `--embeddings`.
+
+For throughput, start `llama-server` with parallel slots (for example
+`--parallel 4`) and match `max_concurrent_requests` so DuckDB keeps every slot
+busy; llama.cpp reuses cached prompt prefixes automatically, so shared system
+prompts stay cheap across rows.

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -175,6 +175,10 @@ std::string NormalizeProviderNameInternal(const std::string &provider_input) {
 	    provider == "local_openai" || provider == "local-models" || provider == "local_models") {
 		return "openai_compatible";
 	}
+	if (provider == "llama.cpp" || provider == "llama-cpp" || provider == "llama_cpp" || provider == "llama-server" ||
+	    provider == "llama_server") {
+		return "llamacpp";
+	}
 	return provider;
 }
 
@@ -2475,6 +2479,11 @@ ProviderConfig ProviderDefaults(const std::string &provider_input) {
 	if (provider == "openai_compatible") {
 		return {provider, "openai_chat", "gpt-4o-mini", "", "", "OPENAI_COMPATIBLE_API_KEY", "", false};
 	}
+	if (provider == "llamacpp") {
+		// llama.cpp llama-server speaks the OpenAI-compatible protocol and ignores the request model
+		// name unless started with --model-alias; the loaded model always answers.
+		return {provider, "openai_chat", "default", "", "http://localhost:8080/v1", "LLAMACPP_API_KEY", "", false};
+	}
 	if (provider == "azure") {
 		return {provider, "openai_chat", "gpt-4o", "", "", "AZURE_OPENAI_API_KEY", "", true};
 	}
@@ -2516,7 +2525,7 @@ ProviderConfig ProviderDefaults(const std::string &provider_input) {
 	throw InvalidInputException(
 	    "Unsupported AI provider \"%s\". Supported providers: ollama, openai, azure, "
 	    "anthropic, claude, databricks, gemini, gcp, mistral, snowflake, zai, deepseek, openrouter, "
-	    "openai_privacy_filter, openai_compatible, local",
+	    "openai_privacy_filter, openai_compatible, local, llamacpp, llama.cpp",
 	    provider_input);
 }
 
@@ -2876,6 +2885,10 @@ std::string EmbeddingDefaultModel(const std::string &provider) {
 	}
 	if (provider == "openai_compatible") {
 		return "text-embedding-3-small";
+	}
+	if (provider == "llamacpp") {
+		// llama-server exposes /v1/embeddings when started with --embeddings and uses the loaded model.
+		return "default";
 	}
 	if (provider == "mistral") {
 		return "mistral-embed";

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -62,6 +62,16 @@ SELECT ai_provider_protocol('openai_privacy_filter');
 ----
 privacy_filter
 
+query IIII
+SELECT ai_provider_protocol('llamacpp'), ai_provider_protocol('llama.cpp'), ai_provider_protocol('llama-server'), ai_provider_base_url('llama.cpp');
+----
+openai_chat	openai_chat	openai_chat	http://localhost:8080/v1
+
+query II
+SELECT contains(ai_completion_request_json('hello', provider := 'llama.cpp'), '"model":"default"'), contains(ai_embedding_request_json('hello', provider := 'llama.cpp'), '"model":"default"');
+----
+true	true
+
 query I
 SELECT ai_recommended_batch_size(100, 50, 6000);
 ----


### PR DESCRIPTION
Fixes #25

## What changed

- `src/duckdb_ai_provider.cpp`: new `llamacpp` provider (aliases `llama.cpp`, `llama-cpp`, `llama_cpp`, `llama-server`, `llama_server`) riding the existing `openai_chat` / `openai_embeddings` protocol. Defaults: base URL `http://localhost:8080/v1` (llama-server's default), no API key required (`LLAMACPP_API_KEY` / `LLAMACPP_BASE_URL` env overrides), request model `default` since llama-server answers with its loaded model.
- `test/sql/duckdb_ai.test`: deterministic coverage for protocol/base-url resolution and completion/embedding request JSON, no network calls.
- Docs: provider tables in `README.md`, `docs/functions.md`, `docs/best-practices.md`, and a new llama.cpp section in `docs/provider-guides.md` (including `--embeddings` for the embedding endpoint and `--parallel` + `max_concurrent_requests` throughput guidance).

## Design note

llama-server exposes the OpenAI-compatible API natively, so this is a defaults-only mapping onto the existing protocol path: no new request builder, no translation layer, and no per-request overhead. Works out of the box with `SET duckdb_ai_provider = 'llama.cpp';`.

## Validation

- `GEN=ninja make release` / `GEN=ninja make test` (186 assertions pass)
- `python3 test/smoke/mock_provider_smoke.py`
- `make format-check`
- `website`: `npm run typecheck` + `npm run build`