### PR TITLE
[codex] reject nonfinite ai option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.1 - 2026-07-07
+
+### Fixed
+
+- Rejected non-finite `temperature` and `log_sample_rate` values from per-call
+  options, DuckDB settings, and `DUCKDB_AI_LOG_SAMPLE_RATE` instead of emitting
+  invalid provider request JSON or silently disabling usage-log sampling.
+
+### Changed
+
+- Refreshed Docusaurus transitive lockfile dependencies within existing package
+  ranges.
+
 ## 0.4.0 - 2026-07-06
 
 ### Added

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.0
+    EXTENSION_VERSION 0.4.1
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -697,7 +697,7 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 	}
 	if (name == "temperature") {
 		options.temperature = OptionDoubleValue(value, function_name, name);
-		if (options.temperature < 0 || options.temperature > 2) {
+		if (!std::isfinite(options.temperature) || options.temperature < 0 || options.temperature > 2) {
 			throw BinderException("%s option \"temperature\" must be between 0 and 2", function_name);
 		}
 		options.has_temperature = true;
@@ -705,7 +705,7 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 	}
 	if (name == "log_sample_rate") {
 		options.log_sample_rate = OptionDoubleValue(value, function_name, name);
-		if (options.log_sample_rate < 0 || options.log_sample_rate > 1) {
+		if (!std::isfinite(options.log_sample_rate) || options.log_sample_rate < 0 || options.log_sample_rate > 1) {
 			throw BinderException("%s option \"log_sample_rate\" must be between 0 and 1", function_name);
 		}
 		options.has_log_sample_rate = true;
@@ -940,6 +940,9 @@ void ApplyDoubleSetting(ClientContext &context, const std::string &name, double 
 		return;
 	}
 	auto setting = DoubleValue::Get(value.DefaultCastAs(LogicalType::DOUBLE));
+	if (!std::isfinite(setting)) {
+		throw BinderException("Setting %s must be between 0 and 1", name);
+	}
 	if (setting < 0) {
 		return;
 	}

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -236,7 +236,7 @@ bool TryReadEnvDouble(const std::string &name, double &target, double min_value,
 	}
 	try {
 		auto value = std::stod(configured);
-		if (value < min_value || value > max_value) {
+		if (!std::isfinite(value) || value < min_value || value > max_value) {
 			throw InvalidInputException("%s must be between %.0f and %.0f", name, min_value, max_value);
 		}
 		target = value;
@@ -3391,6 +3391,9 @@ void RecordFailedEmbeddingUsageEvent(const ProviderConfig &config, const std::st
 
 double LogSampleRate(const CompletionOptions &options) {
 	if (options.has_log_sample_rate) {
+		if (!std::isfinite(options.log_sample_rate) || options.log_sample_rate < 0 || options.log_sample_rate > 1) {
+			throw InvalidInputException("DUCKDB_AI_LOG_SAMPLE_RATE must be between 0 and 1");
+		}
 		return options.log_sample_rate;
 	}
 	auto configured = GetEnv("DUCKDB_AI_LOG_SAMPLE_RATE");
@@ -3399,7 +3402,7 @@ double LogSampleRate(const CompletionOptions &options) {
 	}
 	try {
 		auto rate = std::stod(configured);
-		if (rate < 0 || rate > 1) {
+		if (!std::isfinite(rate) || rate < 0 || rate > 1) {
 			throw InvalidInputException("DUCKDB_AI_LOG_SAMPLE_RATE must be between 0 and 1");
 		}
 		return rate;

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -650,6 +650,24 @@ def run_duckdb_strict_log_error(duckdb_path: Path, base_url: str, port: int) -> 
     return result.stdout
 
 
+def run_duckdb_invalid_env_log_sample_rate(duckdb_path: Path) -> str:
+    sql = "SELECT ai_completion_request_json('hello', provider := 'openai');"
+    env = os.environ.copy()
+    env["DUCKDB_AI_LOG_SAMPLE_RATE"] = "nan"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"duckdb invalid env log sample rate unexpectedly succeeded\n{result.stdout}")
+    return result.stdout
+
+
 def assert_provider_error(output: str):
     required = [
         'AI provider "openai" (openai_chat, model "mock-model") returned HTTP 401',
@@ -706,6 +724,15 @@ def assert_strict_log_error(output: str):
     if MockProviderHandler.log_requests:
         raise AssertionError(
             f"strict log allowlist should block before log request: {MockProviderHandler.log_requests}"
+        )
+
+
+def assert_invalid_env_log_sample_rate(output: str):
+    if "DUCKDB_AI_LOG_SAMPLE_RATE must be between 0 and 1" not in output:
+        raise AssertionError(f"invalid env log sample rate error missing expected message\n{output}")
+    if MockProviderHandler.completion_requests:
+        raise AssertionError(
+            f"invalid env log sample rate should fail before provider request: {MockProviderHandler.completion_requests}"
         )
 
 
@@ -1191,6 +1218,9 @@ def main():
         MockProviderHandler.reset()
         strict_log_error_output = run_duckdb_strict_log_error(args.duckdb, f"http://127.0.0.1:{port}", port)
         assert_strict_log_error(strict_log_error_output)
+        MockProviderHandler.reset()
+        invalid_env_log_sample_rate_output = run_duckdb_invalid_env_log_sample_rate(args.duckdb)
+        assert_invalid_env_log_sample_rate(invalid_env_log_sample_rate_output)
     finally:
         server.shutdown()
         thread.join(timeout=5)

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -609,7 +609,17 @@ SELECT ai_completion_request_json('hello', provider := 'openai', temperature := 
 Binder Error: AI option "temperature" must be between 0 and 2
 
 statement error
+SELECT ai_completion_request_json('hello', provider := 'openai', temperature := CAST('nan' AS DOUBLE));
+----
+Binder Error: AI option "temperature" must be between 0 and 2
+
+statement error
 SELECT ai_completion_request_json('hello', provider := 'openai', log_sample_rate := 1.5);
+----
+Binder Error: AI option "log_sample_rate" must be between 0 and 1
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai', log_sample_rate := CAST('nan' AS DOUBLE));
 ----
 Binder Error: AI option "log_sample_rate" must be between 0 and 1
 
@@ -700,6 +710,17 @@ Binder Error: AI option "output_token_price_per_million" must be greater than or
 
 statement ok
 SET duckdb_ai_log_sample_rate = 2.0;
+
+statement error
+SELECT ai_completion_request_json('hello', provider := 'openai');
+----
+Binder Error: Setting duckdb_ai_log_sample_rate must be between 0 and 1
+
+statement ok
+RESET duckdb_ai_log_sample_rate;
+
+statement ok
+SET duckdb_ai_log_sample_rate = 'nan';
 
 statement error
 SELECT ai_completion_request_json('hello', provider := 'openai');

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4313,13 +4313,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.58.0.tgz",
-      "integrity": "sha512-K82t5e9w3NYQeIcw129f0SCH/Rn8m8GKPJBYge4W/sA4hhE5h7I8YQhs2HRpUQyUpi+qk7I9tbp1/b87eCM/PA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.59.0.tgz",
+      "integrity": "sha512-pJe1jk1u3qzc1LWV9DBuB+LpaHcrg1pdoFF6Rv4grSVztdVCeN3omV1OE2SgugNTHktHsZvM7RgtjpQGuFj7Lg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.58.0",
-        "@jsonjoy.com/fs-node-utils": "4.58.0",
+        "@jsonjoy.com/fs-node-builtins": "4.59.0",
+        "@jsonjoy.com/fs-node-utils": "4.59.0",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -4334,14 +4334,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.58.0.tgz",
-      "integrity": "sha512-1/FdsxQao9pBo2OJLEfKrujHdVyGxXvDTT7EtNh9fvp3MK42nB+xHh1EJr2L1c0a05eCMyFCYZPID3KjX9EAng==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.59.0.tgz",
+      "integrity": "sha512-J0zpzbGNnyvpxJtd2+XE9lT0l/0ceACrKmyF8WwTpXmfZ3SlxFfFpXj1g7R1rUrENihOxpLou5eWi3kjT1TvNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.58.0",
-        "@jsonjoy.com/fs-node-builtins": "4.58.0",
-        "@jsonjoy.com/fs-node-utils": "4.58.0",
+        "@jsonjoy.com/fs-core": "4.59.0",
+        "@jsonjoy.com/fs-node-builtins": "4.59.0",
+        "@jsonjoy.com/fs-node-utils": "4.59.0",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -4356,16 +4356,16 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.58.0.tgz",
-      "integrity": "sha512-bOqoLND5b5xyM+1zro63kClBnB05HTIX0RzOSHy4kAjfnec+CTdV742H/nsDmbkDaaDLHMmYqxAw09NQ8yVIrQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.59.0.tgz",
+      "integrity": "sha512-Ju6afR+tAoyzYe5t6hyOODHMsE6z3/DjLyJcfdqkupJH+90kvlbpzdCq4P7BDUiTqT9RjpQezmf2ucBVBOoGtw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.58.0",
-        "@jsonjoy.com/fs-node-builtins": "4.58.0",
-        "@jsonjoy.com/fs-node-utils": "4.58.0",
-        "@jsonjoy.com/fs-print": "4.58.0",
-        "@jsonjoy.com/fs-snapshot": "4.58.0",
+        "@jsonjoy.com/fs-core": "4.59.0",
+        "@jsonjoy.com/fs-node-builtins": "4.59.0",
+        "@jsonjoy.com/fs-node-utils": "4.59.0",
+        "@jsonjoy.com/fs-print": "4.59.0",
+        "@jsonjoy.com/fs-snapshot": "4.59.0",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -4381,9 +4381,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.58.0.tgz",
-      "integrity": "sha512-M1sAhjR1de4CL7ivQAFYqJRDVE3krwVOmfcAgG5YQJiDWxYfcGDMLUNcx0p/+Rcs31/Inh1m9aUDk/0jfR1T5w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.59.0.tgz",
+      "integrity": "sha512-95OvyK9xq8uNX/jp5RH/IZMtSp/B71aL/v2niiP+vdODvsaGfLwOt7ZlrqkYfr/rx24XGX71v1/UCCbeHmrKQA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
@@ -4397,14 +4397,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.58.0.tgz",
-      "integrity": "sha512-erivc39YHoqWY0U8q5IlEcn238AUkIBByMvM0w7OO/FU9hEH3P7oNkPpYWIMpEMncbePk672GiC8ZSwYc2m7fg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.59.0.tgz",
+      "integrity": "sha512-G8+caP2hF1GNTbT8QOGt08Xf4NZSGDizQRlqwjsIFU01txBGgaR/PigI/QDG66fGVGQOZ2i1p53c1DzyrUuOKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.58.0",
-        "@jsonjoy.com/fs-node-builtins": "4.58.0",
-        "@jsonjoy.com/fs-node-utils": "4.58.0"
+        "@jsonjoy.com/fs-fsa": "4.59.0",
+        "@jsonjoy.com/fs-node-builtins": "4.59.0",
+        "@jsonjoy.com/fs-node-utils": "4.59.0"
       },
       "engines": {
         "node": ">=10.0"
@@ -4418,12 +4418,12 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.58.0.tgz",
-      "integrity": "sha512-IrsAFMFBFQXjpS/u3jOY4DMIbRDg94KxzadddDlJv9xodxZ6/Y3ji91uMwrRqklyu+KoquO/Vxihf3/QrQiuOA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.59.0.tgz",
+      "integrity": "sha512-+1LntwqYeifjOn3frpGds8ehXyWfFj/jEzU+ujzeWFhtrsX5XnJu3A18YSo9+UWiv5NPf64sCz8TOp473d4mpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.58.0"
+        "@jsonjoy.com/fs-node-builtins": "4.59.0"
       },
       "engines": {
         "node": ">=10.0"
@@ -4437,12 +4437,12 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.58.0.tgz",
-      "integrity": "sha512-jbAYbeuzPXIzvWOuuFMoQgrWaQU5hBqevloebLaiAimoBYLjrjiLPdOaaLHepWcZzOq/7Us8x2F22YlsTPbwmw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.59.0.tgz",
+      "integrity": "sha512-hHhXIUV7A++ab7UKVo1ecW8bie4jnXgUWu63dmuEotcWSiEpCKZCoIGuxD6GaXf8J8lv7cUyE/uRFzPjMT7Z5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.58.0",
+        "@jsonjoy.com/fs-node-utils": "4.59.0",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -4457,13 +4457,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.58.0.tgz",
-      "integrity": "sha512-DkozLuMgzfpWZO8o8tSlFJIpUQauG7/sgjH0JrqsbLkmjdoInn/o1W7P9FZQSZlR9lOjDgSXs2MfE/sAUi2JRQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.59.0.tgz",
+      "integrity": "sha512-5qk/6IXt7bXqqYbswvYh0TgasMTFBTvv5rNEzi0YQi0D69NkT57bo+w2+vUm8YSsCvSYi8/sp39GwcvwMOE0RQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.58.0",
+        "@jsonjoy.com/fs-node-utils": "4.59.0",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -7375,9 +7375,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001802",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
-      "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8873,9 +8873,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.387",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
-      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "version": "1.5.388",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
+      "integrity": "sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -12087,19 +12087,19 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.58.0.tgz",
-      "integrity": "sha512-0n6CDBqIT/eGrbWdDVNkLjasjupnEpOFjFOtXrS5p6EYYXGXBn5ZIMLetBlVdQYpP0hGK2MEOgYAC0/+NOr91w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.59.0.tgz",
+      "integrity": "sha512-uJFG7xPJjwOtNAw8sCw140wvk0XUiwioQE7hdz1ho/BrzcqB1RupNnJsuNxk6gWRGkf65jNb7fm5SUDdWOV7Sw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.58.0",
-        "@jsonjoy.com/fs-fsa": "4.58.0",
-        "@jsonjoy.com/fs-node": "4.58.0",
-        "@jsonjoy.com/fs-node-builtins": "4.58.0",
-        "@jsonjoy.com/fs-node-to-fsa": "4.58.0",
-        "@jsonjoy.com/fs-node-utils": "4.58.0",
-        "@jsonjoy.com/fs-print": "4.58.0",
-        "@jsonjoy.com/fs-snapshot": "4.58.0",
+        "@jsonjoy.com/fs-core": "4.59.0",
+        "@jsonjoy.com/fs-fsa": "4.59.0",
+        "@jsonjoy.com/fs-node": "4.59.0",
+        "@jsonjoy.com/fs-node-builtins": "4.59.0",
+        "@jsonjoy.com/fs-node-to-fsa": "4.59.0",
+        "@jsonjoy.com/fs-node-utils": "4.59.0",
+        "@jsonjoy.com/fs-print": "4.59.0",
+        "@jsonjoy.com/fs-snapshot": "4.59.0",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",


### PR DESCRIPTION
## Summary

This PR fixes a public request-shaping bug in the `ai` DuckDB extension: non-finite floating point option values such as `CAST('nan' AS DOUBLE)` were accepted for `temperature` and `log_sample_rate` even though the public option contract says those values must be bounded numbers.

For `temperature`, the bad value reached request preview/build paths and produced invalid JSON such as `"temperature":nan`, which a real provider would reject or parse inconsistently. For `log_sample_rate`, `NaN` could be accepted from a per-call option, a DuckDB setting, or `DUCKDB_AI_LOG_SAMPLE_RATE`; depending on the path, it could silently suppress usage-log posting rather than failing the query with a clear configuration error.

## Root Cause

The range checks used ordinary `<` / `>` comparisons without first checking `std::isfinite`. Since comparisons against `NaN` are false, the existing guards let `NaN` through. The environment parsing helper in the provider runtime had the same issue.

## Fix

The binder and provider runtime now reject non-finite doubles before accepting the value:

- per-call `temperature` rejects `NaN`/non-finite values before request JSON is built
- per-call `log_sample_rate` rejects non-finite values
- `duckdb_ai_log_sample_rate` rejects non-finite DuckDB setting values
- `DUCKDB_AI_LOG_SAMPLE_RATE` rejects non-finite environment values in both snapshot parsing and direct log-sampling fallback paths

The PR also prepares patch release `0.4.1` in `extension_config.cmake` and `CHANGELOG.md`, and refreshes docs-site transitive lockfile packages within the existing package ranges.

## Validation

- Reproduced current bug locally: `temperature := CAST('nan' AS DOUBLE)` emitted invalid JSON containing `"temperature":nan` before the fix.
- Confirmed the fixed build rejects the same repro at bind time.
- `GEN=ninja make release`
- `GEN=ninja make test`
- `python3 test/smoke/mock_provider_smoke.py`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make tidy-check`
- `DUCKDB_BIN=/tmp/duckdb_cli_v1.5.4/duckdb scripts/preview_community_docs.sh --check`
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm audit --audit-level=moderate`
- `npm outdated --json`
- `git diff --check`
