### PR TITLE
fix(xai): refresh grok defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.6 - 2026-07-09
+
+### Fixed
+
+- Updated the xAI / SpaceXAI provider default to `grok-4.5`, added built-in
+  `grok-4.5` pricing metadata, and sent `prompt_cache := true` hints through
+  the documented `x-grok-conv-id` chat-completions header.
+
 ## 0.4.5 - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -531,7 +531,8 @@ SELECT * FROM ai_clear_cache();
 Provider-side prompt caching is separate and reduces cost on repeated static
 prefixes (system prompts, schemas). Enable it with `prompt_cache := true` or
 `SET duckdb_ai_prompt_cache = true`; the extension sends the matching cache
-hints for OpenAI and Anthropic and reports cached token counts in `ai_usage()`.
+hints for OpenAI, Anthropic, and xAI and reports cached token counts in
+`ai_usage()`.
 
 Use `ai_recommended_batch_size` with a small provider-limit table to pick a
 starting batch size before running a large enrichment:

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -398,10 +398,12 @@ SELECT ai_complete_json(
 FROM documents;
 ```
 
-OpenAI-compatible prompt caching generally needs a stable prefix of at least
-1,024 tokens before cached-token discounts appear. Anthropic cache reads and
-writes are exposed in `ai_usage()` as `cached_prompt_tokens` and
-`cache_creation_prompt_tokens`.
+OpenAI receives a stable `prompt_cache_key`, Anthropic receives ephemeral cache
+control on the system prompt, and xAI receives the matching `x-grok-conv-id`
+header for chat-completion calls. OpenAI-compatible prompt caching generally
+needs a stable prefix of at least 1,024 tokens before cached-token discounts
+appear. Anthropic cache reads and writes are exposed in `ai_usage()` as
+`cached_prompt_tokens` and `cache_creation_prompt_tokens`.
 
 This is separate from the extension's exact-response cache. Use `cache := true`
 when identical prompts may repeat inside or across chunks in the same database

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -770,7 +770,7 @@ not from direct API key arguments.
 | `cache` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Enables the current database instance's in-memory response cache for successful provider responses. |
 | `cache_ttl_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Optional response-cache expiration from 0 to 31536000 seconds. `0` means entries do not expire by age. The `DUCKDB_AI_CACHE_TTL_SECONDS` environment variable sets the default. |
 | `cache_max_entries` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | Maximum in-memory response-cache entries from 0 to 1000000. `0` disables response-cache storage. The `DUCKDB_AI_CACHE_MAX_ENTRIES` environment variable sets the default. |
-| `prompt_cache` | `BOOLEAN` | Completion, task wrappers, and SQL assistant | Emits provider-side prompt-cache controls where supported. OpenAI requests include a stable `prompt_cache_key`; Anthropic requests attach ephemeral cache control to the system prompt. The `DUCKDB_AI_PROMPT_CACHE` environment variable enables this by default. |
+| `prompt_cache` | `BOOLEAN` | Completion, task wrappers, and SQL assistant | Emits provider-side prompt-cache controls where supported. OpenAI requests include a stable `prompt_cache_key`; Anthropic requests attach ephemeral cache control to the system prompt; xAI requests send `x-grok-conv-id`. The `DUCKDB_AI_PROMPT_CACHE` environment variable enables this by default. |
 | `allowed_hosts` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Comma-separated provider/logging host allowlist. Entries may be hostnames, `host:port`, full URLs, `*.example.com`, or `*`. |
 | `on_error` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Error handling mode: `fail`, `null`, or `capture`. `capture` is used by `ai_try_complete`; scalar/table functions that cannot return an error field use `NULL` behavior. |
 | `fail_on_error` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Compatibility alias: `true` maps to `on_error := 'fail'`, `false` maps to `on_error := 'null'`. |
@@ -850,7 +850,7 @@ Supported provider names and aliases are:
 | `vercel` | `vercel_ai_gateway`, `vercel_gateway`, `ai_gateway` | Yes | Yes | `openai/gpt-4o-mini` |
 | `vertex` | `google_vertex`, `vertex_ai`, `gcp_vertex` | Yes | No | `google/gemini-2.5-flash` |
 | `volcengine` | `volcano_engine`, `volcengine_ark`, `doubao`, `ark` | Yes | No | `doubao-seed-2-1-pro-260628` |
-| `xai` | `x.ai`, `x-ai`, `grok` | Yes | No | `grok-4` |
+| `xai` | `x.ai`, `x-ai`, `grok` | Yes | No | `grok-4.5` |
 | `zai` | `zhipu` | Yes | Yes | `glm-4.7-flash` |
 | `openai_privacy_filter` | `privacy_filter`, `pii_filter`, `opf` | Redaction only | No | `openai/privacy-filter` |
 | `openai_compatible` | `local`, `openai-compatible`, `local_openai`, `local-models`, `local_models` | Yes | Yes | `gpt-4o-mini` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -69,7 +69,7 @@ LIMIT 1;
 | `vercel` / `vercel_ai_gateway` | OpenAI-compatible chat and embeddings | `openai/gpt-4o-mini`; embeddings use `openai/text-embedding-3-small` | `AI_GATEWAY_API_KEY`, `VERCEL_AI_GATEWAY_API_KEY`, or `VERCEL_OIDC_TOKEN` | Defaults to `https://ai-gateway.vercel.sh/v1`. |
 | `vertex` / `google_vertex` | OpenAI-compatible chat | `google/gemini-2.5-flash` | `VERTEX_AI_ACCESS_TOKEN`, `GOOGLE_CLOUD_ACCESS_TOKEN`, or `VERTEX_API_KEY` | Derives the endpoint from `GOOGLE_CLOUD_PROJECT`, or accepts `VERTEX_AI_BASE_URL`, `GOOGLE_VERTEX_BASE_URL`, or secret `BASE_URL`. |
 | `volcengine` / `doubao` | OpenAI-compatible chat | `doubao-seed-2-1-pro-260628` | `VOLCENGINE_API_KEY`, `ARK_API_KEY`, or `DOUBAO_API_KEY` | Defaults to `https://ark.cn-beijing.volces.com/api/v3`. |
-| `xai` / `grok` | OpenAI-compatible chat | `grok-4` | `XAI_API_KEY` | Defaults to `https://api.x.ai/v1`. |
+| `xai` / `grok` | OpenAI-compatible chat | `grok-4.5` | `XAI_API_KEY` | Defaults to `https://api.x.ai/v1`. |
 | `openai_privacy_filter` | Dedicated redaction endpoint | `openai/privacy-filter` | Optional `OPENAI_PRIVACY_FILTER_API_KEY` | Defaults to `http://localhost:8080` and calls `POST /redact`. |
 | `openai_compatible` / `local` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | Optional `OPENAI_COMPATIBLE_API_KEY` | Requires `BASE_URL` or `OPENAI_COMPATIBLE_BASE_URL`. |
 | `llamacpp` / `llama.cpp` | OpenAI-compatible chat and embeddings | `default` (llama-server answers with its loaded model) | Optional `LLAMACPP_API_KEY` (`llama-server --api-key`) | Defaults to `http://localhost:8080/v1`. Embeddings need `llama-server --embeddings`. |
@@ -941,7 +941,7 @@ SELECT ai_complete(
 Aliases `github`, `github_models`, `github-models`, and `gh_models` resolve to
 the same provider.
 
-## xAI
+## xAI / SpaceXAI
 
 ```sh
 export XAI_API_KEY='...'
@@ -954,7 +954,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET xai_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'xai',
-    MODEL 'grok-4'
+    MODEL 'grok-4.5'
 );
 
 SELECT ai_complete(

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.5
+    EXTENSION_VERSION 0.4.6
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -837,6 +837,8 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	     "live model feed pricing", "2026-06-30"},
 	    {"openrouter", "z-ai/glm-4.7-flash", "completion", 0.06, 0.40, "https://openrouter.ai/api/v1/models",
 	     "live model feed pricing", "2026-06-30"},
+	    {"xai", "grok-4.5", "completion", 2.00, 6.00, "https://docs.x.ai/developers/models",
+	     "standard text token pricing", "2026-07-09"},
 	};
 	return prices;
 }
@@ -2711,7 +2713,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	    {"vertex", "openai_chat", "google/gemini-2.5-flash", "", "", "VERTEX_AI_ACCESS_TOKEN", true},
 	    {"volcengine", "openai_chat", "doubao-seed-2-1-pro-260628", "", "https://ark.cn-beijing.volces.com/api/v3",
 	     "VOLCENGINE_API_KEY", true},
-	    {"xai", "openai_chat", "grok-4", "", "https://api.x.ai/v1", "XAI_API_KEY", true},
+	    {"xai", "openai_chat", "grok-4.5", "", "https://api.x.ai/v1", "XAI_API_KEY", true},
 	    {"zai", "openai_chat", "glm-4.7-flash", "embedding-3", "https://api.z.ai/api/paas/v4", "ZAI_API_KEY", true},
 	};
 	return providers;
@@ -3645,7 +3647,7 @@ std::vector<EmbeddingResult> ParseEmbeddingResults(const ProviderConfig &config,
 	return results;
 }
 
-std::vector<std::string> RequestHeaders(const ProviderConfig &config) {
+std::vector<std::string> RequestHeaders(const ProviderConfig &config, const CompletionOptions &options) {
 	std::vector<std::string> headers {"Content-Type: application/json", "User-Agent: " + ExtensionUserAgent()};
 	if (config.protocol == "anthropic_messages") {
 		headers.push_back("anthropic-version: 2023-06-01");
@@ -3669,6 +3671,12 @@ std::vector<std::string> RequestHeaders(const ProviderConfig &config) {
 		}
 		if (!title.empty()) {
 			headers.push_back("X-OpenRouter-Title: " + title);
+		}
+	}
+	if (config.provider == "xai" && PromptCacheEnabled(options)) {
+		auto prompt_cache_key = PromptCacheKey(config, options);
+		if (!prompt_cache_key.empty()) {
+			headers.push_back("x-grok-conv-id: " + prompt_cache_key);
 		}
 	}
 	return headers;
@@ -4277,7 +4285,7 @@ HttpResponse FetchProviderResponse(const std::string &operation, const ProviderC
                                    const CompletionOptions &options, int64_t estimated_tokens,
                                    std::string &cache_key_out) {
 	if (!ResponseCacheEnabled(options)) {
-		return ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, estimated_tokens);
+		return ProviderHttpPost(endpoint, payload, RequestHeaders(config, options), options, estimated_tokens);
 	}
 	auto &runtime_state = RuntimeState(options);
 	auto cache_key = ResponseCacheKey(operation, config, endpoint, payload);
@@ -4292,7 +4300,8 @@ HttpResponse FetchProviderResponse(const std::string &operation, const ProviderC
 		return WaitForPendingCachedResponse(runtime_state, cache_key, pending, options);
 	}
 	try {
-		auto fresh_response = ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, estimated_tokens);
+		auto fresh_response =
+		    ProviderHttpPost(endpoint, payload, RequestHeaders(config, options), options, estimated_tokens);
 		if (fresh_response.status >= 200 && fresh_response.status < 300) {
 			StoreCachedResponse(runtime_state, cache_key, fresh_response, options);
 		}
@@ -4318,7 +4327,7 @@ std::vector<EmbeddingResult> EmbedBatchRequest(const ProviderConfig &config, con
 	}
 	HttpResponse response;
 	try {
-		response = ProviderHttpPost(endpoint, payload, RequestHeaders(config), options, total_tokens);
+		response = ProviderHttpPost(endpoint, payload, RequestHeaders(config, options), options, total_tokens);
 	} catch (InterruptException &) {
 		throw;
 	} catch (std::exception &ex) {

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -19,6 +19,7 @@ class MockProviderHandler(BaseHTTPRequestHandler):
     authorization_headers = []
     openrouter_referer_headers = []
     openrouter_title_headers = []
+    xai_conversation_headers = []
     claude_api_keys = []
     claude_versions = []
     retry_completion_attempts = 0
@@ -34,6 +35,7 @@ class MockProviderHandler(BaseHTTPRequestHandler):
         cls.authorization_headers.clear()
         cls.openrouter_referer_headers.clear()
         cls.openrouter_title_headers.clear()
+        cls.xai_conversation_headers.clear()
         cls.claude_api_keys.clear()
         cls.claude_versions.clear()
         cls.retry_completion_attempts = 0
@@ -47,6 +49,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             if self.headers.get("x-openrouter-title") or self.headers.get("http-referer"):
                 self.openrouter_referer_headers.append(self.headers.get("http-referer"))
                 self.openrouter_title_headers.append(self.headers.get("x-openrouter-title"))
+            if self.headers.get("x-grok-conv-id"):
+                self.xai_conversation_headers.append(self.headers.get("x-grok-conv-id"))
             request = json.loads(body)
             self.completion_requests.append(request)
             prompt = request["messages"][-1]["content"]
@@ -719,6 +723,50 @@ def assert_openrouter_headers(output: str):
         raise AssertionError(f"unexpected OpenRouter title headers: {MockProviderHandler.openrouter_title_headers}")
 
 
+def run_duckdb_xai_prompt_cache_header(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT ai_complete(
+            'hello xai',
+            provider := 'xai',
+            base_url := '{base_url}',
+            system_prompt := 'answer briefly',
+            prompt_cache := true
+        );
+    """
+    env = os.environ.copy()
+    env["XAI_API_KEY"] = "xai-test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb xAI prompt-cache header smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_xai_prompt_cache_header(output: str):
+    if "mock completion" not in output:
+        raise AssertionError(f"duckdb xAI output missing completion\n{output}")
+    if MockProviderHandler.authorization_headers != ["Bearer xai-test-key"]:
+        raise AssertionError(f"unexpected xAI authorization headers: {MockProviderHandler.authorization_headers}")
+    if len(MockProviderHandler.completion_requests) != 1:
+        raise AssertionError(f"expected one xAI completion request, got {MockProviderHandler.completion_requests}")
+    request = MockProviderHandler.completion_requests[0]
+    if request["model"] != "grok-4.5":
+        raise AssertionError(f"unexpected xAI default model: {request}")
+    if "prompt_cache_key" in request:
+        raise AssertionError(f"xAI prompt cache key should be sent as a header, not request JSON: {request}")
+    if len(MockProviderHandler.xai_conversation_headers) != 1:
+        raise AssertionError(f"missing xAI conversation header: {MockProviderHandler.xai_conversation_headers}")
+    if not MockProviderHandler.xai_conversation_headers[0].startswith("duckdb-ai-"):
+        raise AssertionError(f"unexpected xAI conversation header: {MockProviderHandler.xai_conversation_headers}")
+
+
 def assert_provider_error(output: str):
     required = [
         'AI provider "openai" (openai_chat, model "mock-model") returned HTTP 401',
@@ -1342,6 +1390,9 @@ def main():
         MockProviderHandler.reset()
         openrouter_headers_output = run_duckdb_openrouter_headers(args.duckdb, f"http://127.0.0.1:{port}")
         assert_openrouter_headers(openrouter_headers_output)
+        MockProviderHandler.reset()
+        xai_header_output = run_duckdb_xai_prompt_cache_header(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_xai_prompt_cache_header(xai_header_output)
         MockProviderHandler.reset()
         cache_output = run_duckdb_cache_and_allowlist(args.duckdb, f"http://127.0.0.1:{port}")
         assert_cache_and_allowlist_result(cache_output)

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -47,6 +47,11 @@ SELECT provider, model, operation, printf('%.2f', input_token_price_per_million)
 ----
 mistral	mistral-small-latest	completion	0.15	0.60
 
+query IIIII
+SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'xai' AND model = 'grok-4.5';
+----
+xai	grok-4.5	completion	2.00	6.00
+
 query I
 SELECT contains(source_url, 'openrouter.ai') FROM ai_model_prices() WHERE provider = 'openrouter' AND model = 'openai/gpt-4o-mini';
 ----
@@ -179,6 +184,11 @@ true
 
 query I
 SELECT contains(ai_completion_request_json('hello', provider := 'kimi'), '"model":"kimi-k2.7-code"') AND contains(ai_completion_request_json('hello', provider := 'baidu'), '"model":"ernie-4.5-turbo-128k-preview"') AND contains(ai_completion_request_json('hello', provider := 'hunyuan'), '"model":"hunyuan-turbos-latest"') AND contains(ai_completion_request_json('hello', provider := 'step_fun'), '"model":"step-3.7-flash"') AND contains(ai_completion_request_json('hello', provider := 'minimax'), '"model":"MiniMax-M3"') AND contains(ai_completion_request_json('hello', provider := 'poe'), '"model":"GPT-5.4"') AND contains(ai_completion_request_json('hello', provider := 'ark'), '"model":"doubao-seed-2-1-pro-260628"');
+----
+true
+
+query I
+SELECT contains(ai_completion_request_json('hello', provider := 'x.ai'), '"model":"grok-4.5"');
 ----
 true
 


### PR DESCRIPTION
Refresh the xAI / SpaceXAI provider integration for the current public Grok default, add pricing metadata, and prepare the v0.4.6 patch release. Local validation passed with formatter, release build, SQLLogic, mock provider smoke, docs typecheck/build, community docs preview, and a live Ollama sanity call.

### Codex description

- Update xAI default completion model and docs from `grok-4` to `grok-4.5`
- Add built-in `grok-4.5` pricing metadata and deterministic SQL coverage
- Send `prompt_cache := true` hints to xAI via the documented `x-grok-conv-id` header and cover it in mock-provider smoke
- Bump extension metadata and changelog for v0.4.6 release after merge