### PR TITLE
docs: update install instructions for community extension release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,19 @@ One extension covers both ends of the spectrum:
 
 ## Quick Start
 
-The `ai` extension is not published in the DuckDB community extension repository yet
-(submission in progress). Until then, build and load it from this source tree
-(requires a C++ toolchain, CMake, and ninja):
+The `ai` extension is published as a [DuckDB community extension](https://duckdb.org/community_extensions/extensions/ai).
+Install and load it from any DuckDB client:
+
+```sql
+INSTALL ai FROM community;
+LOAD ai;
+```
+
+To build from source instead (requires a C++ toolchain, CMake, and ninja):
 
 ```sh
 GEN=ninja make release
 ./build/release/duckdb
-```
-
-Then load the extension:
-
-```sql
-LOAD ai;
 ```
 
 Confirm that the extension loaded:

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -5,13 +5,15 @@ sidebar_position: 3
 # Provider guides
 
 This page gives one simple end-to-end example for each supported provider.
-Examples assume you have built the extension and are running the bundled DuckDB
-shell:
+Examples assume the extension is installed and loaded:
 
-```sh
-GEN=ninja make release
-./build/release/duckdb
+```sql
+INSTALL ai FROM community;
+LOAD ai;
 ```
+
+(Or build from source with `GEN=ninja make release` and run
+`./build/release/duckdb`.)
 
 Each guide uses a DuckDB secret for provider, model, and base URL settings. The
 API key is read from the matching environment variable when the provider call


### PR DESCRIPTION
- README quick start now uses `INSTALL ai FROM community; LOAD ai;` (extension is live at https://duckdb.org/community_extensions/extensions/ai), with build-from-source kept as an alternative
- provider-guides.md updated to match