### PR TITLE
Update provider defaults for current APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.2 - 2026-07-07
+
+### Fixed
+
+- Updated provider defaults and built-in pricing metadata for current public
+  provider docs: Gemini text embeddings now default to `gemini-embedding-001`,
+  DeepSeek completion calls default to `deepseek-v4-flash`, and Z.ai calls use
+  `https://api.z.ai/api/paas/v4` with `glm-4.7-flash`.
+
 ## 0.4.1 - 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ End-to-end setup examples for each provider are in
 | `openai` | OpenAI chat and embedding models | `https://api.openai.com/v1`; `OPENAI_API_KEY` |
 | `openrouter` | OpenRouter model routing | `https://openrouter.ai/api/v1`; `OPENROUTER_API_KEY` |
 | `snowflake` | Snowflake Cortex REST Chat Completions API | Set `BASE_URL`, `SNOWFLAKE_ACCOUNT_URL`, or `SNOWFLAKE_ACCOUNT`; `SNOWFLAKE_PAT` |
-| `zai` | Z.ai / BigModel chat models | `https://open.bigmodel.cn/api/paas/v4`; `ZAI_API_KEY` |
+| `zai` | Z.ai / BigModel chat models | `https://api.z.ai/api/paas/v4`; `ZAI_API_KEY` |
 
 You can configure providers three ways:
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -821,8 +821,8 @@ Supported provider names and aliases are:
 | `anthropic` | `claude` | Yes | No | `claude-haiku-4-5` |
 | `gemini` | `gcp`, `google`, `google_gemini` | Yes | Yes | `gemini-2.5-flash` |
 | `mistral` | none | Yes | Yes | `mistral-small-latest` |
-| `zai` | `zhipu` | Yes | Yes | `glm-4-flash` |
-| `deepseek` | none | Yes | No | `deepseek-chat` |
+| `zai` | `zhipu` | Yes | Yes | `glm-4.7-flash` |
+| `deepseek` | none | Yes | No | `deepseek-v4-flash` |
 | `openrouter` | none | Yes | Yes | `openai/gpt-4o-mini` |
 | `databricks` | `mosaic`, `mosaic_ai`, `databricks_ai` | Yes | No | `databricks-llama-4-maverick` |
 | `snowflake` | none | Yes | No | `snowflake-llama-3.3-70b` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -37,10 +37,10 @@ LIMIT 1;
 | `openai` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | `OPENAI_API_KEY` | Defaults to `https://api.openai.com/v1`. |
 | `azure` | OpenAI-compatible chat and embeddings | `gpt-4o`; embeddings use `text-embedding-3-small` | `AZURE_OPENAI_API_KEY` | Appends `/openai/v1` to `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, or secret `BASE_URL` when needed. |
 | `anthropic` / `claude` | Anthropic Messages | `claude-haiku-4-5` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | Defaults to `https://api.anthropic.com/v1`. |
-| `gemini` / `gcp` / `google` | OpenAI-compatible chat and embeddings | `gemini-2.5-flash`; embeddings use `text-embedding-004` | `GEMINI_API_KEY` | Defaults to Google's OpenAI-compatible endpoint. |
+| `gemini` / `gcp` / `google` | OpenAI-compatible chat and embeddings | `gemini-2.5-flash`; embeddings use `gemini-embedding-001` | `GEMINI_API_KEY` | Defaults to Google's OpenAI-compatible endpoint. |
 | `mistral` | OpenAI-compatible chat and embeddings | `mistral-small-latest`; embeddings use `mistral-embed` | `MISTRAL_API_KEY` | Defaults to `https://api.mistral.ai/v1`. |
-| `zai` / `zhipu` | OpenAI-compatible chat and embeddings | `glm-4-flash`; embeddings use `embedding-3` | `ZAI_API_KEY` | Defaults to `https://open.bigmodel.cn/api/paas/v4`. |
-| `deepseek` | OpenAI-compatible chat | `deepseek-chat` | `DEEPSEEK_API_KEY` | Defaults to `https://api.deepseek.com`. |
+| `zai` / `zhipu` | OpenAI-compatible chat and embeddings | `glm-4.7-flash`; embeddings use `embedding-3` | `ZAI_API_KEY` | Defaults to `https://api.z.ai/api/paas/v4`. |
+| `deepseek` | OpenAI-compatible chat | `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | Defaults to `https://api.deepseek.com`. |
 | `openrouter` | OpenAI-compatible chat and embeddings | `openai/gpt-4o-mini`; embeddings use `openai/text-embedding-3-small` | `OPENROUTER_API_KEY` | Defaults to `https://openrouter.ai/api/v1`. |
 | `databricks` | OpenAI-compatible chat | `databricks-llama-4-maverick` | `DATABRICKS_TOKEN` | Derives `/serving-endpoints` from `DATABRICKS_HOST`, or accepts full Model Serving, AI Gateway, or chat-completions URLs. |
 | `snowflake` | OpenAI-compatible chat | `snowflake-llama-3.3-70b` | `SNOWFLAKE_PAT` or `SNOWFLAKE_TOKEN` | Derives `/api/v2/cortex/v1` from Snowflake account URL, host, or account id. |
@@ -221,7 +221,7 @@ SELECT ai_complete(
 SELECT ai_embed(
     'DuckDB vector search',
     secret := 'gemini_ai',
-    model := 'text-embedding-004'
+    model := 'gemini-embedding-001'
 )[1] AS first_embedding_value;
 ```
 
@@ -268,7 +268,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET zai_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'zai',
-    MODEL 'glm-4-flash'
+    MODEL 'glm-4.7-flash'
 );
 
 SELECT ai_complete(
@@ -298,7 +298,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET deepseek_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'deepseek',
-    MODEL 'deepseek-chat'
+    MODEL 'deepseek-v4-flash'
 );
 
 SELECT ai_complete(

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.1
+    EXTENSION_VERSION 0.4.2
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -596,6 +596,8 @@ bool HasEstimatedCost(double estimated_cost_usd) {
 
 const std::vector<ModelPrice> &BuiltinModelPrices() {
 	static const std::vector<ModelPrice> prices {
+	    {"openai", "gpt-5.5", "completion", 5.00, 30.00, "https://developers.openai.com/api/docs/pricing",
+	     "standard text token pricing for <272K context length", "2026-07-07"},
 	    {"openai", "gpt-5.4", "completion", 2.50, 15.00, "https://developers.openai.com/api/docs/pricing",
 	     "standard text token pricing", "2026-06-30"},
 	    {"openai", "gpt-5.4-mini", "completion", 0.75, 4.50,
@@ -613,15 +615,14 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-06-30"},
 	    {"gemini", "gemini-2.5-flash", "completion", 0.30, 2.50, "https://ai.google.dev/gemini-api/docs/pricing",
 	     "text/image/video input <= 200k tokens", "2026-06-30"},
-	    {"gemini", "text-embedding-004", "embedding", 0.00, -1, "https://ai.google.dev/gemini-api/docs/pricing",
-	     "listed as free tier pricing", "2026-06-30"},
+	    {"gemini", "gemini-embedding-001", "embedding", 0.15, -1, "https://ai.google.dev/gemini-api/docs/pricing",
+	     "standard text embedding input tokens only", "2026-07-07"},
 	    {"mistral", "mistral-small-latest", "completion", 0.10, 0.30, "https://mistral.ai/pricing/",
 	     "standard text token pricing", "2026-06-30"},
 	    {"mistral", "mistral-embed", "embedding", 0.10, -1, "https://mistral.ai/pricing/",
 	     "embedding input tokens only", "2026-06-30"},
-	    {"deepseek", "deepseek-chat", "completion", 0.27, 1.10,
-	     "https://api-docs.deepseek.com/quick_start/pricing/pricing_details", "input price uses cache-miss pricing",
-	     "2026-06-30"},
+	    {"deepseek", "deepseek-v4-flash", "completion", 0.14, 0.28, "https://api-docs.deepseek.com/quick_start/pricing",
+	     "input price uses cache-miss pricing", "2026-07-07"},
 	    {"zai", "glm-4.7-flash", "completion", 0.00, 0.00, "https://docs.z.ai/guides/overview/pricing",
 	     "standard text token pricing", "2026-06-30"},
 	    {"zai", "glm-4.7-flashx", "completion", 0.07, 0.40, "https://docs.z.ai/guides/overview/pricing",
@@ -2488,15 +2489,15 @@ ProviderConfig ProviderDefaults(const std::string &provider_input) {
 		return {provider, "openai_chat", "gpt-4o", "", "", "AZURE_OPENAI_API_KEY", "", true};
 	}
 	if (provider == "deepseek") {
-		return {provider, "openai_chat", "deepseek-chat", "", "https://api.deepseek.com", "DEEPSEEK_API_KEY", "", true};
+		return {provider, "openai_chat", "deepseek-v4-flash", "", "https://api.deepseek.com", "DEEPSEEK_API_KEY",
+		        "",       true};
 	}
 	if (provider == "mistral") {
 		return {provider, "openai_chat", "mistral-small-latest", "", "https://api.mistral.ai/v1", "MISTRAL_API_KEY",
 		        "",       true};
 	}
 	if (provider == "zai" || provider == "zhipu") {
-		return {"zai", "openai_chat", "glm-4-flash", "", "https://open.bigmodel.cn/api/paas/v4", "ZAI_API_KEY",
-		        "",    true};
+		return {"zai", "openai_chat", "glm-4.7-flash", "", "https://api.z.ai/api/paas/v4", "ZAI_API_KEY", "", true};
 	}
 	if (provider == "gemini") {
 		return {provider,
@@ -2894,7 +2895,7 @@ std::string EmbeddingDefaultModel(const std::string &provider) {
 		return "mistral-embed";
 	}
 	if (provider == "gemini") {
-		return "text-embedding-004";
+		return "gemini-embedding-001";
 	}
 	if (provider == "zai") {
 		return "embedding-3";

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -100,7 +100,12 @@ openai_chat	openai_chat
 query I
 SELECT ai_provider_protocol('gemini') || '@' || ai_provider_base_url('gemini') || '|' || ai_provider_protocol('mistral') || '@' || ai_provider_base_url('mistral') || '|' || ai_provider_protocol('zai') || '@' || ai_provider_base_url('zai') || '|' || ai_provider_protocol('deepseek') || '@' || ai_provider_base_url('deepseek') || '|' || ai_provider_protocol('openrouter') || '@' || ai_provider_base_url('openrouter');
 ----
-openai_chat@https://generativelanguage.googleapis.com/v1beta/openai|openai_chat@https://api.mistral.ai/v1|openai_chat@https://open.bigmodel.cn/api/paas/v4|openai_chat@https://api.deepseek.com|openai_chat@https://openrouter.ai/api/v1
+openai_chat@https://generativelanguage.googleapis.com/v1beta/openai|openai_chat@https://api.mistral.ai/v1|openai_chat@https://api.z.ai/api/paas/v4|openai_chat@https://api.deepseek.com|openai_chat@https://openrouter.ai/api/v1
+
+query III
+SELECT contains(ai_completion_request_json('hello', provider := 'zai'), '"model":"glm-4.7-flash"'), contains(ai_completion_request_json('hello', provider := 'deepseek'), '"model":"deepseek-v4-flash"'), contains(ai_embedding_request_json('duck', provider := 'gemini'), '"model":"gemini-embedding-001"');
+----
+true	true	true
 
 query I
 SELECT count(*) > 0 FROM duckdb_secret_types() WHERE type = 'duckdb_ai';


### PR DESCRIPTION
## Summary

- Update current provider defaults for Gemini text embeddings, DeepSeek, and Z.ai.
- Refresh built-in pricing metadata for OpenAI `gpt-5.5`, Gemini embeddings, and DeepSeek V4 Flash.
- Bump the extension to `0.4.2` because the provider default changes fix public API drift.

## Why

Provider docs changed in ways that affect default request shape:

- Gemini OpenAI-compatible embeddings now document `gemini-embedding-001` for text-only embeddings.
- DeepSeek pricing/docs list `deepseek-chat` as a compatibility model with replacement models including `deepseek-v4-flash`.
- Z.ai docs use `https://api.z.ai/api/paas/v4` and the newer `glm-4.7-*` model family.

Sources checked:

- https://developers.openai.com/api/docs/pricing
- https://developers.openai.com/api/docs/guides/latest-model.md
- https://ai.google.dev/gemini-api/docs/openai
- https://ai.google.dev/gemini-api/docs/pricing
- https://api-docs.deepseek.com/quick_start/pricing
- https://docs.z.ai/guides/overview/quickstart
- https://docs.z.ai/guides/overview/pricing

## Validation

- `git diff --check`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release`
- `GEN=ninja make test`
- `python3 test/smoke/mock_provider_smoke.py`
- `npm ci` in `website/`
- `npm run typecheck` in `website/`
- `npm run build` in `website/`
- `scripts/preview_community_docs.sh --check`
- `npm outdated --json` in `website/` returned `{}`

## Release

Release intentionally triggered: this fixes public provider defaults/endpoints, so the patch bumps `EXTENSION_VERSION` to `0.4.2`.
