### PR TITLE
fix(providers): refresh retired defaults and token limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.7 - 2026-07-10
+
+### Fixed
+
+- Updated Cloudflare Workers AI, Tencent TokenHub / Hunyuan, and Baidu Qianfan
+  defaults to current supported endpoints and models while retaining legacy
+  Hunyuan environment-variable aliases for existing configurations.
+- Sent completion limits through `max_completion_tokens` for OpenAI,
+  Cloudflare Workers AI, and Snowflake Cortex requests, matching their current
+  public APIs while preserving the SQL `max_tokens` option.
+- Removed retired Claude 3.5 Haiku built-in pricing metadata.
+
 ## 0.4.6 - 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ End-to-end setup examples for each provider are in
 | `github` / `github_models` | GitHub Models for prototyping and CI workflows | `https://models.github.ai/inference`; `GITHUB_TOKEN` |
 | `groq` | GroqCloud low-latency hosted open-weight models | `https://api.groq.com/openai/v1`; `GROQ_API_KEY` |
 | `huggingface` / `hf` | Hugging Face Inference Providers router | `https://router.huggingface.co/v1`; `HF_TOKEN` |
-| `hunyuan` / `tencent_hunyuan` | Tencent Hunyuan OpenAI-compatible models | `https://api.hunyuan.cloud.tencent.com/v1`; `HUNYUAN_API_KEY` |
+| `hunyuan` / `tencent_hunyuan` | Tencent TokenHub Hy3 models | `https://tokenhub.tencentmaas.com/v1`; `HUNYUAN_API_KEY` or `TOKENHUB_API_KEY` |
 | `minimax` | MiniMax OpenAI-compatible models | `https://api.minimax.io/v1`; `MINIMAX_API_KEY` |
 | `mistral` | Mistral chat models | `https://api.mistral.ai/v1`; `MISTRAL_API_KEY` |
 | `moonshot` / `kimi` | Moonshot AI / Kimi models | `https://api.moonshot.ai/v1`; `MOONSHOT_API_KEY` or `KIMI_API_KEY` |

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -758,7 +758,7 @@ not from direct API key arguments.
 | `profile`, `secret`, `secret_name` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | DuckDB secret name or profile. |
 | `temperature` | `DOUBLE` | Completion, SQL assistant, aggregate | Sampling temperature between 0 and 2. |
 | `system_prompt` | `VARCHAR` | Completion, SQL assistant, aggregate | Optional system message for providers that support chat-style payloads. |
-| `max_tokens` | `BIGINT` | Completion, SQL assistant, aggregate | Maximum provider output tokens. Must be greater than 0. |
+| `max_tokens` | `BIGINT` | Completion, SQL assistant, aggregate | Maximum provider output tokens. Must be greater than 0. OpenAI, Cloudflare, and Snowflake requests emit the current `max_completion_tokens` API field; other compatible providers retain `max_tokens`. |
 | `base_url` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider or gateway base URL override. |
 | `timeout_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | HTTP timeout. Must be greater than 0. |
 | `connect_timeout_seconds` | `BIGINT` | Completion, embedding, SQL assistant, aggregate | HTTP connection timeout from 1 to 31536000 seconds. It must be less than or equal to the total timeout when a provider call runs. |
@@ -821,7 +821,7 @@ Supported provider names and aliases are:
 | `anthropic` | `claude` | Yes | No | `claude-haiku-4-5` |
 | `bedrock` | `aws_bedrock`, `amazon_bedrock`, `bedrock_mantle` | Yes | No | `amazon.nova-lite-v1:0` |
 | `cerebras` | `cerebras_cloud` | Yes | No | `gpt-oss-120b` |
-| `cloudflare` | `workers_ai`, `cloudflare_workers_ai`, `cloudflare_ai` | Yes | Yes | `@cf/meta/llama-3.1-8b-instruct` |
+| `cloudflare` | `workers_ai`, `cloudflare_workers_ai`, `cloudflare_ai` | Yes | Yes | `@cf/zai-org/glm-4.7-flash` |
 | `cohere` | `cohere_ai` | Yes | Yes | `command-a-03-2025` |
 | `dashscope` | `qwen`, `alibaba`, `alibaba_model_studio`, `model_studio` | Yes | Yes | `qwen-plus` |
 | `databricks` | `mosaic`, `mosaic_ai`, `databricks_ai` | Yes | No | `databricks-llama-4-maverick` |
@@ -832,7 +832,7 @@ Supported provider names and aliases are:
 | `github` | `github_models`, `github-models`, `gh_models` | Yes | Yes | `openai/gpt-4o` |
 | `groq` | `groqcloud`, `groq_cloud` | Yes | No | `openai/gpt-oss-20b` |
 | `huggingface` | `hf`, `hugging_face`, `huggingface_hub` | Yes | No | `openai/gpt-oss-120b` |
-| `hunyuan` | `tencent`, `tencent_hunyuan` | Yes | No | `hunyuan-turbos-latest` |
+| `hunyuan` | `tencent`, `tencent_hunyuan` | Yes | No | `hy3` |
 | `minimax` | `mini_max` | Yes | No | `MiniMax-M3` |
 | `mistral` | none | Yes | Yes | `mistral-small-latest` |
 | `moonshot` | `kimi`, `moonshot_ai`, `kimi_api` | Yes | No | `kimi-k2.7-code` |
@@ -841,7 +841,7 @@ Supported provider names and aliases are:
 | `openrouter` | none | Yes | Yes | `openai/gpt-4o-mini` |
 | `perplexity` | `pplx` | Yes | No | `sonar` |
 | `poe` | `poe_api` | Yes | No | `GPT-5.4` |
-| `qianfan` | `baidu`, `baidu_qianfan`, `ernie`, `wenxin` | Yes | No | `ernie-4.5-turbo-128k-preview` |
+| `qianfan` | `baidu`, `baidu_qianfan`, `ernie`, `wenxin` | Yes | No | `ernie-4.5-turbo-128k` |
 | `sambanova` | `sambanova_ai`, `samba_nova`, `sambacloud` | Yes | No | `Meta-Llama-3.3-70B-Instruct` |
 | `siliconflow` | `silicon_flow` | Yes | No | `Qwen/Qwen2.5-72B-Instruct` |
 | `snowflake` | none | Yes | No | `claude-sonnet-4-5` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -39,7 +39,7 @@ LIMIT 1;
 | `anthropic` / `claude` | Anthropic Messages | `claude-haiku-4-5` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | Defaults to `https://api.anthropic.com/v1`. |
 | `bedrock` | OpenAI-compatible chat | `amazon.nova-lite-v1:0` | `AWS_BEDROCK_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, or `BEDROCK_API_KEY` | Set `AWS_REGION`, `AWS_BEDROCK_REGION`, `AWS_BEDROCK_BASE_URL`, or secret `BASE_URL`. |
 | `cerebras` | OpenAI-compatible chat | `gpt-oss-120b` | `CEREBRAS_API_KEY` | Defaults to `https://api.cerebras.ai/v1`. |
-| `cloudflare` / `workers_ai` | OpenAI-compatible chat and embeddings | `@cf/meta/llama-3.1-8b-instruct`; embeddings use `@cf/baai/bge-base-en-v1.5` | `CLOUDFLARE_API_KEY`, `CLOUDFLARE_API_TOKEN`, or `CLOUDFLARE_AUTH_TOKEN` | Derives the endpoint from `CLOUDFLARE_ACCOUNT_ID`, or accepts `CLOUDFLARE_WORKERS_AI_BASE_URL`, `CLOUDFLARE_AI_BASE_URL`, or secret `BASE_URL`. |
+| `cloudflare` / `workers_ai` | OpenAI-compatible chat and embeddings | `@cf/zai-org/glm-4.7-flash`; embeddings use `@cf/baai/bge-base-en-v1.5` | `CLOUDFLARE_API_KEY`, `CLOUDFLARE_API_TOKEN`, or `CLOUDFLARE_AUTH_TOKEN` | Derives the endpoint from `CLOUDFLARE_ACCOUNT_ID`, or accepts `CLOUDFLARE_WORKERS_AI_BASE_URL`, `CLOUDFLARE_AI_BASE_URL`, or secret `BASE_URL`. |
 | `cohere` | OpenAI-compatible chat and embeddings | `command-a-03-2025`; embeddings use `embed-v4.0` | `COHERE_API_KEY` | Defaults to `https://api.cohere.ai/compatibility/v1`. |
 | `dashscope` / `qwen` | OpenAI-compatible chat and embeddings | `qwen-plus`; embeddings use `text-embedding-v4` | `DASHSCOPE_API_KEY`, `ALIBABA_API_KEY`, or `QWEN_API_KEY` | Defaults to `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; override with a workspace-specific base URL when needed. |
 | `deepinfra` | OpenAI-compatible chat and embeddings | `meta-llama/Meta-Llama-3.1-8B-Instruct`; embeddings use `BAAI/bge-large-en-v1.5` | `DEEPINFRA_API_KEY` | Defaults to `https://api.deepinfra.com/v1/openai`. |
@@ -48,7 +48,7 @@ LIMIT 1;
 | `github` / `github_models` | OpenAI-compatible chat and embeddings | `openai/gpt-4o`; embeddings use `openai/text-embedding-3-small` | `GITHUB_TOKEN`, `GITHUB_MODELS_TOKEN`, or `GITHUB_API_KEY` | Defaults to `https://models.github.ai/inference`. |
 | `groq` | OpenAI-compatible chat | `openai/gpt-oss-20b` | `GROQ_API_KEY` | Defaults to `https://api.groq.com/openai/v1`. |
 | `huggingface` / `hf` | OpenAI-compatible chat | `openai/gpt-oss-120b` | `HF_TOKEN`, `HUGGINGFACE_API_KEY`, or `HUGGING_FACE_HUB_TOKEN` | Defaults to `https://router.huggingface.co/v1`. |
-| `hunyuan` / `tencent_hunyuan` | OpenAI-compatible chat | `hunyuan-turbos-latest` | `HUNYUAN_API_KEY` or `TENCENT_HUNYUAN_API_KEY` | Defaults to `https://api.hunyuan.cloud.tencent.com/v1`. |
+| `hunyuan` / `tencent_hunyuan` | OpenAI-compatible chat through Tencent TokenHub | `hy3` | `HUNYUAN_API_KEY`, `TOKENHUB_API_KEY`, or `TENCENT_TOKENHUB_API_KEY` | Defaults to `https://tokenhub.tencentmaas.com/v1`; `TOKENHUB_BASE_URL` selects another TokenHub region. |
 | `minimax` | OpenAI-compatible chat | `MiniMax-M3` | `MINIMAX_API_KEY` or `MINI_MAX_API_KEY` | Defaults to `https://api.minimax.io/v1`. |
 | `mistral` | OpenAI-compatible chat and embeddings | `mistral-small-latest`; embeddings use `mistral-embed` | `MISTRAL_API_KEY` | Defaults to `https://api.mistral.ai/v1`. |
 | `moonshot` / `kimi` | OpenAI-compatible chat | `kimi-k2.7-code` | `MOONSHOT_API_KEY` or `KIMI_API_KEY` | Defaults to `https://api.moonshot.ai/v1`. |
@@ -61,7 +61,7 @@ LIMIT 1;
 | `snowflake` | OpenAI-compatible chat | `claude-sonnet-4-5` | `SNOWFLAKE_PAT` or `SNOWFLAKE_TOKEN` | Derives `/api/v2/cortex/v1` from Snowflake account URL, host, or account id. |
 | `perplexity` | OpenAI-compatible chat | `sonar` | `PERPLEXITY_API_KEY` | Defaults to `https://api.perplexity.ai`. |
 | `poe` | OpenAI-compatible chat | `GPT-5.4` | `POE_API_KEY` | Defaults to `https://api.poe.com/v1`. |
-| `qianfan` / `ernie` | OpenAI-compatible chat | `ernie-4.5-turbo-128k-preview` | `QIANFAN_API_KEY`, `BAIDU_QIANFAN_API_KEY`, or `BAIDU_API_KEY` | Defaults to `https://qianfan.baidubce.com/v2`. |
+| `qianfan` / `ernie` | OpenAI-compatible chat | `ernie-4.5-turbo-128k` | `QIANFAN_API_KEY`, `BAIDU_QIANFAN_API_KEY`, or `BAIDU_API_KEY` | Defaults to `https://qianfan.baidubce.com/v2`. |
 | `sambanova` | OpenAI-compatible chat | `Meta-Llama-3.3-70B-Instruct` | `SAMBANOVA_API_KEY` | Defaults to `https://api.sambanova.ai/v1`. |
 | `siliconflow` | OpenAI-compatible chat | `Qwen/Qwen2.5-72B-Instruct` | `SILICONFLOW_API_KEY` | Defaults to `https://api.siliconflow.com/v1`. |
 | `together` | OpenAI-compatible chat and embeddings | `meta-llama/Llama-3.3-70B-Instruct-Turbo`; embeddings use `BAAI/bge-base-en-v1.5` | `TOGETHER_API_KEY` | Defaults to `https://api.together.xyz/v1`. |
@@ -555,7 +555,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET cloudflare_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'workers_ai',
-    MODEL '@cf/meta/llama-3.1-8b-instruct'
+    MODEL '@cf/zai-org/glm-4.7-flash'
 );
 
 SELECT ai_complete(
@@ -753,7 +753,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET qianfan_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'ernie',
-    MODEL 'ernie-4.5-turbo-128k-preview'
+    MODEL 'ernie-4.5-turbo-128k'
 );
 
 SELECT ai_complete(
@@ -765,10 +765,10 @@ SELECT ai_complete(
 Aliases `qianfan`, `baidu`, `baidu_qianfan`, `ernie`, and `wenxin` resolve to
 the same provider. Embeddings are not configured for this provider.
 
-## Tencent Hunyuan
+## Tencent TokenHub / Hunyuan
 
 ```sh
-export HUNYUAN_API_KEY='...'
+export TOKENHUB_API_KEY='...'
 ./build/release/duckdb
 ```
 
@@ -778,7 +778,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET hunyuan_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'tencent_hunyuan',
-    MODEL 'hunyuan-turbos-latest'
+    MODEL 'hy3'
 );
 
 SELECT ai_complete(
@@ -788,7 +788,10 @@ SELECT ai_complete(
 ```
 
 Aliases `hunyuan`, `tencent`, and `tencent_hunyuan` resolve to the same
-provider. Embeddings are not configured for this provider.
+provider. `HUNYUAN_API_KEY` and `TENCENT_HUNYUAN_API_KEY` remain accepted for
+existing configurations. Set `TOKENHUB_BASE_URL` for the international or a
+custom regional TokenHub endpoint. Embeddings are not configured for this
+provider.
 
 ## StepFun
 

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.6
+    EXTENSION_VERSION 0.4.7
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -811,8 +811,6 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	     "2026-06-30"},
 	    {"anthropic", "claude-haiku-4-5", "completion", 1.00, 5.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-06-30"},
-	    {"anthropic", "claude-3-5-haiku-latest", "completion", 0.80, 4.00,
-	     "https://platform.claude.com/docs/en/about-claude/pricing", "legacy Haiku 3.5 pricing", "2026-06-30"},
 	    {"anthropic", "claude-sonnet-4-5", "completion", 3.00, 15.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-06-30"},
 	    {"gemini", "gemini-3.5-flash", "completion", 1.50, 9.00, "https://ai.google.dev/gemini-api/docs/pricing",
@@ -2661,7 +2659,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	     true},
 	    {"bedrock", "openai_chat", "amazon.nova-lite-v1:0", "", "", "AWS_BEDROCK_API_KEY", true},
 	    {"cerebras", "openai_chat", "gpt-oss-120b", "", "https://api.cerebras.ai/v1", "CEREBRAS_API_KEY", true},
-	    {"cloudflare", "openai_chat", "@cf/meta/llama-3.1-8b-instruct", "@cf/baai/bge-base-en-v1.5", "",
+	    {"cloudflare", "openai_chat", "@cf/zai-org/glm-4.7-flash", "@cf/baai/bge-base-en-v1.5", "",
 	     "CLOUDFLARE_API_KEY", true},
 	    {"cohere", "openai_chat", "command-a-03-2025", "embed-v4.0", "https://api.cohere.ai/compatibility/v1",
 	     "COHERE_API_KEY", true},
@@ -2679,8 +2677,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	     "https://models.github.ai/inference", "GITHUB_TOKEN", true},
 	    {"groq", "openai_chat", "openai/gpt-oss-20b", "", "https://api.groq.com/openai/v1", "GROQ_API_KEY", true},
 	    {"huggingface", "openai_chat", "openai/gpt-oss-120b", "", "https://router.huggingface.co/v1", "HF_TOKEN", true},
-	    {"hunyuan", "openai_chat", "hunyuan-turbos-latest", "", "https://api.hunyuan.cloud.tencent.com/v1",
-	     "HUNYUAN_API_KEY", true},
+	    {"hunyuan", "openai_chat", "hy3", "", "https://tokenhub.tencentmaas.com/v1", "HUNYUAN_API_KEY", true},
 	    {"llamacpp", "openai_chat", "default", "default", "http://localhost:8080/v1", "LLAMACPP_API_KEY", false},
 	    {"minimax", "openai_chat", "MiniMax-M3", "", "https://api.minimax.io/v1", "MINIMAX_API_KEY", true},
 	    {"mistral", "openai_chat", "mistral-small-latest", "mistral-embed", "https://api.mistral.ai/v1",
@@ -2698,8 +2695,8 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	     "https://openrouter.ai/api/v1", "OPENROUTER_API_KEY", true},
 	    {"perplexity", "openai_chat", "sonar", "", "https://api.perplexity.ai", "PERPLEXITY_API_KEY", true},
 	    {"poe", "openai_chat", "GPT-5.4", "", "https://api.poe.com/v1", "POE_API_KEY", true},
-	    {"qianfan", "openai_chat", "ernie-4.5-turbo-128k-preview", "", "https://qianfan.baidubce.com/v2",
-	     "QIANFAN_API_KEY", true},
+	    {"qianfan", "openai_chat", "ernie-4.5-turbo-128k", "", "https://qianfan.baidubce.com/v2", "QIANFAN_API_KEY",
+	     true},
 	    {"sambanova", "openai_chat", "Meta-Llama-3.3-70B-Instruct", "", "https://api.sambanova.ai/v1",
 	     "SAMBANOVA_API_KEY", true},
 	    {"siliconflow", "openai_chat", "Qwen/Qwen2.5-72B-Instruct", "", "https://api.siliconflow.com/v1",
@@ -2801,6 +2798,14 @@ std::string ResolveBaseUrl(const ProviderConfig &config) {
 		}
 	}
 	if (config.provider == "hunyuan") {
+		auto tencent_tokenhub_base_url = GetEnv("TENCENT_TOKENHUB_BASE_URL");
+		if (!tencent_tokenhub_base_url.empty()) {
+			return NormalizeBaseUrlForProvider(config.provider, tencent_tokenhub_base_url);
+		}
+		auto tokenhub_base_url = GetEnv("TOKENHUB_BASE_URL");
+		if (!tokenhub_base_url.empty()) {
+			return NormalizeBaseUrlForProvider(config.provider, tokenhub_base_url);
+		}
 		auto tencent_hunyuan_base_url = GetEnv("TENCENT_HUNYUAN_BASE_URL");
 		if (!tencent_hunyuan_base_url.empty()) {
 			return NormalizeBaseUrlForProvider(config.provider, tencent_hunyuan_base_url);
@@ -2992,6 +2997,14 @@ std::string ResolveApiKey(const ProviderConfig &config) {
 		}
 	}
 	if (config.provider == "hunyuan") {
+		auto tencent_tokenhub_api_key = GetEnv("TENCENT_TOKENHUB_API_KEY");
+		if (!tencent_tokenhub_api_key.empty()) {
+			return tencent_tokenhub_api_key;
+		}
+		auto tokenhub_api_key = GetEnv("TOKENHUB_API_KEY");
+		if (!tokenhub_api_key.empty()) {
+			return tokenhub_api_key;
+		}
 		auto tencent_hunyuan_api_key = GetEnv("TENCENT_HUNYUAN_API_KEY");
 		if (!tencent_hunyuan_api_key.empty()) {
 			return tencent_hunyuan_api_key;
@@ -3164,6 +3177,10 @@ std::string ResolveModel(const ProviderConfig &config, const std::string &model_
 		}
 	}
 	if (config.provider == "hunyuan") {
+		auto tokenhub_model = GetEnv("TOKENHUB_MODEL");
+		if (!tokenhub_model.empty()) {
+			return tokenhub_model;
+		}
 		auto tencent_hunyuan_model = GetEnv("TENCENT_HUNYUAN_MODEL");
 		if (!tencent_hunyuan_model.empty()) {
 			return tencent_hunyuan_model;
@@ -3470,7 +3487,11 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 	               "\",\"messages\":" + ChatMessagesJson(prompt, options.system_prompt) +
 	               ",\"temperature\":" + JsonDouble(temperature);
 	if (options.has_max_tokens) {
-		payload += ",\"max_tokens\":" + std::to_string(options.max_tokens);
+		if (config.provider == "openai" || config.provider == "cloudflare" || config.provider == "snowflake") {
+			payload += ",\"max_completion_tokens\":" + std::to_string(options.max_tokens);
+		} else {
+			payload += ",\"max_tokens\":" + std::to_string(options.max_tokens);
+		}
 	}
 	auto response_format = OpenAIResponseFormatJson(options);
 	if (!response_format.empty()) {

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -370,7 +370,8 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             'hello snowflake',
             secret := 'smoke_snowflake_ai',
             provider := 'snowflake',
-            model := 'claude-sonnet-4-5'
+            model := 'claude-sonnet-4-5',
+            max_tokens := 19
         ) AS snowflake_completion;
         SELECT result.response, result.error IS NULL
         FROM (SELECT ai_try_complete('try complete smoke', max_tokens := 5) AS result);
@@ -891,7 +892,7 @@ def assert_provider_metadata(output: str):
         "https://aiplatform.googleapis.com/v1/projects/duckdb-ai-test/locations/us-central1/endpoints/openapi",
         "https://api.moonshot.ai/v1",
         "https://qianfan.baidubce.com/v2",
-        "https://api.hunyuan.cloud.tencent.com/v1",
+        "https://tokenhub.tencentmaas.com/v1",
         "https://api.stepfun.ai/v1",
         "https://ai-gateway.vercel.sh/v1",
         "https://ark.cn-beijing.volces.com/api/v3",
@@ -999,8 +1000,8 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"unexpected completion prompt: {completion_request}")
     if completion_request.get("temperature") != 0.2:
         raise AssertionError(f"unexpected completion temperature: {completion_request}")
-    if completion_request.get("max_tokens") != 17:
-        raise AssertionError(f"unexpected completion max_tokens: {completion_request}")
+    if completion_request.get("max_completion_tokens") != 17 or "max_tokens" in completion_request:
+        raise AssertionError(f"unexpected completion token limit: {completion_request}")
 
     structured_request = MockProviderHandler.completion_requests[1]
     response_format = structured_request.get("response_format")
@@ -1142,13 +1143,15 @@ def assert_smoke_result(output: str):
     snowflake_request = MockProviderHandler.completion_requests[30]
     if snowflake_request.get("model") != "claude-sonnet-4-5":
         raise AssertionError(f"unexpected Snowflake model: {snowflake_request}")
+    if snowflake_request.get("max_completion_tokens") != 19 or "max_tokens" in snowflake_request:
+        raise AssertionError(f"unexpected Snowflake token limit: {snowflake_request}")
     if snowflake_request["messages"][-1]["content"] != "hello snowflake":
         raise AssertionError(f"unexpected Snowflake prompt: {snowflake_request}")
     try_complete_request = MockProviderHandler.completion_requests[31]
     if try_complete_request["messages"][-1]["content"] != "try complete smoke":
         raise AssertionError(f"unexpected try completion prompt: {try_complete_request}")
-    if try_complete_request.get("max_tokens") != 5:
-        raise AssertionError(f"unexpected try completion max tokens: {try_complete_request}")
+    if try_complete_request.get("max_completion_tokens") != 5 or "max_tokens" in try_complete_request:
+        raise AssertionError(f"unexpected try completion token limit: {try_complete_request}")
     extract_record_request = MockProviderHandler.completion_requests[32]
     if extract_record_request["messages"][-1]["content"] != "return scalar record JSON object":
         raise AssertionError(f"unexpected extract record prompt: {extract_record_request}")

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -155,7 +155,7 @@ openai_chat@|openai_chat@https://api.siliconflow.com/v1|openai_chat@https://ai-g
 query I
 SELECT ai_provider_protocol('kimi') || '@' || ai_provider_base_url('kimi') || '|' || ai_provider_protocol('ernie') || '@' || ai_provider_base_url('ernie') || '|' || ai_provider_protocol('tencent_hunyuan') || '@' || ai_provider_base_url('tencent_hunyuan');
 ----
-openai_chat@https://api.moonshot.ai/v1|openai_chat@https://qianfan.baidubce.com/v2|openai_chat@https://api.hunyuan.cloud.tencent.com/v1
+openai_chat@https://api.moonshot.ai/v1|openai_chat@https://qianfan.baidubce.com/v2|openai_chat@https://tokenhub.tencentmaas.com/v1
 
 query I
 SELECT ai_provider_protocol('step') || '@' || ai_provider_base_url('step') || '|' || ai_provider_protocol('mini_max') || '@' || ai_provider_base_url('mini_max') || '|' || ai_provider_protocol('poe') || '@' || ai_provider_base_url('poe') || '|' || ai_provider_protocol('doubao') || '@' || ai_provider_base_url('doubao');
@@ -178,12 +178,12 @@ SELECT contains(ai_completion_request_json('hello', provider := 'groq'), '"model
 true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'workers_ai'), '"model":"@cf/meta/llama-3.1-8b-instruct"') AND contains(ai_completion_request_json('hello', provider := 'qwen'), '"model":"qwen-plus"') AND contains(ai_completion_request_json('hello', provider := 'nebius'), '"model":"meta-llama/Meta-Llama-3.1-70B-Instruct"') AND contains(ai_completion_request_json('hello', provider := 'sambanova'), '"model":"Meta-Llama-3.3-70B-Instruct"') AND contains(ai_completion_request_json('hello', provider := 'siliconflow'), '"model":"Qwen/Qwen2.5-72B-Instruct"') AND contains(ai_completion_request_json('hello', provider := 'vercel'), '"model":"openai/gpt-4o-mini"');
+SELECT contains(ai_completion_request_json('hello', provider := 'workers_ai'), '"model":"@cf/zai-org/glm-4.7-flash"') AND contains(ai_completion_request_json('hello', provider := 'qwen'), '"model":"qwen-plus"') AND contains(ai_completion_request_json('hello', provider := 'nebius'), '"model":"meta-llama/Meta-Llama-3.1-70B-Instruct"') AND contains(ai_completion_request_json('hello', provider := 'sambanova'), '"model":"Meta-Llama-3.3-70B-Instruct"') AND contains(ai_completion_request_json('hello', provider := 'siliconflow'), '"model":"Qwen/Qwen2.5-72B-Instruct"') AND contains(ai_completion_request_json('hello', provider := 'vercel'), '"model":"openai/gpt-4o-mini"');
 ----
 true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'kimi'), '"model":"kimi-k2.7-code"') AND contains(ai_completion_request_json('hello', provider := 'baidu'), '"model":"ernie-4.5-turbo-128k-preview"') AND contains(ai_completion_request_json('hello', provider := 'hunyuan'), '"model":"hunyuan-turbos-latest"') AND contains(ai_completion_request_json('hello', provider := 'step_fun'), '"model":"step-3.7-flash"') AND contains(ai_completion_request_json('hello', provider := 'minimax'), '"model":"MiniMax-M3"') AND contains(ai_completion_request_json('hello', provider := 'poe'), '"model":"GPT-5.4"') AND contains(ai_completion_request_json('hello', provider := 'ark'), '"model":"doubao-seed-2-1-pro-260628"');
+SELECT contains(ai_completion_request_json('hello', provider := 'kimi'), '"model":"kimi-k2.7-code"') AND contains(ai_completion_request_json('hello', provider := 'baidu'), '"model":"ernie-4.5-turbo-128k"') AND contains(ai_completion_request_json('hello', provider := 'hunyuan'), '"model":"hy3"') AND contains(ai_completion_request_json('hello', provider := 'step_fun'), '"model":"step-3.7-flash"') AND contains(ai_completion_request_json('hello', provider := 'minimax'), '"model":"MiniMax-M3"') AND contains(ai_completion_request_json('hello', provider := 'poe'), '"model":"GPT-5.4"') AND contains(ai_completion_request_json('hello', provider := 'ark'), '"model":"doubao-seed-2-1-pro-260628"');
 ----
 true
 
@@ -343,9 +343,14 @@ SELECT contains(ai_completion_request_json('hello', provider := 'anthropic', sys
 true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'openai', temperature := 0.7, max_tokens := 42), '"temperature":0.7,"max_tokens":42');
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', temperature := 0.7, max_tokens := 42), '"temperature":0.7,"max_completion_tokens":42') AND NOT contains(ai_completion_request_json('hello', provider := 'openai', max_tokens := 42), '"max_tokens"');
 ----
 true
+
+query II
+SELECT contains(ai_completion_request_json('hello', provider := 'workers_ai', max_tokens := 42), '"max_completion_tokens":42'), contains(ai_completion_request_json('hello', provider := 'snowflake', max_tokens := 42), '"max_completion_tokens":42');
+----
+true	true
 
 query I
 SELECT contains(ai_completion_request_json('hello', provider := 'openai', model := 'gpt-test', use_builtin_model_prices := true), '"model":"gpt-test"');


### PR DESCRIPTION
Refresh provider defaults and request fields that drifted from current public APIs, preventing calls from targeting retired models or legacy token-limit parameters.\n\n### Codex description\n\n- move Cloudflare Workers AI, Tencent TokenHub / Hunyuan, and Baidu Qianfan defaults to current supported public endpoints and models while preserving legacy Hunyuan environment aliases\n- emit max_completion_tokens for OpenAI, Cloudflare, and Snowflake while preserving the public SQL max_tokens option, and remove retired Claude 3.5 Haiku pricing metadata\n- update focused SQLLogic, mock-provider, and provider documentation coverage\n- validate formatting, release build, 250 SQL assertions, mock-provider smoke, docs typecheck/build, community docs snapshot, and a live local Ollama/Gemma completion\n- bump the extension to 0.4.7; the release will be tagged after merge and its distribution workflow verified