### PR TITLE
feat: bind-verified SQL self-correction (fix_attempts) across assistant functions

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -46,8 +46,8 @@ FROM ai_usage();
 | `ai_schema_prompt([include_tables])` | Table | Returns deterministic local catalog context for prompting SQL models. |
 | `ai_explain_sql(sql[, ...])` | Table | Explains one read-only DuckDB `SELECT` statement. |
 | `ai_fix_sql(sql[, ...])` | Table | Rewrites a broken query as one corrected read-only DuckDB `SELECT`, or rewrites one line with `mode := 'line'`. |
-| `ai_is_read_only_sql(sql)` | Scalar | Returns whether SQL is one parser-valid read-only `SELECT`. |
-| `ai_validate_read_only_sql(sql)` | Scalar | Returns normalized SQL or raises if it is not one read-only `SELECT`. |
+| `ai_is_read_only_sql(sql[, check_binding])` | Scalar | Returns whether SQL is one parser-valid read-only `SELECT`; optionally also checks it binds against the catalog. |
+| `ai_validate_read_only_sql(sql[, check_binding])` | Scalar | Returns normalized SQL or raises if it is not one read-only `SELECT`; optionally also checks it binds against the catalog. |
 | `ai_count_tokens(text[, model[, provider]])` | Scalar | Returns a local approximate token count. |
 | `ai_recommended_batch_size(input_tokens_per_row, max_output_tokens_per_row, token_limit_per_minute[, request_limit_per_minute[, safety_factor]])` | Scalar | Returns a conservative row batch size for rate-limited AI jobs. |
 | `ai_provider_base_url(provider)` | Scalar | Returns the default base URL for a supported provider. |
@@ -429,12 +429,21 @@ Result: `VARCHAR`
 Description: Calls a completion model to generate one DuckDB `SELECT` statement,
 strips common markdown code fences, and rejects output that is not one read-only
 `SELECT`. When `schema_context` is omitted, the function builds local catalog
-context from `ai_schema_prompt()`.
+context from `ai_schema_prompt()`. With `fix_attempts := N` (0 to 5, default 0),
+the function verifies the generated SQL binds against the current catalog and,
+when it does not, feeds the bind error back to the model for up to `N`
+correction rounds before failing.
 
 Example:
 
 ```sql
 SELECT ai_sql('count orders by status');
+```
+
+Example with self-correction:
+
+```sql
+SELECT ai_sql('count orders by status', fix_attempts := 2);
 ```
 
 Result: `VARCHAR` containing a read-only DuckDB `SELECT`
@@ -447,6 +456,15 @@ current DuckDB database instance for repeated binds with the same question,
 schema context, and output-affecting options. Use `on_error := 'null'` to return
 an empty error-shaped relation instead of failing the bind.
 
+With `fix_attempts := N` (0 to 5, default 0), the function verifies the
+generated SQL binds against the current catalog before returning it. When
+binding fails — a hallucinated column, a wrong function name, a typo — the
+DuckDB bind error is fed back to the model for up to `N` correction rounds.
+Each correction is a regular model call and appears in `ai_usage()` alongside an
+`ai_query_data_fix_attempt` event. Cached SQL is re-verified on cache hits when
+`fix_attempts > 0`, so entries that stopped binding after a schema change are
+repaired instead of failing.
+
 Example:
 
 ```sql
@@ -454,6 +472,18 @@ SELECT *
 FROM ai_query_data(
     'count orders by status',
     schema_context := (SELECT summary FROM ai_schema_prompt(include_tables := ['main.orders']))
+);
+```
+
+Example with self-correction (useful in views, scheduled queries, and other
+non-interactive contexts):
+
+```sql
+SELECT *
+FROM ai_query_data(
+    'revenue by pickup borough',
+    include_tables := ['trips', 'zones'],
+    fix_attempts := 2
 );
 ```
 
@@ -503,11 +533,31 @@ corrected read-only DuckDB `SELECT` statement. With `mode := 'line'`, it rewrite
 only the line identified by an error message and returns the detected line number
 plus replacement line.
 
+In query mode, pass `error :=` to include the failure message in the correction
+prompt — the error text is usually what makes the fix reliable. Passing `error`
+without an explicit `mode` selects line mode for backward compatibility, so
+combine it with `mode := 'query'` for full-query rewrites. Query mode also
+accepts `fix_attempts := N` (0 to 5, default 0) to verify the corrected SQL
+binds against the current catalog and re-correct with the bind error for up to
+`N` rounds.
+
 Example:
 
 ```sql
 SELECT sql
 FROM ai_fix_sql('SEELECT status, count(*) FRUM orders GROUP BY status');
+```
+
+Example with the error message and bind verification:
+
+```sql
+SELECT sql
+FROM ai_fix_sql(
+    'SELECT statuss, count(*) FROM orders GROUP BY statuss',
+    mode := 'query',
+    error := 'Binder Error: Referenced column "statuss" not found',
+    fix_attempts := 1
+);
 ```
 
 Result: one `sql VARCHAR` column
@@ -527,28 +577,34 @@ Line-mode result: `line_number BIGINT`, `replacement_line VARCHAR`
 
 ## SQL validation functions
 
-#### `ai_is_read_only_sql(sql)`
+#### `ai_is_read_only_sql(sql[, check_binding])`
 
 Description: Returns whether `sql` parses as exactly one read-only DuckDB
-`SELECT` statement.
+`SELECT` statement. With `check_binding` set to `true`, the statement must also
+bind against the current catalog — hallucinated tables, columns, or functions
+return `false` even when the SQL parses. The bind check runs in the current
+session, so temporary tables are visible, and nothing is executed.
 
 Example:
 
 ```sql
 SELECT ai_is_read_only_sql('SELECT 42');
+SELECT ai_is_read_only_sql('SELECT missing_column FROM my_table', true);
 ```
 
 Result: `BOOLEAN`
 
-#### `ai_validate_read_only_sql(sql)`
+#### `ai_validate_read_only_sql(sql[, check_binding])`
 
 Description: Returns the input SQL when it is one read-only DuckDB `SELECT`;
-otherwise raises an error.
+otherwise raises an error. With `check_binding` set to `true`, the statement
+must also bind against the current catalog.
 
 Example:
 
 ```sql
 SELECT ai_validate_read_only_sql('SELECT count(*) FROM my_table');
+SELECT ai_validate_read_only_sql('SELECT count(*) FROM my_table', true);
 ```
 
 Result: `VARCHAR`
@@ -742,7 +798,8 @@ SQL assistant table functions also accept:
 | `exclude_tables` | `VARCHAR[]` | Remove matching tables from generated local catalog context. |
 | `sample_rows` | `BIGINT` | Include up to 100 sample rows per local table. |
 | `mode` | `VARCHAR` | `ai_fix_sql` only. `query` or `full` rewrites the full query; `line` rewrites one error line. |
-| `error` | `VARCHAR` | `ai_fix_sql` line mode only. Error text used to identify the target line. |
+| `error` | `VARCHAR` | `ai_fix_sql` only. Error text included in the correction prompt; in line mode it also identifies the target line. Without an explicit `mode`, passing `error` selects line mode. |
+| `fix_attempts` | `BIGINT` | `ai_sql`, `ai_query_data`, and `ai_fix_sql` query mode. Number of bind-verified self-correction rounds from 0 to 5. Default 0 keeps single-shot behavior. |
 
 Aggregate functions also accept:
 

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/parser/constraints/not_null_constraint.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "duckdb/storage/data_table.hpp"
@@ -57,6 +58,7 @@ namespace {
 constexpr int64_t MAX_TOKEN_LIMIT_PER_MINUTE = 10000000000LL;
 constexpr idx_t MAX_PROVIDER_CHUNK_WORKERS = 64;
 constexpr size_t MAX_PROMPT_QUERY_CACHE_ENTRIES = 1024;
+constexpr int64_t MAX_SQL_FIX_ATTEMPTS = 5;
 std::atomic<uint64_t> NEXT_QUERY_ID {1};
 
 // Tripwire so CompletionOptionsEqual is updated when CompletionOptions gains fields. The size is
@@ -208,6 +210,7 @@ struct PromptAssistantBindData : public FunctionData {
 	std::string sql;
 	std::string error_message;
 	std::string schema_context;
+	int64_t fix_attempts = 0;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<PromptAssistantBindData>(kind);
@@ -215,13 +218,15 @@ struct PromptAssistantBindData : public FunctionData {
 		result->sql = sql;
 		result->error_message = error_message;
 		result->schema_context = schema_context;
+		result->fix_attempts = fix_attempts;
 		return std::move(result);
 	}
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<PromptAssistantBindData>();
 		return kind == other.kind && CompletionOptionsEqual(options, other.options) && sql == other.sql &&
-		       error_message == other.error_message && schema_context == other.schema_context;
+		       error_message == other.error_message && schema_context == other.schema_context &&
+		       fix_attempts == other.fix_attempts;
 	}
 };
 
@@ -259,6 +264,7 @@ struct SchemaTableInfo {
 vector<std::string> ReadIncludeTablesValue(const Value &value_p, const std::string &name,
                                            const std::string &function_name);
 int64_t ReadSampleRowsValue(const Value &value_p, const std::string &function_name);
+int64_t ReadFixAttemptsValue(const Value &value_p, const std::string &function_name);
 
 struct AiCompletionBindData : public FunctionData {
 	explicit AiCompletionBindData(bool request_json_p, bool validate_json_output_p = false)
@@ -463,6 +469,7 @@ struct AiPromptSqlBindData : public FunctionData {
 	idx_t model_index = 0;
 	bool has_provider_arg = false;
 	idx_t provider_index = 0;
+	int64_t fix_attempts = 0;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<AiPromptSqlBindData>();
@@ -475,6 +482,7 @@ struct AiPromptSqlBindData : public FunctionData {
 		result->model_index = model_index;
 		result->has_provider_arg = has_provider_arg;
 		result->provider_index = provider_index;
+		result->fix_attempts = fix_attempts;
 		return std::move(result);
 	}
 
@@ -487,7 +495,7 @@ struct AiPromptSqlBindData : public FunctionData {
 		       has_schema_context_arg == other.has_schema_context_arg &&
 		       schema_context_index == other.schema_context_index && has_model_arg == other.has_model_arg &&
 		       model_index == other.model_index && has_provider_arg == other.has_provider_arg &&
-		       provider_index == other.provider_index;
+		       provider_index == other.provider_index && fix_attempts == other.fix_attempts;
 	}
 };
 
@@ -2828,6 +2836,12 @@ unique_ptr<FunctionData> AiPromptSqlBind(ClientContext &context, ScalarFunction 
 			bound_function.arguments.emplace_back(LogicalType::BIGINT);
 			continue;
 		}
+		if (alias == "fix_attempts") {
+			auto value = EvaluateConstantOption(context, *arguments[i], alias, LogicalType::BIGINT);
+			bind_data->fix_attempts = ReadFixAttemptsValue(value, bound_function.name);
+			bound_function.arguments.emplace_back(LogicalType::BIGINT);
+			continue;
+		}
 		ApplyNamedOption(context, bind_data->options, *arguments[i], alias);
 		bound_function.arguments.emplace_back(PromptSqlOptionType(alias));
 	}
@@ -3899,6 +3913,24 @@ bool ValidateReadOnlySql(const std::string &sql, std::string &error) {
 	return true;
 }
 
+bool VerifySqlBinds(ClientContext &context, const std::string &sql, std::string &error) {
+	try {
+		Parser parser(context.GetParserOptions());
+		parser.ParseQuery(sql);
+		if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+			error = "expected exactly one SELECT statement";
+			return false;
+		}
+		auto binder = Binder::CreateBinder(context);
+		binder->Bind(*parser.statements[0]);
+		return true;
+	} catch (std::exception &ex) {
+		ErrorData error_data(ex);
+		error = error_data.Message();
+		return false;
+	}
+}
+
 void RequireReadOnlySql(const std::string &sql, const std::string &function_name) {
 	std::string error;
 	if (!ValidateReadOnlySql(sql, error)) {
@@ -3956,8 +3988,19 @@ std::string BuildPromptFixupSystemPrompt(const std::string &schema_context) {
 	return prompt;
 }
 
-std::string BuildPromptFixupPrompt(const std::string &sql) {
+std::string BuildPromptFixupPrompt(const std::string &sql, const std::string &error_message = "",
+                                   const std::string &question = "") {
 	std::string prompt;
+	if (!question.empty()) {
+		prompt += "\nOriginal question:\n";
+		prompt += question;
+		prompt += "\n";
+	}
+	if (!error_message.empty()) {
+		prompt += "\nError message:\n";
+		prompt += error_message;
+		prompt += "\n";
+	}
 	prompt += "\nBroken SQL query:\n";
 	prompt += sql;
 	return prompt;
@@ -4033,16 +4076,39 @@ std::string ReplaceSqlLine(const std::string &sql, idx_t one_based_line_number, 
 }
 
 std::string GeneratePromptFixupSql(const std::string &sql, const std::string &schema_context,
-                                   const duckdb_ai::CompletionOptions &options) {
+                                   const duckdb_ai::CompletionOptions &options, const std::string &error_message = "",
+                                   const std::string &question = "") {
 	auto request_options = options;
 	AppendSystemPrompt(request_options, BuildPromptFixupSystemPrompt(schema_context));
-	auto prompt = BuildPromptFixupPrompt(sql);
+	auto prompt = BuildPromptFixupPrompt(sql, error_message, question);
 	auto fixed_sql = StripMarkdownSqlFence(duckdb_ai::Complete(prompt, request_options).text);
 	std::string error;
 	if (!ValidateReadOnlySql(fixed_sql, error)) {
 		throw InvalidInputException("AI corrected SQL is not a single read-only SELECT statement: %s", error);
 	}
 	return fixed_sql;
+}
+
+std::string RepairGeneratedSql(ClientContext &context, const std::string &question, std::string generated_sql,
+                               const std::string &schema_context, const duckdb_ai::CompletionOptions &options,
+                               int64_t fix_attempts, const std::string &usage_event) {
+	if (fix_attempts <= 0) {
+		return generated_sql;
+	}
+	std::string bind_error;
+	for (int64_t attempt = 0; attempt < fix_attempts; attempt++) {
+		if (VerifySqlBinds(context, generated_sql, bind_error)) {
+			return generated_sql;
+		}
+		duckdb_ai::RecordLocalUsageEvent(&context, usage_event, static_cast<int64_t>(generated_sql.size()),
+		                                 static_cast<int64_t>(bind_error.size()));
+		generated_sql = GeneratePromptFixupSql(generated_sql, schema_context, options, bind_error, question);
+	}
+	if (!VerifySqlBinds(context, generated_sql, bind_error)) {
+		throw InvalidInputException("AI generated SQL still fails to bind after %lld fix attempt(s): %s", fix_attempts,
+		                            bind_error);
+	}
+	return generated_sql;
 }
 
 unique_ptr<TableRef> ParseReadOnlySubquery(const std::string &sql, const ParserOptions &options) {
@@ -4082,13 +4148,18 @@ std::string OptionalTableStringInput(const TableFunctionBindInput &input, idx_t 
 }
 
 void ApplyPromptQueryValueOption(duckdb_ai::CompletionOptions &options, std::string &schema_context,
-                                 PromptSchemaOptions &schema_options, const std::string &name, const Value &value_p) {
+                                 PromptSchemaOptions &schema_options, int64_t &fix_attempts, const std::string &name,
+                                 const Value &value_p) {
 	if (value_p.IsNull()) {
 		throw BinderException("ai_query_data option \"%s\" must not be NULL", name);
 	}
 	auto value = value_p;
 	if (name == "schema_context" || name == "schema") {
 		schema_context = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
+		return;
+	}
+	if (name == "fix_attempts") {
+		fix_attempts = ReadFixAttemptsValue(value, "ai_query_data");
 		return;
 	}
 	if (name == "include_tables") {
@@ -4206,6 +4277,7 @@ unique_ptr<TableRef> PromptQueryBindReplace(ClientContext &context, TableFunctio
 	auto question = RequiredTableStringInput(input, 0, "question");
 	auto schema_context = OptionalTableStringInput(input, 1);
 	PromptSchemaOptions schema_options;
+	int64_t fix_attempts = 0;
 	if (input.inputs.size() > 2) {
 		options.model = OptionalTableStringInput(input, 2);
 	}
@@ -4213,8 +4285,8 @@ unique_ptr<TableRef> PromptQueryBindReplace(ClientContext &context, TableFunctio
 		options.provider = OptionalTableStringInput(input, 3);
 	}
 	for (auto &named_parameter : input.named_parameters) {
-		ApplyPromptQueryValueOption(options, schema_context, schema_options, LowerAscii(named_parameter.first),
-		                            named_parameter.second);
+		ApplyPromptQueryValueOption(options, schema_context, schema_options, fix_attempts,
+		                            LowerAscii(named_parameter.first), named_parameter.second);
 	}
 	if (schema_context.empty()) {
 		schema_context = BuildPromptSchemaContext(context, schema_options);
@@ -4225,11 +4297,18 @@ unique_ptr<TableRef> PromptQueryBindReplace(ClientContext &context, TableFunctio
 		auto cache_key = PromptQueryCacheKey(question, schema_context, options);
 		std::string generated_sql;
 		if (TryGetPromptQueryCachedSql(context, cache_key, generated_sql)) {
-			duckdb_ai::RecordLocalUsageEvent(&context, "ai_query_data_cache_hit", static_cast<int64_t>(question.size()),
-			                                 static_cast<int64_t>(generated_sql.size()));
-			return ParseReadOnlySubquery(generated_sql, context.GetParserOptions());
+			std::string bind_error;
+			if (fix_attempts <= 0 || VerifySqlBinds(context, generated_sql, bind_error)) {
+				duckdb_ai::RecordLocalUsageEvent(&context, "ai_query_data_cache_hit",
+				                                 static_cast<int64_t>(question.size()),
+				                                 static_cast<int64_t>(generated_sql.size()));
+				return ParseReadOnlySubquery(generated_sql, context.GetParserOptions());
+			}
+			// the cached SQL no longer binds (e.g. the schema changed): fall through and regenerate
 		}
 		generated_sql = GeneratePromptSql(question, schema_context, options);
+		generated_sql = RepairGeneratedSql(context, question, std::move(generated_sql), schema_context, options,
+		                                   fix_attempts, "ai_query_data_fix_attempt");
 		StorePromptQueryCachedSql(context, cache_key, generated_sql);
 		return ParseReadOnlySubquery(generated_sql, context.GetParserOptions());
 	} catch (std::exception &ex) {
@@ -4305,6 +4384,21 @@ void AiPromptSqlFunction(DataChunk &args, ExpressionState &state, Vector &result
 	RunProviderJobs(
 	    jobs, [&](ProviderStringJob &job) { job.output = GeneratePromptSql(job.input, job.parameter, job.options); });
 
+	if (bind_data.fix_attempts > 0) {
+		// bind verification needs the client context, so repair runs serially after the parallel generation
+		for (auto &job : jobs) {
+			if (job.exception || !job.completed) {
+				continue;
+			}
+			try {
+				job.output = RepairGeneratedSql(state.GetContext(), job.input, std::move(job.output), job.parameter,
+				                                job.options, bind_data.fix_attempts, "ai_sql_fix_attempt");
+			} catch (std::exception &) {
+				job.exception = std::current_exception();
+			}
+		}
+	}
+
 	for (auto &job : jobs) {
 		if (job.exception) {
 			if (job.fail_on_error) {
@@ -4352,6 +4446,18 @@ int64_t ReadSampleRowsValue(const Value &value_p, const std::string &function_na
 		throw BinderException("%s sample_rows must be between 0 and 100", function_name);
 	}
 	return sample_rows;
+}
+
+int64_t ReadFixAttemptsValue(const Value &value_p, const std::string &function_name) {
+	if (value_p.IsNull()) {
+		throw BinderException("%s fix_attempts must not be NULL", function_name);
+	}
+	auto value = value_p;
+	auto fix_attempts = BigIntValue::Get(value.DefaultCastAs(LogicalType::BIGINT));
+	if (fix_attempts < 0 || fix_attempts > MAX_SQL_FIX_ATTEMPTS) {
+		throw BinderException("%s fix_attempts must be between 0 and %lld", function_name, MAX_SQL_FIX_ATTEMPTS);
+	}
+	return fix_attempts;
 }
 
 PromptSchemaOptions PromptSchemaOptionsFromInput(TableFunctionBindInput &input) {
@@ -4467,7 +4573,7 @@ void ApplyPromptAssistantValueOption(PromptAssistantBindData &bind_data, PromptS
 		return;
 	}
 	if (name == "error") {
-		if (bind_data.kind != PromptAssistantKind::FIX_LINE) {
+		if (bind_data.kind != PromptAssistantKind::FIX_LINE && bind_data.kind != PromptAssistantKind::FIXUP) {
 			throw BinderException("%s does not support an error option", function_name);
 		}
 		if (has_error) {
@@ -4475,6 +4581,13 @@ void ApplyPromptAssistantValueOption(PromptAssistantBindData &bind_data, PromptS
 		}
 		bind_data.error_message = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
 		has_error = true;
+		return;
+	}
+	if (name == "fix_attempts") {
+		if (bind_data.kind != PromptAssistantKind::FIXUP) {
+			throw BinderException("%s only supports fix_attempts with mode query", function_name);
+		}
+		bind_data.fix_attempts = ReadFixAttemptsValue(value, function_name);
 		return;
 	}
 	if (name == "mode") {
@@ -4611,7 +4724,10 @@ void PromptAssistantFunction(ClientContext &context, TableFunctionInput &input, 
 			auto explanation = duckdb_ai::Complete(prompt, options).text;
 			output.SetValue(0, 0, Value(explanation));
 		} else if (bind_data.kind == PromptAssistantKind::FIXUP) {
-			auto fixed_sql = GeneratePromptFixupSql(bind_data.sql, bind_data.schema_context, options);
+			auto fixed_sql =
+			    GeneratePromptFixupSql(bind_data.sql, bind_data.schema_context, options, bind_data.error_message);
+			fixed_sql = RepairGeneratedSql(context, "", std::move(fixed_sql), bind_data.schema_context, options,
+			                               bind_data.fix_attempts, "ai_fix_sql_fix_attempt");
 			output.SetValue(0, 0, Value(fixed_sql));
 		} else {
 			auto line_number = ExtractLineNumber(bind_data.error_message);
@@ -4637,24 +4753,51 @@ void PromptAssistantFunction(ClientContext &context, TableFunctionInput &input, 
 	state.emitted = true;
 }
 
-void AiIsReadOnlySqlFunction(DataChunk &args, ExpressionState &, Vector &result) {
+void AiIsReadOnlySqlFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &sql_vector = args.data[0];
-	UnaryExecutor::Execute<string_t, bool>(sql_vector, result, args.size(), [&](string_t sql) {
-		std::string error;
-		return ValidateReadOnlySql(sql.GetString(), error);
-	});
+	if (args.ColumnCount() < 2) {
+		UnaryExecutor::Execute<string_t, bool>(sql_vector, result, args.size(), [&](string_t sql) {
+			std::string error;
+			return ValidateReadOnlySql(sql.GetString(), error);
+		});
+		return;
+	}
+	BinaryExecutor::Execute<string_t, bool, bool>(
+	    sql_vector, args.data[1], result, args.size(), [&](string_t sql, bool check_binding) {
+		    auto sql_string = sql.GetString();
+		    std::string error;
+		    if (!ValidateReadOnlySql(sql_string, error)) {
+			    return false;
+		    }
+		    return !check_binding || VerifySqlBinds(state.GetContext(), sql_string, error);
+	    });
 }
 
-void AiValidateReadOnlySqlFunction(DataChunk &args, ExpressionState &, Vector &result) {
+void AiValidateReadOnlySqlFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &sql_vector = args.data[0];
-	UnaryExecutor::Execute<string_t, string_t>(sql_vector, result, args.size(), [&](string_t sql) {
-		auto sql_string = sql.GetString();
-		std::string error;
-		if (!ValidateReadOnlySql(sql_string, error)) {
-			throw InvalidInputException("AI generated SQL is not a single read-only SELECT statement: %s", error);
-		}
-		return StringVector::AddString(result, sql_string);
-	});
+	if (args.ColumnCount() < 2) {
+		UnaryExecutor::Execute<string_t, string_t>(sql_vector, result, args.size(), [&](string_t sql) {
+			auto sql_string = sql.GetString();
+			std::string error;
+			if (!ValidateReadOnlySql(sql_string, error)) {
+				throw InvalidInputException("AI generated SQL is not a single read-only SELECT statement: %s", error);
+			}
+			return StringVector::AddString(result, sql_string);
+		});
+		return;
+	}
+	BinaryExecutor::Execute<string_t, bool, string_t>(
+	    sql_vector, args.data[1], result, args.size(), [&](string_t sql, bool check_binding) {
+		    auto sql_string = sql.GetString();
+		    std::string error;
+		    if (!ValidateReadOnlySql(sql_string, error)) {
+			    throw InvalidInputException("AI generated SQL is not a single read-only SELECT statement: %s", error);
+		    }
+		    if (check_binding && !VerifySqlBinds(state.GetContext(), sql_string, error)) {
+			    throw InvalidInputException("AI generated SQL does not bind: %s", error);
+		    }
+		    return StringVector::AddString(result, sql_string);
+	    });
 }
 
 inline void AiProviderBaseUrl(DataChunk &args, ExpressionState &, Vector &result) {
@@ -5065,20 +5208,28 @@ static const AiFunctionDocumentation AI_FUNCTION_DOCUMENTATION[] = {
      "SELECT ai_agg(review, 'List the top complaints') FROM reviews;"},
     {"ai_summarize_agg", "Summarizes grouped text values with one completion call.",
      "SELECT ai_summarize_agg(review) FROM reviews;"},
-    {"ai_sql", "Generates one read-only DuckDB SELECT statement from a natural-language question.",
+    {"ai_sql",
+     "Generates one read-only DuckDB SELECT statement from a natural-language question. With fix_attempts := N it "
+     "verifies the SQL binds against the catalog and self-corrects using the bind error.",
      "SELECT ai_sql('total sales by region');"},
-    {"ai_query_data", "Generates one read-only SELECT at bind time and executes it as a subquery.",
+    {"ai_query_data",
+     "Generates one read-only SELECT at bind time and executes it as a subquery. With fix_attempts := N it verifies "
+     "the SQL binds against the catalog and self-corrects using the bind error.",
      "SELECT * FROM ai_query_data('total sales by region');"},
     {"ai_schema_prompt", "Returns deterministic local catalog context for prompting SQL models.",
      "SELECT * FROM ai_schema_prompt();"},
     {"ai_explain_sql", "Explains one read-only DuckDB SELECT statement.", "SELECT * FROM ai_explain_sql('SELECT 42');"},
     {"ai_fix_sql",
-     "Rewrites a broken query as one corrected read-only DuckDB SELECT, or rewrites one line with mode := 'line'.",
+     "Rewrites a broken query as one corrected read-only DuckDB SELECT, or rewrites one line with mode := 'line'. "
+     "Accepts error := to pass the failure message and fix_attempts := N for bind-verified self-correction.",
      "SELECT * FROM ai_fix_sql('SELEC 42');"},
-    {"ai_is_read_only_sql", "Returns whether SQL is one parser-valid read-only SELECT statement.",
+    {"ai_is_read_only_sql",
+     "Returns whether SQL is one parser-valid read-only SELECT statement. Pass true as the second argument to also "
+     "check that the SQL binds against the catalog.",
      "SELECT ai_is_read_only_sql('SELECT 42');"},
     {"ai_validate_read_only_sql",
-     "Returns normalized SQL or raises an error if it is not one read-only SELECT statement.",
+     "Returns normalized SQL or raises an error if it is not one read-only SELECT statement. Pass true as the second "
+     "argument to also check that the SQL binds against the catalog.",
      "SELECT ai_validate_read_only_sql('SELECT 42');"},
     {"ai_count_tokens", "Returns a local approximate token count for text.", "SELECT ai_count_tokens('hello world');"},
     {"ai_recommended_batch_size", "Returns a conservative row batch size for rate-limited AI jobs.",
@@ -5295,12 +5446,15 @@ void AddCompletionNamedParameters(TableFunction &function, bool include_response
 	}
 }
 
-void AddPromptQueryNamedParameters(TableFunction &function) {
+void AddPromptQueryNamedParameters(TableFunction &function, bool include_fix_attempts = true) {
 	function.named_parameters["schema_context"] = LogicalType::VARCHAR;
 	function.named_parameters["schema"] = LogicalType::VARCHAR;
 	function.named_parameters["include_tables"] = LogicalType::LIST(LogicalType::VARCHAR);
 	function.named_parameters["exclude_tables"] = LogicalType::LIST(LogicalType::VARCHAR);
 	function.named_parameters["sample_rows"] = LogicalType::BIGINT;
+	if (include_fix_attempts) {
+		function.named_parameters["fix_attempts"] = LogicalType::BIGINT;
+	}
 	AddCompletionNamedParameters(function, true, false);
 }
 
@@ -5315,7 +5469,7 @@ void AddAiRecordNamedParameters(TableFunction &function) {
 }
 
 void AddPromptAssistantNamedParameters(TableFunction &function, bool include_error) {
-	AddPromptQueryNamedParameters(function);
+	AddPromptQueryNamedParameters(function, include_error);
 	if (include_error) {
 		function.named_parameters["error"] = LogicalType::VARCHAR;
 		function.named_parameters["mode"] = LogicalType::VARCHAR;
@@ -5463,10 +5617,18 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterPromptFixupFunction(loader, "ai_fix_sql");
 	RegisterPromptQueryFunction(loader, "ai_query_data");
 
-	RegisterDocumentedFunction(loader, ScalarFunction("ai_is_read_only_sql", {LogicalType::VARCHAR},
-	                                                  LogicalType::BOOLEAN, AiIsReadOnlySqlFunction));
-	RegisterDocumentedFunction(loader, ScalarFunction("ai_validate_read_only_sql", {LogicalType::VARCHAR},
-	                                                  LogicalType::VARCHAR, AiValidateReadOnlySqlFunction));
+	ScalarFunctionSet ai_is_read_only_sql("ai_is_read_only_sql");
+	ai_is_read_only_sql.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::BOOLEAN, AiIsReadOnlySqlFunction));
+	ai_is_read_only_sql.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::BOOLEAN, AiIsReadOnlySqlFunction));
+	RegisterDocumentedFunction(loader, std::move(ai_is_read_only_sql));
+	ScalarFunctionSet ai_validate_read_only_sql("ai_validate_read_only_sql");
+	ai_validate_read_only_sql.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, AiValidateReadOnlySqlFunction));
+	ai_validate_read_only_sql.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN},
+	                                                     LogicalType::VARCHAR, AiValidateReadOnlySqlFunction));
+	RegisterDocumentedFunction(loader, std::move(ai_validate_read_only_sql));
 	RegisterDocumentedFunction(loader, ScalarFunction("ai_provider_base_url", {LogicalType::VARCHAR},
 	                                                  LogicalType::VARCHAR, AiProviderBaseUrl));
 	RegisterDocumentedFunction(loader, ScalarFunction("ai_provider_protocol", {LogicalType::VARCHAR},

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -105,6 +105,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 content = "```sql\nSELECT 42\n```"
             elif "Correct one line in the DuckDB SQL query" in full_prompt:
                 content = "SELECT 42"
+            elif "Generate one DuckDB SQL SELECT statement" in full_prompt and "self correct count" in full_prompt:
+                content = "SELECT broken_column FROM smoke_fix_missing"
             elif "Generate one DuckDB SQL SELECT statement" in full_prompt:
                 content = "```sql\nSELECT 42\n```"
             elif "Return only a JSON array of chosen labels" in full_prompt:
@@ -422,6 +424,99 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
     if result.returncode != 0:
         raise AssertionError(f"duckdb exited with {result.returncode}\n{result.stdout}")
     return result.stdout
+
+
+def run_duckdb_self_correction(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT * FROM ai_clear_usage();
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_model = 'mock-model';
+        SET duckdb_ai_sql_assistant_model = 'mock-sql-model';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_timeout_seconds = 5;
+        CREATE OR REPLACE SECRET smoke_fix_duckdb_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'openai'
+        );
+        SELECT * FROM ai_query_data(
+            'self correct count',
+            schema_context := 'CREATE TABLE smoke_fix(id INTEGER)',
+            fix_attempts := 2
+        );
+        SELECT ai_sql(
+            'self correct count',
+            schema_context := 'CREATE TABLE smoke_fix(id INTEGER)',
+            fix_attempts := 2
+        ) AS repaired_sql;
+        SELECT sql AS fixed_with_error
+        FROM ai_fix_sql(
+            'SELECT broken_column FROM smoke_fix_missing',
+            mode := 'query',
+            error := 'Catalog Error: Table with name smoke_fix_missing does not exist',
+            schema_context := 'CREATE TABLE smoke_fix(id INTEGER)'
+        );
+        SELECT event, count(*) AS events
+        FROM ai_usage()
+        WHERE event IN ('ai_query_data_fix_attempt', 'ai_sql_fix_attempt')
+        GROUP BY event
+        ORDER BY event;
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb self correction smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_self_correction_result(output: str):
+    required = [
+        "repaired_sql",
+        "SELECT 42",
+        "fixed_with_error",
+        "ai_query_data_fix_attempt",
+        "ai_sql_fix_attempt",
+    ]
+    missing = [value for value in required if value not in output]
+    if missing:
+        raise AssertionError(f"self correction output missing {missing}\n{output}")
+
+    if len(MockProviderHandler.completion_requests) != 5:
+        raise AssertionError(
+            f"expected 5 self correction completion requests, got {len(MockProviderHandler.completion_requests)}"
+        )
+    query_data_repair = "\n".join(
+        message["content"] for message in MockProviderHandler.completion_requests[1]["messages"]
+    )
+    for expected in (
+        "Correct the DuckDB SQL query",
+        "Original question:",
+        "self correct count",
+        "Error message:",
+        "smoke_fix_missing",
+        "Broken SQL query:",
+        "SELECT broken_column FROM smoke_fix_missing",
+    ):
+        if expected not in query_data_repair:
+            raise AssertionError(f"ai_query_data repair prompt missing {expected!r}\n{query_data_repair}")
+    fixup_prompt = "\n".join(message["content"] for message in MockProviderHandler.completion_requests[4]["messages"])
+    for expected in (
+        "Correct the DuckDB SQL query",
+        "Error message:",
+        "Catalog Error: Table with name smoke_fix_missing does not exist",
+        "Broken SQL query:",
+    ):
+        if expected not in fixup_prompt:
+            raise AssertionError(f"ai_fix_sql prompt missing {expected!r}\n{fixup_prompt}")
 
 
 def run_duckdb_provider_error(duckdb_path: Path, base_url: str) -> str:
@@ -1081,6 +1176,10 @@ def main():
     try:
         output = run_duckdb(args.duckdb, f"http://127.0.0.1:{port}")
         assert_smoke_result(output)
+        MockProviderHandler.reset()
+        self_correction_output = run_duckdb_self_correction(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_self_correction_result(self_correction_output)
+        MockProviderHandler.reset()
         provider_error_output = run_duckdb_provider_error(args.duckdb, f"http://127.0.0.1:{port}")
         assert_provider_error(provider_error_output)
         MockProviderHandler.reset()

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -138,6 +138,42 @@ SELECT ai_validate_read_only_sql('CREATE TABLE t(i INTEGER)');
 Invalid Input Error: AI generated SQL is not a single read-only SELECT statement:
 
 statement ok
+CREATE TABLE bind_check_table(id INTEGER, label VARCHAR);
+
+query I
+SELECT ai_is_read_only_sql('SELECT id FROM bind_check_table', true);
+----
+true
+
+query I
+SELECT ai_is_read_only_sql('SELECT missing_column FROM bind_check_table', true);
+----
+false
+
+query I
+SELECT ai_is_read_only_sql('SELECT * FROM missing_bind_check_table', true);
+----
+false
+
+query I
+SELECT ai_is_read_only_sql('SELECT missing_column FROM bind_check_table', false);
+----
+true
+
+query I
+SELECT ai_validate_read_only_sql('SELECT id FROM bind_check_table', true);
+----
+SELECT id FROM bind_check_table
+
+statement error
+SELECT ai_validate_read_only_sql('SELECT missing_column FROM bind_check_table', true);
+----
+Invalid Input Error: AI generated SQL does not bind:
+
+statement ok
+DROP TABLE bind_check_table;
+
+statement ok
 CREATE TABLE ai_schema_prompt_orders(id INTEGER NOT NULL, status VARCHAR DEFAULT 'new', note VARCHAR);
 
 statement ok
@@ -527,6 +563,45 @@ statement error
 SELECT * FROM ai_query_data('count rows', sample_rows := 101);
 ----
 Binder Error: ai_query_data sample_rows must be between 0 and 100
+
+statement error
+SELECT * FROM ai_query_data('count rows', fix_attempts := -1);
+----
+Binder Error: ai_query_data fix_attempts must be between 0 and 5
+
+statement error
+SELECT * FROM ai_query_data('count rows', fix_attempts := 6);
+----
+Binder Error: ai_query_data fix_attempts must be between 0 and 5
+
+statement error
+SELECT ai_sql('count rows', fix_attempts := 10);
+----
+Binder Error: ai_sql fix_attempts must be between 0 and 5
+
+query I
+SELECT count(*) FROM ai_query_data('count rows', fix_attempts := 2, provider := 'not-a-provider', fail_on_error := false);
+----
+0
+
+query I
+SELECT ai_sql('count rows', fix_attempts := 2, provider := 'not-a-provider', fail_on_error := false) IS NULL;
+----
+true
+
+query I
+SELECT sql IS NULL FROM ai_fix_sql('SEELECT 42', mode := 'query', error := 'Parser Error: syntax error at or near "SEELECT"', fix_attempts := 1, provider := 'not-a-provider', fail_on_error := false);
+----
+true
+
+statement error
+SELECT * FROM ai_fix_sql('SEELECT 42', mode := 'line', error := 'some error', fix_attempts := 1, provider := 'not-a-provider', fail_on_error := false);
+----
+Binder Error: ai_fix_sql only supports fix_attempts with mode query
+
+statement error
+SELECT * FROM ai_explain_sql('SELECT 42', fix_attempts := 1, provider := 'not-a-provider', fail_on_error := false);
+----
 
 statement error
 SELECT ai_completion_request_json('hello', provider := 'openai', temperature := 3.0);


### PR DESCRIPTION
Closes #26. Generalizes the approach that was suggested to adding "opt-ins". We firrst verify binding, then can fed back the broken SQL + question for N correction round

## What changed

- **`VerifySqlBinds` helper**: binds generated SQL with a child binder in the current session (temp tables visible, nothing executed) and returns the DuckDB bind error.
- **`ai_query_data` / `ai_sql`**: new opt-in `fix_attempts := N` (0–5, default 0 = current behavior). After generation, the SQL is bind-verified; on failure the bind error, original question, and broken SQL are fed back to the model for up to N correction rounds. Each round is a normal model call and emits an `ai_query_data_fix_attempt` / `ai_sql_fix_attempt` usage event.
- **Cache**: with `fix_attempts > 0`, cache hits are re-verified, so entries that stopped binding after a schema change are repaired instead of failing (no cache-key change needed).
- **`ai_fix_sql`**: query mode now accepts `error :=` (threaded into the correction prompt) and `fix_attempts` to bind-verify its own output. Line-mode inference for bare `error` is unchanged.
- **`ai_is_read_only_sql` / `ai_validate_read_only_sql`**: optional second `check_binding` argument exposing bind-level validation standalone.
- Docs: `docs/functions.md` reference and named-options table updated.