### PR TITLE
feat: expand ai sql execution and rag workflows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ endif()
 
 target_link_libraries(${EXTENSION_NAME} duckdb_yyjson)
 target_link_libraries(${LOADABLE_EXTENSION_NAME} duckdb_yyjson)
+target_link_libraries(${EXTENSION_NAME} duckdb_re2)
+target_link_libraries(${LOADABLE_EXTENSION_NAME} duckdb_re2)
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,8 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+# The generic `test/*` filter also selects DuckDB's built-in tests because the
+# unittest runner reports those with the same prefix. Keep this extension's test
+# target scoped to its SQLLogic suite.
+TESTS_BASE_DIRECTORY = "test/sql/"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ One extension covers both ends of the spectrum:
 - Generate valid JSON, typed DuckDB columns, or per-row `STRUCT` values from
   model output, validated against a JSON Schema.
 - Create embeddings (batched automatically per chunk), compare text with cosine
-  similarity, and rerank candidates.
+  similarity with distinct-value deduplication, and rerank candidates.
+- Prepare RAG data with deterministic Unicode-aware chunks, Markdown heading
+  context, page metadata, and optional model enrichment.
+- Register safe external-model profiles that reference credential secrets, with
+  optional guarded endpoint provisioning through a separate control plane.
+- Build an experimental relation-level classifier that uses local embedding
+  centroids and falls back to an LLM only for uncertain rows.
 - Ask questions about local tables and generate read-only DuckDB `SELECT`
   statements — generated SQL is parser-validated before it runs.
 - Route model calls across local Ollama, hosted providers, and
@@ -216,6 +222,33 @@ FROM support_tickets AS left_ticket
 JOIN support_tickets AS right_ticket
     ON left_ticket.ticket_id < right_ticket.ticket_id
 ORDER BY similarity DESC;
+```
+
+Prepare Markdown for retrieval and embedding:
+
+```sql
+SELECT chunk_id, chunk_to_retrieve, chunk_to_embed, heading, page
+FROM ai_prep_search(
+    '# Billing' || chr(10) || 'The invoice was charged twice.',
+    source_id := 'ticket-42',
+    title := 'Duplicate charge',
+    chunk_size := 1000,
+    overlap_percent := 10
+);
+```
+
+Register a reusable model profile without putting credentials in the model
+object:
+
+```sql
+CREATE EXTERNAL MODEL support_model WITH (
+    provider = 'openai',
+    model = 'gpt-4o-mini',
+    credential = 'openai_ai',
+    capabilities = 'completion,json_schema'
+);
+
+SELECT ai_complete('Summarize this ticket.', profile := 'support_model');
 ```
 
 Create typed columns from one prompt:

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -30,6 +30,7 @@ FROM ai_usage();
 | `ai_embedding_request_json(text[, model[, provider]])` | Scalar | Returns the embedding request JSON without making a network call. |
 | `ai_similarity(left_text, right_text[, model[, provider]])` | Scalar | Embeds two strings and returns cosine similarity. |
 | `ai_rerank(query, candidate[, model[, provider]])` | Scalar | Uses a completion model to score candidate relevance from `0` to `1`. |
+| `ai_score(input, criteria[, model[, provider]])` | Scalar | Scores how well input satisfies criteria from `0` to `1`. |
 | `ai_summarize(text[, model[, provider]])` | Scalar | Summarizes text with a completion model. |
 | `ai_sentiment(text[, model[, provider]])` | Scalar | Classifies text as positive, neutral, or negative. |
 | `ai_fix_grammar(text[, model[, provider]])` | Scalar | Rewrites text with corrected grammar, spelling, and punctuation. |
@@ -37,10 +38,16 @@ FROM ai_usage();
 | `ai_translate(text, target_language[, model[, provider]])` | Scalar | Translates text to the target language. |
 | `ai_classify(text, labels[, model[, provider]])` | Scalar | Chooses one label from a comma-separated `VARCHAR` or `VARCHAR[]` label list. |
 | `ai_classify_labels(text, labels[, model[, provider]])` | Scalar | Chooses zero or more labels from a comma-separated `VARCHAR` or `VARCHAR[]` label list. |
+| `ai_classify_result(text, labels[, ...])` | Scalar | Returns multi-label classification as `STRUCT(value, error, metadata)`. |
+| `ai_classify_optimized(text, artifact[, ...])` | Scalar | Uses a local centroid classifier and falls back to an LLM below the configured confidence margin. |
 | `ai_extract(text, instruction[, model[, provider]])` | Scalar | Extracts requested information from text. |
 | `ai_filter(text, predicate[, model[, provider]])` | Scalar | Evaluates a natural-language predicate and returns `BOOLEAN`. |
 | `ai_agg(text, instruction[, model[, provider]])` | Aggregate | Runs one completion over grouped text values and an instruction. |
 | `ai_summarize_agg(text[, model[, provider]])` | Aggregate | Summarizes grouped text values. |
+| `ai_build_classifier(text, labels[, ...])` | Aggregate | Builds an experimental persisted classifier artifact for cost-optimized single-label classification. |
+| `ai_generate_chunks(text[, ...])` | Table | Splits text into deterministic Unicode-aware fixed or recursive chunks. |
+| `ai_prep_search(text[, ...])` | Table | Produces retrieval and context-enriched embedding chunks for RAG. |
+| `ai_parse_document(content, mime_type, parser_profile[, ...])` | Table | Calls a normalized remote document parser without bundling PDF/OCR dependencies. |
 | `ai_sql(question[, schema_context[, model[, provider]]])` | Scalar | Generates one read-only DuckDB `SELECT` statement. |
 | `ai_query_data(question[, schema_context[, model[, provider]]])` | Table | Generates one read-only `SELECT` at bind time and executes it as a subquery. |
 | `ai_schema_prompt([include_tables])` | Table | Returns deterministic local catalog context for prompting SQL models. |
@@ -53,9 +60,14 @@ FROM ai_usage();
 | `ai_provider_base_url(provider)` | Scalar | Returns the default base URL for a supported provider. |
 | `ai_provider_protocol(provider)` | Scalar | Returns the internal provider protocol. |
 | `ai_usage()` | Table | Returns recent per-database AI usage events. |
+| `ai_usage_summary()` | Table | Returns query-level calls, batches, retries, cache hits, cost, and dropped-event counters. |
 | `ai_clear_usage()` | Table | Clears the per-database usage event buffer. |
 | `ai_clear_cache()` | Table | Clears per-database in-memory response and generated-SQL caches. |
 | `ai_secrets()` | Table | Lists configured `duckdb_ai` secrets with credentials redacted. |
+| `ai_models()` | Table | Lists safe external-model metadata and validation status. |
+| `ai_provision_endpoint(profile[, ...])` | Table | Dry-runs or explicitly submits guarded asynchronous endpoint provisioning. |
+| `ai_endpoint_status(operation_id)` | Table | Returns the current normalized endpoint operation status. |
+| `ai_deprovision_endpoint(profile)` | Table | Explicitly submits asynchronous endpoint deprovisioning. |
 | `ai_model_prices()` | Table | Returns the built-in provider/model pricing catalog. |
 
 ## Completion functions
@@ -260,6 +272,24 @@ LIMIT 10;
 
 Result: `DOUBLE`
 
+#### `ai_score(input, criteria[, model[, provider]])`
+
+Description: Uses a completion model with a strict JSON Schema containing one
+numeric `score` to evaluate how well `input` satisfies `criteria`. Values
+outside the inclusive `[0, 1]` range and malformed responses are rejected.
+
+Example:
+
+```sql
+SELECT ai_score(
+    ticket_body,
+    'contains a reproducible production-impacting database issue'
+) AS escalation_score
+FROM support_tickets;
+```
+
+Result: `DOUBLE`
+
 ## Task wrappers
 
 #### `ai_summarize(text[, model[, provider]])`
@@ -336,7 +366,9 @@ Result: `VARCHAR`
 
 Description: Classifies text into exactly one label from `labels`. `labels` can
 be a comma-separated `VARCHAR` or a `VARCHAR[]`; use `VARCHAR[]` when labels may
-contain commas.
+contain commas. Use constant `label_descriptions :=`, `instructions :=`, and
+`examples :=` strings to add label semantics, global rules, and few-shot
+examples without changing the return type.
 
 Example:
 
@@ -344,6 +376,14 @@ Example:
 SELECT ai_classify('invoice overdue', 'billing, support');
 
 SELECT ai_classify('invoice overdue', ['billing, overdue', 'support']);
+
+SELECT ai_classify(
+    'invoice overdue',
+    ['billing', 'support'],
+    label_descriptions := '{"billing":"payments, invoices, or charges","support":"product help"}',
+    instructions := 'Prefer billing when an invoice is explicitly mentioned.',
+    examples := '[{"input":"card charged twice","label":"billing"}]'
+);
 ```
 
 Result: `VARCHAR`
@@ -364,6 +404,54 @@ SELECT ai_classify_labels(
 ```
 
 Result: `VARCHAR[]`
+
+#### `ai_classify_result(text, labels[, model[, provider]])`
+
+Description: Multi-label classification with pipeline-safe diagnostics. It
+always captures provider and parsing failures instead of failing the full
+vector, and returns metadata describing the selected provider and model.
+
+Example:
+
+```sql
+WITH classified AS (
+    SELECT id, ai_classify_result(body, ['billing', 'performance', 'support']) AS result
+    FROM support_tickets
+)
+SELECT id, result.value, result.metadata
+FROM classified
+WHERE result.error IS NULL;
+```
+
+Result: `STRUCT(value VARCHAR[], error VARCHAR, metadata VARCHAR)`
+
+#### `ai_classify_optimized(text, artifact[, ...])`
+
+Description: Experimental single-label classification. The function embeds
+`text`, compares it with the centroids in an `ai_build_classifier()` artifact,
+and returns locally when the best/second-best cosine margin meets the artifact
+threshold. It calls the fallback completion profile only when the artifact is
+unusable, embedding fails, or the margin is too small. Embeddings are packed and
+deduplicated by model options across each DuckDB vector chunk.
+
+Example:
+
+```sql
+SELECT
+    ticket_id,
+    result.value,
+    result.used_fallback,
+    result.metadata
+FROM (
+    SELECT
+        ticket_id,
+        ai_classify_optimized(body, artifact, fallback_profile := 'support_model') AS result
+    FROM support_tickets
+    CROSS JOIN classifier_artifacts
+);
+```
+
+Result: `STRUCT(value VARCHAR, used_fallback BOOLEAN, confidence DOUBLE, error VARCHAR, metadata VARCHAR)`
 
 #### `ai_extract(text, instruction[, model[, provider]])`
 
@@ -395,8 +483,11 @@ Result: `BOOLEAN`
 
 #### `ai_agg(text, instruction[, model[, provider]])`
 
-Description: Collects grouped input text up to `max_context_chars`, then calls
-one completion model with `instruction`.
+Description: Collects all grouped input text. When the input exceeds
+`max_context_chars`, the default `overflow_policy := 'hierarchical'` recursively
+maps chunks to compact evidence and reduces those partials until a final prompt
+fits. No input is silently discarded. Use `overflow_policy := 'error'` when the
+query must fail instead of issuing a request tree.
 
 Example:
 
@@ -410,7 +501,8 @@ Result: `VARCHAR`
 #### `ai_summarize_agg(text[, model[, provider]])`
 
 Description: Convenience wrapper around `ai_agg` with the built-in summarization
-instruction. It collects grouped input text and returns one summary per group.
+instruction. It uses the same hierarchical overflow behavior and returns one
+summary per group.
 
 Example:
 
@@ -421,6 +513,119 @@ GROUP BY customer_id;
 ```
 
 Result: `VARCHAR`
+
+#### `ai_build_classifier(text, labels[, ...])`
+
+Description: Experimental relation-level `MINIMIZE_COST` workflow. The
+aggregate samples up to `sample_size` rows, labels them with the configured task
+model, embeds the successful samples in packed requests, builds one centroid per
+label, and validates on a deterministic held-out subset. The returned versioned
+artifact includes quality, fallback margin, embedding profile, labels, and
+centroids. Version 1 supports single-label classification only.
+
+Example:
+
+```sql
+CREATE TABLE classifier_artifacts AS
+SELECT ai_build_classifier(
+    body,
+    ['billing', 'performance', 'support'],
+    optimization := 'minimize_cost',
+    sample_size := 256,
+    quality_threshold := 0.85,
+    confidence_margin := 0.08,
+    embedding_profile := 'support_embeddings',
+    profile := 'support_model'
+) AS artifact
+FROM support_tickets;
+```
+
+Result: `VARCHAR` containing a versioned JSON classifier artifact, or `NULL`
+when `fail_on_error := false` and training cannot produce a usable artifact.
+
+## RAG and document functions
+
+#### `ai_generate_chunks(input[, ...])`
+
+Description: Local deterministic chunking. `fixed` splits at exact Unicode code
+point counts. `recursive` prefers paragraph, sentence, line, then word
+boundaries. `overlap_percent` is limited to `0` through `50`; offsets are
+zero-based Unicode code points and `end_offset` is exclusive. IDs are stable for
+the same source text, source ID, strategy, size, overlap, and chunk index. Empty
+and `NULL` input return zero rows.
+
+Example:
+
+```sql
+SELECT *
+FROM ai_generate_chunks(
+    '# Introduction' || chr(10) || chr(10) ||
+        'DuckDB is an in-process analytical database.',
+    source_id := 'document-42',
+    chunk_size := 1000,
+    overlap_percent := 10,
+    strategy := 'recursive'
+);
+```
+
+Result columns: `source_id`, `chunk_id`, `chunk_index`, `start_offset`,
+`end_offset`, `chunk_length`, `estimated_tokens`, `chunk`.
+
+#### `ai_prep_search(input[, ...])`
+
+Description: Builds retrieval-ready rows from text or Markdown. It keeps the
+original chunk in `chunk_to_retrieve`, adds title and the active Markdown
+heading to `chunk_to_embed`, preserves page numbers separated by form-feed page
+breaks, and carries JSON metadata. Line-aware recursive boundaries keep
+Markdown table rows intact when a row fits the configured chunk size.
+
+`enrich := false` is fully local and deterministic. `enrich := true` makes one
+model call for concise document-level context and captures a row-level error
+when `fail_on_error := false`.
+
+Example:
+
+```sql
+SELECT *
+FROM ai_prep_search(
+    '# Billing' || chr(10) || chr(10) ||
+        'The invoice was charged twice.',
+    source_id := 'ticket-42',
+    title := 'Duplicate charge',
+    metadata := json_object('uri', '/tickets/42'),
+    chunk_size := 1000,
+    overlap_percent := 10,
+    enrich := false
+);
+```
+
+Result columns: `source_id`, `chunk_id`, `chunk_index`, `chunk_to_retrieve`,
+`chunk_to_embed`, `heading`, `page`, `start_offset`, `end_offset`, `metadata`,
+`error`.
+
+#### `ai_parse_document(content, mime_type, parser_profile[, ...])`
+
+Description: Sends binary content to the optional companion control plane's
+normalized document parser. The core extension performs base64 transport and
+schema normalization only; it does not bundle PDF, Office, OCR, or vendor SDK
+dependencies. For local extraction, use DuckDB's community `pdf` extension and
+pass its Markdown or text output to `ai_prep_search()`.
+
+Example:
+
+```sql
+SELECT *
+FROM ai_parse_document(
+    read_blob('contract.pdf').content,
+    'application/pdf',
+    'document-ai',
+    pages := '1-10',
+    fail_on_error := false
+);
+```
+
+Result columns: `document_id`, `page`, `element_index`, `element_type`, `text`,
+`markdown`, `bbox`, `confidence`, `metadata`, `error`.
 
 ## SQL assistant functions
 
@@ -681,9 +886,32 @@ ORDER BY event_id DESC;
 ```
 
 Result columns: `event_id`, `created_at`, `event`, `function_name`, `query_id`,
-`provider`, `protocol`, `model`, character counts, token counts,
+`operation_id`, `parent_operation_id`, `provider`, `protocol`, `model`, character counts, token counts,
 cached-token counts, elapsed time, retry count, HTTP status, cache hit flag,
 status, error, and estimated cost.
+
+#### `ai_usage_summary()`
+
+Description: Groups the retained usage buffer by `query_id`. `calls` counts
+per-input events, while `batch_count` counts distinct provider request operation
+IDs, so packed embedding execution is visible without losing row-level token and
+error details. The result also includes retries, cache hits, total tokens,
+elapsed time, estimated cost, retained events, and counters for usage or log
+events dropped from bounded buffers.
+
+Example:
+
+```sql
+SELECT query_id, provider, calls, batch_count, retries, cache_hits,
+       estimated_cost_usd, dropped_events
+FROM ai_usage_summary()
+ORDER BY estimated_cost_usd DESC;
+```
+
+Result columns: `query_id`, `provider`, `model`, `calls`, `batch_count`,
+`retries`, `failures`, `cache_hits`, `total_tokens`, `elapsed_ms`,
+`estimated_cost_usd`, `retained_events`, `dropped_events`, `queued_log_events`,
+`dropped_log_events`.
 
 #### `ai_clear_usage()`
 
@@ -702,8 +930,8 @@ Result: one `cleared BOOLEAN` column
 #### `ai_clear_cache()`
 
 Description: Clears the current DuckDB database instance's opt-in in-memory
-response cache and `ai_query_data()` generated-SQL cache, then returns one
-confirmation row.
+response cache, `ai_query_data()` generated-SQL cache, and bounded query-local
+`ai_similarity()` embedding cache, then returns one confirmation row.
 
 Example:
 
@@ -726,8 +954,82 @@ SELECT name, provider, model, base_url, has_api_key
 FROM ai_secrets();
 ```
 
-Result columns: `name`, `provider`, `model`, `base_url`, `scope`,
-`has_api_key`
+Result columns: `name`, `provider`, `model`, `base_url`, `scope`, `storage`,
+`persistent`, `has_api_key`
+
+#### `CREATE EXTERNAL MODEL` and `ai_models()`
+
+Description: `CREATE EXTERNAL MODEL` registers a non-secret model profile in
+DuckDB's local secret catalog. The object stores provider routing, a reference
+to a `TYPE duckdb_ai` credential secret, capabilities, and safe JSON options; it
+never stores API keys. Existing `profile :=` resolution checks external models
+first and then falls back to a credential-secret profile with that name.
+
+Example:
+
+```sql
+CREATE OR REPLACE SECRET azure_ai (
+    TYPE duckdb_ai,
+    AI_PROVIDER 'azure',
+    API_KEY '...'
+);
+
+CREATE OR REPLACE EXTERNAL MODEL support_model
+WITH (
+    provider = 'azure',
+    model = 'gpt-4o',
+    location = 'https://my-resource.openai.azure.com/openai/v1',
+    credential = 'azure_ai',
+    model_type = 'completion',
+    capabilities = 'completion,json_schema',
+    options = '{"max_input_tokens":128000,"max_batch_inputs":512,"input_token_price_per_million":2.5,"output_token_price_per_million":10}'
+);
+
+SELECT ai_complete('Summarize this ticket.', profile := 'support_model');
+SELECT * FROM ai_models();
+```
+
+Embedding profiles can set `max_batch_inputs`, `max_inputs`,
+`max_batch_tokens`, `max_request_bytes`, `context_size` or `max_input_tokens`,
+`embedding_dimensions`, and `native_batch_support` in `options`. Packing uses
+these limits before sending requests and recursively splits provider HTTP 413
+responses. Declared embedding dimensions are validated against provider output.
+Profiles can also set non-negative `input_token_price_per_million` and
+`output_token_price_per_million`; an explicit per-call or session price takes
+precedence.
+
+`ai_models()` result columns: `name`, `provider`, `model`, `location`,
+`credential`, `model_type`, `capabilities`, `options`, `max_batch_inputs`,
+`max_batch_tokens`, `max_request_bytes`, `context_tokens`,
+`embedding_dimensions`, `native_batch_jobs`, input/output token prices,
+`storage`, `persistent`, and `validation_status`.
+
+#### Endpoint control-plane functions
+
+Description: Optional table functions for an external, asynchronous endpoint
+service. Registration and inference never create billable cloud resources.
+`ai_provision_endpoint()` defaults to a local dry run. Submission requires both
+`dry_run := false` and a positive `max_hourly_cost_usd`; the service is expected
+to make operations idempotent and keep cloud credentials server-side.
+
+```sql
+SELECT * FROM ai_provision_endpoint('support_model');
+
+SELECT *
+FROM ai_provision_endpoint(
+    'support_model',
+    dry_run := false,
+    max_hourly_cost_usd := 5.00
+);
+
+SELECT * FROM ai_endpoint_status('operation-id');
+SELECT * FROM ai_deprovision_endpoint('support_model');
+```
+
+Set `DUCKDB_AI_CONTROL_PLANE_URL` for applied operations and optionally
+`DUCKDB_AI_CONTROL_PLANE_TOKEN` for bearer authentication. The normalized result
+columns are `operation_id`, `status`, `endpoint_url`,
+`estimated_hourly_cost_usd`, `action_required`, and `response`.
 
 #### `ai_model_prices()`
 
@@ -808,6 +1110,20 @@ Aggregate functions also accept:
 | `instruction`, `task` | `VARCHAR` | Constant instruction for `ai_agg`. |
 | `separator` | `VARCHAR` | Separator inserted between grouped input values. |
 | `max_context_chars` | `BIGINT` | Maximum grouped text characters sent to the model. |
+| `overflow_policy` | `VARCHAR` | `hierarchical` (default) recursively reduces every input, while `error` rejects groups that exceed `max_context_chars`. |
+
+Classification functions also accept:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `label_descriptions` | `VARCHAR` | Constant label semantics, commonly encoded as JSON. |
+| `instructions` | `VARCHAR` | Constant global classification rules. |
+| `examples` | `VARCHAR` | Constant few-shot examples, commonly encoded as JSON. |
+
+`ai_build_classifier()` additionally accepts `optimization := 'minimize_cost'`,
+`sample_size`, `quality_threshold`, `confidence_margin`, `embedding_model`,
+`embedding_provider`, and `embedding_profile`. `ai_classify_optimized()` accepts
+`fallback_profile` plus completion options for the uncertain-row fallback.
 
 ## Provider settings and secrets
 
@@ -874,18 +1190,19 @@ highest precedence:
 
 | Setting | Applies to |
 | --- | --- |
-| `duckdb_ai_completion_model` | `ai_complete`, `ai_complete_json`, `ai_complete_record`, `ai_completion_request_json`, `ai_rerank` |
-| `duckdb_ai_task_model` | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_classify_labels`, `ai_extract`, `ai_filter` |
+| `duckdb_ai_completion_model` | `ai_complete`, `ai_complete_json`, `ai_complete_record`, `ai_completion_request_json`, `ai_rerank`, `ai_score` |
+| `duckdb_ai_task_model` | `ai_summarize`, `ai_sentiment`, `ai_fix_grammar`, `ai_redact`, `ai_translate`, `ai_classify`, `ai_classify_labels`, `ai_classify_result`, `ai_extract`, `ai_filter`, classifier labeling and fallback |
 | `duckdb_ai_aggregate_model` | `ai_agg`, `ai_summarize_agg` |
 | `duckdb_ai_sql_assistant_model` | `ai_sql`, `ai_query_data`, `ai_explain_sql`, `ai_fix_sql` |
-| `duckdb_ai_embedding_model` | `ai_embed`, `ai_embedding_request_json`, `ai_similarity` |
+| `duckdb_ai_embedding_model` | `ai_embed`, `ai_embedding_request_json`, `ai_similarity`, `ai_build_classifier`, `ai_classify_optimized` |
 
 Model resolution order is:
 
 1. Per-call `model := ...`
-2. Matching function-family setting
-3. `duckdb_ai_model`
-4. Provider default model
+2. External model selected through `profile := ...`
+3. Matching function-family setting
+4. `duckdb_ai_model`
+5. Provider default model
 
 Credentials should use environment variables or DuckDB secrets:
 

--- a/docs/runtime-behavior.md
+++ b/docs/runtime-behavior.md
@@ -40,6 +40,7 @@ The affected state includes:
 
 - `ai_usage()` and `ai_clear_usage()`,
 - opt-in response cache entries used by `cache := true` or `duckdb_ai_cache`,
+- bounded query-local embeddings used to deduplicate `ai_similarity()` inputs,
 - generated SQL cache entries for successful `ai_query_data()` binds,
 - `duckdb_ai_max_concurrent_requests`,
 - `duckdb_ai_min_request_interval_ms`, and
@@ -48,9 +49,10 @@ The affected state includes:
 ## Intra-chunk provider concurrency
 
 Row-wise provider scalar functions prepare row inputs, options, and secrets on
-the DuckDB execution thread, then run provider work in a bounded worker pool for
-the current vector chunk. The DuckDB result vectors are filled after worker
-completion on the execution thread.
+the DuckDB execution thread, then submit provider work to a bounded executor
+owned by the current DuckDB database instance. Worker threads persist across
+vector chunks instead of being created once per vector. The DuckDB result
+vectors are filled after worker completion on the execution thread.
 
 This applies to:
 
@@ -68,8 +70,39 @@ provider rate limiter still controls outbound request pacing.
 Configured worker caps must be between 0 and 64; larger values are rejected
 instead of being silently clamped.
 
-Aggregate functions and SQL-assistant table functions perform one provider call
-per group or invocation and do not need intra-chunk fan-out.
+SQL-assistant table functions perform one provider call per invocation.
+Aggregate functions use one request for groups that fit `max_context_chars` and
+a bounded parallel map/reduce request tree for larger groups.
+
+## Embedding request packing
+
+`ai_embed()`, `ai_similarity()`, classifier training, and optimized
+classification pack embedding inputs by provider/model option group. A request
+is closed when the configured input count, estimated token count, or request
+byte limit would be exceeded. External model `options` can override these
+limits; conservative built-in defaults apply otherwise.
+
+`ai_similarity()` deduplicates both sides of every row, keeps a bounded
+query-local embedding cache across DuckDB vector chunks, embeds each distinct
+value once, and computes cosine similarity locally. Its request count therefore
+scales with packed distinct values rather than two HTTP requests per row. The
+query cache is capped at 8 MiB and the database keeps at most eight recent query
+caches; `ai_clear_cache()` clears it explicitly. Query-cache hits appear in
+`ai_usage_summary()` without increasing `batch_count`.
+
+When a provider rejects a multi-input embedding request with HTTP 413 or a
+recognized payload/context-size error, the extension recursively bisects that
+request. A single input that exceeds an external model's declared context or
+byte limit fails explicitly.
+
+## Context-safe aggregate reduction
+
+`ai_agg()` and `ai_summarize_agg()` never truncate grouped input. Groups within
+`max_context_chars` use one final request. Larger groups are split on UTF-8-safe
+boundaries, mapped concurrently into compact evidence, packed, and recursively
+reduced until one final request fits. Every child uses the parent query's
+operation tree for usage attribution. Set `overflow_policy := 'error'` to reject
+an oversized group before any provider call.
 
 ## Cancellation and retries
 
@@ -81,6 +114,12 @@ Retries are disabled by default. When enabled with `retry_count` or
 `duckdb_ai_retry_count`, retryable HTTP failures use exponential backoff with
 jitter. HTTP `Retry-After` headers on provider responses take precedence over
 the configured backoff.
+
+Usage events keep one `operation_id` for all input events produced by a packed
+request. Hierarchical aggregate children additionally carry a
+`parent_operation_id`; retries retain the same operation ID and increment the
+event's retry count. `ai_usage_summary()` exposes both row-event calls and
+distinct request batches, plus bounded-buffer drop counters.
 
 ## HTTP connection behavior
 
@@ -96,6 +135,15 @@ connect timeout defaults to the smaller of 10 seconds and the total timeout. Set
 
 Provider redirects are not followed. This avoids forwarding authorization or
 API-key headers to an unexpected redirect target.
+
+Provider and usage-log destinations must use `http` or `https`. URLs containing
+embedded credentials or raw control characters are rejected before libcurl is
+called. The same control-character check applies to generated HTTP headers.
+
+Provider and usage-log response bodies are limited to 64 MiB by default to
+prevent an untrusted endpoint from growing an unbounded in-memory buffer. Set
+`DUCKDB_AI_MAX_RESPONSE_BYTES` to a positive byte count, up to 1 GiB, when a
+large batched embedding response requires a different bound.
 
 `CURLOPT_NOSIGNAL` is enabled so DuckDB host processes are not exposed to
 libcurl signal behavior during DNS or timeout handling.
@@ -126,7 +174,23 @@ The maximum number of cached entries defaults to `1024`. Set
 response-cache storage.
 
 `ai_query_data()` also keeps a small in-memory generated-SQL cache for successful
-binds. `ai_clear_cache()` clears both caches.
+binds. `ai_clear_cache()` clears the response, generated-SQL, and similarity
+query caches.
+
+## Deterministic performance benchmark
+
+The local benchmark uses a threaded mock embedding endpoint and reports request
+count, wall time, peak DuckDB thread count, peak resident memory, and dropped
+usage events for 1,000 and 10,000 rows. It also derives a provider cost estimate
+from mock token usage at a fixed price:
+
+```sh
+python3 test/benchmarks/ai_runtime_benchmark.py
+```
+
+It covers unique `ai_embed()` inputs and repeated `ai_similarity()` inputs. The
+latter uses 20 distinct values at both row counts, making a regression from
+query-level distinct-value scaling directly visible in `http_requests`.
 
 ## Egress allowlisting
 
@@ -157,3 +221,5 @@ embedding arrays, `ai_complete_json()` validation, and
 
 `ai_complete_json()` and `ai_complete_record()` intentionally implement a
 documented JSON Schema subset rather than full JSON Schema draft parity.
+Schema `pattern` checks use RE2-compatible regular expressions so validation
+has bounded-time matching behavior; constructs unsupported by RE2 are rejected.

--- a/docs/security-data-flow.md
+++ b/docs/security-data-flow.md
@@ -14,9 +14,16 @@ an explicit data egress path from DuckDB to the configured provider or gateway.
   `duckdb_ai_log_endpoint` or `DUCKDB_AI_LOG_ENDPOINT` is configured.
 - Usage logs omit prompt, input, and response text by default.
 - API keys are read from environment variables or `TYPE duckdb_ai` secrets.
+- External model objects contain only safe routing metadata and the name of a
+  `TYPE duckdb_ai` credential secret; they never contain credential material.
 - `TYPE duckdb_ai` secrets redact `API_KEY` values when listed.
 - Provider error messages redact the active API key before surfacing errors.
 - Provider redirects are not followed for API calls.
+- Provider and log URLs are restricted to HTTP(S), and URLs with embedded
+  credentials or raw control characters are rejected.
+- HTTP response bodies are bounded to 64 MiB by default; use
+  `DUCKDB_AI_MAX_RESPONSE_BYTES` to configure a different bound up to 1 GiB.
+- Caller-controlled HTTP header values reject CR, LF, and NUL characters.
 - Provider response parsing uses DuckDB's vendored `yyjson` parser.
 
 ## Egress controls
@@ -34,16 +41,31 @@ URLs, `*.example.com`, or `*`.
 The allowlist check runs before the HTTP request, including for usage-log
 endpoints.
 
+The URL validation still runs when no host allowlist is configured. An
+allowlist controls which HTTP(S) hosts are reachable; it does not enable other
+libcurl protocols.
+
 ## Data sent by function family
 
 | Function family | Data sent |
 | --- | --- |
 | `ai_complete`, `ai_try_complete`, `ai_complete_json`, `ai_rerank`, task wrappers, aggregates, and SQL assistant functions | Prompt text, configured system prompt, model name, response-format hints, and provider options needed by the selected provider API. |
 | `ai_complete_record` | Prompt text plus the supplied JSON Schema. |
-| `ai_embed` and `ai_similarity` | Input text to embed and model name. `ai_embed` may batch multiple rows with the same options into one provider request; `ai_similarity` reuses a constant-side embedding within a chunk and sends non-constant inputs as embedding requests. |
+| `ai_embed`, `ai_similarity`, and optimized classification | Input text to embed and model name. Inputs with the same options are packed by count, estimated tokens, and bytes. `ai_similarity` uses a bounded query-local cache to send each distinct value once across vector chunks. |
 | `ai_redact` with `openai_privacy_filter` | Raw input text and model name to `POST /redact`. |
-| `ai_completion_request_json`, `ai_embedding_request_json`, `ai_schema_prompt`, `ai_is_read_only_sql`, `ai_validate_read_only_sql`, `ai_count_tokens`, `ai_recommended_batch_size`, metadata functions, and catalog table functions | No provider network call. |
+| `ai_generate_chunks`, `ai_prep_search(..., enrich := false)`, `ai_completion_request_json`, `ai_embedding_request_json`, `ai_schema_prompt`, `ai_is_read_only_sql`, `ai_validate_read_only_sql`, `ai_count_tokens`, `ai_recommended_batch_size`, metadata functions, and catalog table functions | No provider network call. |
 | `ai_query_data` | The natural-language question and generated schema context are sent during bind; generated SQL is validated as one read-only DuckDB `SELECT` before execution. SQL assistant schema context is sent in the provider system message when the provider protocol supports it. Successful generated SQL is cached in memory for repeated binds with the same question, schema context, and output-affecting options. |
+| `ai_parse_document` | Binary document content encoded as base64, MIME type, parser profile, and optional page selection are sent to `DUCKDB_AI_CONTROL_PLANE_URL`. |
+| Endpoint provisioning functions | Safe external-model metadata, operation IDs, and explicit spend ceilings are sent to `DUCKDB_AI_CONTROL_PLANE_URL`. Cloud credentials are not read or sent by the extension. |
+
+## Optional control plane
+
+Endpoint provisioning and remote document parsing are disabled until
+`DUCKDB_AI_CONTROL_PLANE_URL` is configured. The optional
+`DUCKDB_AI_CONTROL_PLANE_TOKEN` is sent as a bearer token and should be scoped to
+the companion service, not to a cloud provider. Applied provisioning requires
+an explicit `dry_run := false` and positive hourly spend ceiling. Registration,
+query binding, and first inference never provision resources.
 
 ## Logging
 

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -2,6 +2,7 @@
 
 #include "ai_extension.hpp"
 #include "duckdb_ai_provider.hpp"
+#include "yyjson.hpp"
 
 #include "duckdb.hpp"
 #include "duckdb/catalog/catalog.hpp"
@@ -15,6 +16,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/parser/parser_extension.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
@@ -37,11 +39,13 @@
 #include <cerrno>
 #include <cctype>
 #include <cmath>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <exception>
-#include <future>
+#include <functional>
+#include <iomanip>
 #include <initializer_list>
 #include <limits>
 #include <mutex>
@@ -58,6 +62,8 @@ namespace {
 constexpr int64_t MAX_TOKEN_LIMIT_PER_MINUTE = 10000000000LL;
 constexpr idx_t MAX_PROVIDER_CHUNK_WORKERS = 64;
 constexpr size_t MAX_PROMPT_QUERY_CACHE_ENTRIES = 1024;
+constexpr size_t MAX_SIMILARITY_QUERY_CACHES = 8;
+constexpr size_t MAX_SIMILARITY_QUERY_CACHE_BYTES = 8 * 1024 * 1024;
 constexpr int64_t MAX_SQL_FIX_ATTEMPTS = 5;
 std::atomic<uint64_t> NEXT_QUERY_ID {1};
 
@@ -65,19 +71,21 @@ std::atomic<uint64_t> NEXT_QUERY_ID {1};
 // ABI-specific (std::string layout differs per standard library), so only enforce it on the
 // toolchains where the expected values are known instead of breaking every other build.
 #if defined(__APPLE__)
-static_assert(sizeof(duckdb_ai::CompletionOptions) == 608 || sizeof(duckdb_ai::CompletionOptions) == 728,
+static_assert(sizeof(duckdb_ai::CompletionOptions) == 688 || sizeof(duckdb_ai::CompletionOptions) == 808,
               "Update CompletionOptionsEqual when CompletionOptions fields change");
 #endif
 
 bool CompletionOptionsEqual(const duckdb_ai::CompletionOptions &left, const duckdb_ai::CompletionOptions &right) {
+	// Request operation IDs intentionally do not affect batching or provider configuration equality.
 	return left.model == right.model && left.provider == right.provider && left.secret_name == right.secret_name &&
-	       left.system_prompt == right.system_prompt && left.base_url == right.base_url &&
-	       left.api_key == right.api_key && left.has_temperature == right.has_temperature &&
-	       left.temperature == right.temperature && left.has_max_tokens == right.has_max_tokens &&
-	       left.max_tokens == right.max_tokens && left.has_timeout_seconds == right.has_timeout_seconds &&
-	       left.timeout_seconds == right.timeout_seconds && left.has_retry_count == right.has_retry_count &&
-	       left.retry_count == right.retry_count && left.has_retry_backoff_ms == right.has_retry_backoff_ms &&
-	       left.retry_backoff_ms == right.retry_backoff_ms &&
+	       left.explicit_model == right.explicit_model && left.explicit_provider == right.explicit_provider &&
+	       left.explicit_base_url == right.explicit_base_url && left.system_prompt == right.system_prompt &&
+	       left.base_url == right.base_url && left.api_key == right.api_key &&
+	       left.has_temperature == right.has_temperature && left.temperature == right.temperature &&
+	       left.has_max_tokens == right.has_max_tokens && left.max_tokens == right.max_tokens &&
+	       left.has_timeout_seconds == right.has_timeout_seconds && left.timeout_seconds == right.timeout_seconds &&
+	       left.has_retry_count == right.has_retry_count && left.retry_count == right.retry_count &&
+	       left.has_retry_backoff_ms == right.has_retry_backoff_ms && left.retry_backoff_ms == right.retry_backoff_ms &&
 	       left.has_max_concurrent_requests == right.has_max_concurrent_requests &&
 	       left.max_concurrent_requests == right.max_concurrent_requests &&
 	       left.has_min_request_interval_ms == right.has_min_request_interval_ms &&
@@ -104,7 +112,7 @@ bool CompletionOptionsEqual(const duckdb_ai::CompletionOptions &left, const duck
 	       left.log_sample_rate == right.log_sample_rate && left.fail_on_error == right.fail_on_error &&
 	       left.on_error == right.on_error && left.response_format == right.response_format &&
 	       left.response_schema == right.response_schema && left.function_name == right.function_name &&
-	       left.query_id == right.query_id;
+	       left.query_id == right.query_id && left.model_options == right.model_options;
 }
 
 void AddTableColumns(vector<LogicalType> &return_types, vector<string> &names,
@@ -130,6 +138,243 @@ struct AiUsageScanData : public GlobalTableFunctionState {
 	vector<duckdb_ai::UsageEvent> events;
 };
 
+struct AiUsageSummaryRow {
+	std::string query_id;
+	std::string provider;
+	std::string model;
+	uint64_t calls = 0;
+	uint64_t retries = 0;
+	uint64_t failures = 0;
+	uint64_t cache_hits = 0;
+	std::set<std::string> operation_ids;
+	int64_t total_tokens = 0;
+	int64_t elapsed_ms = 0;
+	double estimated_cost_usd = 0;
+};
+
+struct AiUsageSummaryScanData : public GlobalTableFunctionState {
+	idx_t offset = 0;
+	vector<AiUsageSummaryRow> rows;
+	duckdb_ai::UsageBufferStats stats;
+};
+
+struct AiTextChunk {
+	std::string source_id;
+	std::string chunk_id;
+	idx_t chunk_index;
+	idx_t start_offset;
+	idx_t end_offset;
+	std::string text;
+	std::string heading;
+	idx_t page;
+};
+
+struct AiChunkBindData : public FunctionData {
+	std::string input;
+	std::string source_id;
+	std::string title;
+	std::string metadata;
+	std::string strategy = "recursive";
+	idx_t chunk_size = 1000;
+	double overlap_percent = 10;
+	bool prep_search = false;
+	bool enrich = false;
+	duckdb_ai::CompletionOptions options;
+	vector<AiTextChunk> chunks;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<AiChunkBindData>();
+		result->input = input;
+		result->source_id = source_id;
+		result->title = title;
+		result->metadata = metadata;
+		result->strategy = strategy;
+		result->chunk_size = chunk_size;
+		result->overlap_percent = overlap_percent;
+		result->prep_search = prep_search;
+		result->enrich = enrich;
+		result->options = options;
+		result->chunks = chunks;
+		return std::move(result);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<AiChunkBindData>();
+		return input == other.input && source_id == other.source_id && title == other.title &&
+		       metadata == other.metadata && strategy == other.strategy && chunk_size == other.chunk_size &&
+		       overlap_percent == other.overlap_percent && prep_search == other.prep_search && enrich == other.enrich &&
+		       CompletionOptionsEqual(options, other.options);
+	}
+};
+
+struct AiChunkScanData : public GlobalTableFunctionState {
+	idx_t offset = 0;
+	bool prepared = false;
+	std::string document_context;
+	std::string enrichment_error;
+};
+
+struct ExternalModelBindData : public FunctionData {
+	std::string name;
+	std::string provider;
+	std::string model;
+	std::string location;
+	std::string credential;
+	std::string model_type;
+	std::string capabilities;
+	std::string options;
+	bool replace = false;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<ExternalModelBindData>();
+		result->name = name;
+		result->provider = provider;
+		result->model = model;
+		result->location = location;
+		result->credential = credential;
+		result->model_type = model_type;
+		result->capabilities = capabilities;
+		result->options = options;
+		result->replace = replace;
+		return std::move(result);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<ExternalModelBindData>();
+		return name == other.name && provider == other.provider && model == other.model && location == other.location &&
+		       credential == other.credential && model_type == other.model_type && capabilities == other.capabilities &&
+		       options == other.options && replace == other.replace;
+	}
+};
+
+enum class ControlPlaneOperation : uint8_t { PROVISION, STATUS, DEPROVISION };
+
+struct ControlPlaneBindData : public FunctionData {
+	explicit ControlPlaneBindData(ControlPlaneOperation operation_p) : operation(operation_p) {
+	}
+
+	ControlPlaneOperation operation;
+	std::string argument;
+	bool dry_run = true;
+	bool has_max_hourly_cost = false;
+	double max_hourly_cost_usd = 0;
+	duckdb_ai::CompletionOptions options;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<ControlPlaneBindData>(operation);
+		result->argument = argument;
+		result->dry_run = dry_run;
+		result->has_max_hourly_cost = has_max_hourly_cost;
+		result->max_hourly_cost_usd = max_hourly_cost_usd;
+		result->options = options;
+		return std::move(result);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<ControlPlaneBindData>();
+		return operation == other.operation && argument == other.argument && dry_run == other.dry_run &&
+		       has_max_hourly_cost == other.has_max_hourly_cost && max_hourly_cost_usd == other.max_hourly_cost_usd &&
+		       CompletionOptionsEqual(options, other.options);
+	}
+};
+
+struct DocumentParseBindData : public FunctionData {
+	std::string content;
+	std::string mime_type;
+	std::string parser_profile;
+	std::string pages;
+	duckdb_ai::CompletionOptions options;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<DocumentParseBindData>();
+		result->content = content;
+		result->mime_type = mime_type;
+		result->parser_profile = parser_profile;
+		result->pages = pages;
+		result->options = options;
+		return std::move(result);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<DocumentParseBindData>();
+		return content == other.content && mime_type == other.mime_type && parser_profile == other.parser_profile &&
+		       pages == other.pages && CompletionOptionsEqual(options, other.options);
+	}
+};
+
+struct DocumentElement {
+	std::string document_id;
+	int64_t page = -1;
+	int64_t element_index = -1;
+	std::string element_type;
+	std::string text;
+	std::string markdown;
+	std::string bbox;
+	double confidence = 0;
+	bool has_confidence = false;
+	std::string metadata;
+	std::string error;
+};
+
+struct DocumentParseScanData : public GlobalTableFunctionState {
+	idx_t offset = 0;
+	bool loaded = false;
+	vector<DocumentElement> elements;
+};
+
+struct ClassifierBuildBindData : public FunctionData {
+	std::vector<std::string> labels;
+	duckdb_ai::CompletionOptions label_options;
+	duckdb_ai::CompletionOptions embedding_options;
+	idx_t sample_size = 256;
+	double quality_threshold = 0.8;
+	double confidence_margin = 0.05;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<ClassifierBuildBindData>();
+		result->labels = labels;
+		result->label_options = label_options;
+		result->embedding_options = embedding_options;
+		result->sample_size = sample_size;
+		result->quality_threshold = quality_threshold;
+		result->confidence_margin = confidence_margin;
+		return std::move(result);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<ClassifierBuildBindData>();
+		return labels == other.labels && CompletionOptionsEqual(label_options, other.label_options) &&
+		       CompletionOptionsEqual(embedding_options, other.embedding_options) && sample_size == other.sample_size &&
+		       quality_threshold == other.quality_threshold && confidence_margin == other.confidence_margin;
+	}
+
+	bool SupportStatementCache() const override {
+		return false;
+	}
+};
+
+struct ClassifierBuildState {
+	idx_t size;
+	idx_t alloc_size;
+	idx_t sample_count;
+	idx_t row_count;
+	char *dataptr;
+};
+
+struct OptimizedClassifierBindData : public FunctionData {
+	duckdb_ai::CompletionOptions fallback_options;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<OptimizedClassifierBindData>();
+		result->fallback_options = fallback_options;
+		return std::move(result);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return CompletionOptionsEqual(fallback_options, other_p.Cast<OptimizedClassifierBindData>().fallback_options);
+	}
+};
+
 struct AiClearUsageScanData : public GlobalTableFunctionState {
 	AiClearUsageScanData() : emitted(false) {
 	}
@@ -148,6 +393,11 @@ struct AiModelPricesScanData : public GlobalTableFunctionState {
 struct AiSecretsScanData : public GlobalTableFunctionState {
 	idx_t offset = 0;
 	vector<SecretEntry> secrets;
+};
+
+struct AiModelsScanData : public GlobalTableFunctionState {
+	idx_t offset = 0;
+	vector<SecretEntry> models;
 };
 
 struct PromptSchemaOptions {
@@ -399,6 +649,9 @@ struct AiTaskBindData : public FunctionData {
 	bool has_provider_arg = false;
 	idx_t provider_index = 0;
 	bool parameter_is_label_list = false;
+	std::string label_descriptions;
+	std::string instructions;
+	std::string examples;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<AiTaskBindData>(task, required_args);
@@ -408,6 +661,9 @@ struct AiTaskBindData : public FunctionData {
 		result->has_provider_arg = has_provider_arg;
 		result->provider_index = provider_index;
 		result->parameter_is_label_list = parameter_is_label_list;
+		result->label_descriptions = label_descriptions;
+		result->instructions = instructions;
+		result->examples = examples;
 		return std::move(result);
 	}
 
@@ -416,7 +672,9 @@ struct AiTaskBindData : public FunctionData {
 		return task == other.task && required_args == other.required_args &&
 		       CompletionOptionsEqual(options, other.options) && has_model_arg == other.has_model_arg &&
 		       model_index == other.model_index && has_provider_arg == other.has_provider_arg &&
-		       provider_index == other.provider_index && parameter_is_label_list == other.parameter_is_label_list;
+		       provider_index == other.provider_index && parameter_is_label_list == other.parameter_is_label_list &&
+		       label_descriptions == other.label_descriptions && instructions == other.instructions &&
+		       examples == other.examples;
 	}
 };
 
@@ -429,6 +687,7 @@ struct AiAggregateBindData : public FunctionData {
 	std::string instruction;
 	std::string separator = "\n---\n";
 	idx_t max_context_chars = 100000;
+	std::string overflow_policy = "hierarchical";
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<AiAggregateBindData>(kind);
@@ -436,6 +695,7 @@ struct AiAggregateBindData : public FunctionData {
 		result->instruction = instruction;
 		result->separator = separator;
 		result->max_context_chars = max_context_chars;
+		result->overflow_policy = overflow_policy;
 		return std::move(result);
 	}
 
@@ -443,7 +703,7 @@ struct AiAggregateBindData : public FunctionData {
 		auto &other = other_p.Cast<AiAggregateBindData>();
 		return kind == other.kind && CompletionOptionsEqual(options, other.options) &&
 		       instruction == other.instruction && separator == other.separator &&
-		       max_context_chars == other.max_context_chars;
+		       max_context_chars == other.max_context_chars && overflow_policy == other.overflow_policy;
 	}
 
 	bool SupportStatementCache() const override {
@@ -455,7 +715,6 @@ struct AiAggregateState {
 	idx_t size;
 	idx_t alloc_size;
 	idx_t row_count;
-	bool truncated;
 	char *dataptr;
 };
 
@@ -649,10 +908,12 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
                                 bool allow_log_payload_options) {
 	if (name == "model") {
 		options.model = OptionStringValue(value, function_name, name);
+		options.explicit_model = true;
 		return true;
 	}
 	if (name == "provider") {
 		options.provider = OptionStringValue(value, function_name, name);
+		options.explicit_provider = true;
 		return true;
 	}
 	if (name == "profile" || name == "secret" || name == "secret_name") {
@@ -665,6 +926,7 @@ bool ApplyCompletionValueOption(duckdb_ai::CompletionOptions &options, const std
 	}
 	if (name == "base_url") {
 		options.base_url = OptionStringValue(value, function_name, name);
+		options.explicit_base_url = true;
 		return true;
 	}
 	if (name == "allowed_hosts") {
@@ -885,6 +1147,15 @@ void ApplyAggregateOption(ClientContext &context, AiAggregateBindData &bind_data
 			throw BinderException("AI aggregate option \"max_context_chars\" must be greater than 0");
 		}
 		bind_data.max_context_chars = NumericCast<idx_t>(max_context_chars);
+		return;
+	}
+	if (name == "overflow_policy") {
+		auto option = EvaluateConstantOption(context, expr, name, LogicalType::VARCHAR);
+		auto value = LowerAscii(StringValue::Get(option));
+		if (value != "hierarchical" && value != "error") {
+			throw BinderException("AI aggregate option \"overflow_policy\" must be hierarchical or error");
+		}
+		bind_data.overflow_policy = value;
 		return;
 	}
 	ApplyNamedOption(context, bind_data.options, expr, name);
@@ -1112,6 +1383,33 @@ std::string OptionalSecretInputString(const CreateSecretInput &input, const std:
 	return StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
 }
 
+std::string ExternalModelSecretName(const std::string &name) {
+	return "__duckdb_ai_model_" + name;
+}
+
+unique_ptr<BaseSecret> CreateAiModelSecretFromConfig(ClientContext &, CreateSecretInput &input) {
+	auto provider = OptionalSecretInputString(input, "ai_provider");
+	auto model = OptionalSecretInputString(input, "model");
+	if (provider.empty() || model.empty()) {
+		throw InvalidInputException("duckdb_ai_model entries require AI_PROVIDER and MODEL");
+	}
+	provider = duckdb_ai::NormalizeProviderName(provider);
+	auto scope = input.scope;
+	if (scope.empty()) {
+		scope.push_back(provider);
+	}
+	auto secret = make_uniq<KeyValueSecret>(scope, input.type, input.provider, input.name);
+	secret->secret_map["provider"] = Value(provider);
+	secret->secret_map["model"] = Value(model);
+	for (auto key : {"location", "credential", "model_type", "capabilities", "options"}) {
+		auto value = OptionalSecretInputString(input, key);
+		if (!value.empty()) {
+			secret->secret_map[key] = Value(value);
+		}
+	}
+	return std::move(secret);
+}
+
 unique_ptr<BaseSecret> CreateAiProviderSecretFromConfig(ClientContext &, CreateSecretInput &input) {
 	auto scope = input.scope;
 	auto provider = OptionalSecretInputString(input, "ai_provider");
@@ -1141,6 +1439,34 @@ void ApplyAiProviderSecret(ClientContext &context, duckdb_ai::CompletionOptions 
 	unique_ptr<SecretEntry> secret_entry;
 	bool explicit_secret = !options.secret_name.empty();
 	if (explicit_secret) {
+		auto profile_name = options.secret_name;
+		auto model_entry = secret_manager.GetSecretByName(transaction, ExternalModelSecretName(profile_name));
+		if (model_entry && model_entry->secret && model_entry->secret->GetType() == "duckdb_ai_model") {
+			const auto &model_secret = dynamic_cast<const KeyValueSecret &>(*model_entry->secret);
+			std::string value;
+			if (!options.explicit_provider && TryReadSecretString(model_secret, "provider", value)) {
+				options.provider = value;
+			}
+			value.clear();
+			if (!options.explicit_model && TryReadSecretString(model_secret, "model", value)) {
+				options.model = value;
+			}
+			value.clear();
+			if (!options.explicit_base_url && TryReadSecretString(model_secret, "location", value)) {
+				options.base_url = value;
+			}
+			value.clear();
+			if (TryReadSecretString(model_secret, "options", value)) {
+				options.model_options = value;
+				duckdb_ai::ApplyModelProfileOptions(options);
+			}
+			std::string credential;
+			if (!TryReadSecretString(model_secret, "credential", credential)) {
+				options.secret_name.clear();
+				return;
+			}
+			options.secret_name = credential;
+		}
 		secret_entry = secret_manager.GetSecretByName(transaction, options.secret_name);
 		if (!secret_entry || !secret_entry->secret) {
 			throw InvalidInputException("AI secret \"%s\" was not found", options.secret_name);
@@ -1375,16 +1701,138 @@ struct ProviderDoubleJob : public ProviderJobBase {
 	double output = 0;
 };
 
-struct SimilarityEmbeddingCacheEntry {
-	std::string input;
-	duckdb_ai::CompletionOptions options;
-	std::vector<double> values;
-};
-
 struct SecretResolutionCacheEntry {
 	duckdb_ai::CompletionOptions input_options;
 	duckdb_ai::CompletionOptions resolved_options;
 };
+
+struct ProviderExecutorState : public ObjectCacheEntry {
+	~ProviderExecutorState() override {
+		{
+			std::lock_guard<std::mutex> lock(mutex);
+			shutdown = true;
+		}
+		cv.notify_all();
+		for (auto &worker : workers) {
+			if (worker.joinable()) {
+				worker.join();
+			}
+		}
+	}
+
+	static std::string ObjectType() {
+		return "duckdb_ai_provider_executor";
+	}
+
+	std::string GetObjectType() override {
+		return ObjectType();
+	}
+
+	optional_idx GetEstimatedCacheMemory() const override {
+		return optional_idx {};
+	}
+
+	void EnsureWorkers(idx_t requested_workers) {
+		std::lock_guard<std::mutex> lock(mutex);
+		while (workers.size() < requested_workers) {
+			workers.emplace_back([this]() {
+				while (true) {
+					std::function<void()> task;
+					{
+						std::unique_lock<std::mutex> lock(mutex);
+						cv.wait(lock, [&]() { return shutdown || !queue.empty(); });
+						if (shutdown && queue.empty()) {
+							return;
+						}
+						task = std::move(queue.front());
+						queue.pop_front();
+					}
+					task();
+				}
+			});
+		}
+	}
+
+	void Submit(std::function<void()> task) {
+		{
+			std::lock_guard<std::mutex> lock(mutex);
+			queue.push_back(std::move(task));
+		}
+		cv.notify_one();
+	}
+
+	std::mutex mutex;
+	std::condition_variable cv;
+	std::deque<std::function<void()>> queue;
+	std::vector<std::thread> workers;
+	bool shutdown = false;
+};
+
+struct SimilarityOptionCache {
+	duckdb_ai::CompletionOptions options;
+	std::unordered_map<std::string, std::vector<double>> embeddings;
+};
+
+struct SimilarityQueryCache {
+	std::mutex mutex;
+	std::vector<SimilarityOptionCache> option_groups;
+	size_t estimated_bytes = 0;
+};
+
+struct SimilarityCacheState : public ObjectCacheEntry {
+	static std::string ObjectType() {
+		return "duckdb_ai_similarity_query_cache";
+	}
+
+	std::string GetObjectType() override {
+		return ObjectType();
+	}
+
+	optional_idx GetEstimatedCacheMemory() const override {
+		return optional_idx {};
+	}
+
+	std::mutex mutex;
+	std::unordered_map<idx_t, std::shared_ptr<SimilarityQueryCache>> queries;
+	std::deque<idx_t> recency_order;
+};
+
+ProviderExecutorState fallback_provider_executor;
+
+ProviderExecutorState &ProviderExecutor(const duckdb_ai::CompletionOptions &options) {
+	if (!options.client_context) {
+		return fallback_provider_executor;
+	}
+	return *ObjectCache::GetObjectCache(*options.client_context)
+	            .GetOrCreate<ProviderExecutorState>(ProviderExecutorState::ObjectType());
+}
+
+std::shared_ptr<SimilarityQueryCache> SimilarityCache(ClientContext &context) {
+	auto &state =
+	    *ObjectCache::GetObjectCache(context).GetOrCreate<SimilarityCacheState>(SimilarityCacheState::ObjectType());
+	auto query_id = context.transaction.HasActiveTransaction() ? context.transaction.GetActiveQuery() : 0;
+	std::lock_guard<std::mutex> lock(state.mutex);
+	auto entry = state.queries.find(query_id);
+	if (entry != state.queries.end()) {
+		return entry->second;
+	}
+	while (state.queries.size() >= MAX_SIMILARITY_QUERY_CACHES && !state.recency_order.empty()) {
+		state.queries.erase(state.recency_order.front());
+		state.recency_order.pop_front();
+	}
+	auto cache = std::make_shared<SimilarityQueryCache>();
+	state.queries.emplace(query_id, cache);
+	state.recency_order.push_back(query_id);
+	return cache;
+}
+
+void ClearSimilarityCache(ClientContext &context) {
+	auto &state =
+	    *ObjectCache::GetObjectCache(context).GetOrCreate<SimilarityCacheState>(SimilarityCacheState::ObjectType());
+	std::lock_guard<std::mutex> lock(state.mutex);
+	state.queries.clear();
+	state.recency_order.clear();
+}
 
 void ApplyAiProviderSecretCached(ClientContext &context, duckdb_ai::CompletionOptions &options,
                                  std::vector<SecretResolutionCacheEntry> &cache) {
@@ -1410,8 +1858,9 @@ idx_t ProviderWorkerCount(const std::vector<JOB> &jobs) {
 	for (auto &job : jobs) {
 		auto cap = duckdb_ai::EffectiveMaxConcurrentRequests(job.options);
 		if (cap > 0) {
-			configured_workers = std::max<idx_t>(
-			    configured_workers, static_cast<idx_t>(std::min<int64_t>(cap, MAX_PROVIDER_CHUNK_WORKERS)));
+			auto bounded_cap = static_cast<idx_t>(std::min<int64_t>(cap, MAX_PROVIDER_CHUNK_WORKERS));
+			configured_workers =
+			    configured_workers == 0 ? bounded_cap : MinValue<idx_t>(configured_workers, bounded_cap);
 		}
 	}
 	idx_t worker_count = configured_workers;
@@ -1426,6 +1875,9 @@ idx_t ProviderWorkerCount(const std::vector<JOB> &jobs) {
 
 template <class JOB, class CALLBACK>
 void RunProviderJobs(std::vector<JOB> &jobs, CALLBACK callback) {
+	if (jobs.empty()) {
+		return;
+	}
 	auto worker_count = ProviderWorkerCount(jobs);
 	std::atomic<bool> stop {false};
 	auto run_one = [&](JOB &job) {
@@ -1457,23 +1909,29 @@ void RunProviderJobs(std::vector<JOB> &jobs, CALLBACK callback) {
 		return;
 	}
 
-	std::atomic<idx_t> next_job {0};
-	std::vector<std::future<void>> workers;
-	workers.reserve(worker_count);
-	for (idx_t worker = 0; worker < worker_count; worker++) {
-		workers.push_back(std::async(std::launch::async, [&]() {
-			while (!stop.load()) {
-				auto job_index = next_job.fetch_add(1);
-				if (job_index >= jobs.size()) {
-					return;
-				}
+	struct BatchWaitState {
+		std::mutex mutex;
+		std::condition_variable cv;
+		idx_t remaining = 0;
+	};
+	auto wait_state = std::make_shared<BatchWaitState>();
+	wait_state->remaining = jobs.size();
+	auto &executor = ProviderExecutor(jobs[0].options);
+	executor.EnsureWorkers(worker_count);
+	for (idx_t job_index = 0; job_index < jobs.size(); job_index++) {
+		executor.Submit([&, job_index, wait_state]() {
+			if (!stop.load()) {
 				run_one(jobs[job_index]);
 			}
-		}));
+			{
+				std::lock_guard<std::mutex> lock(wait_state->mutex);
+				wait_state->remaining--;
+			}
+			wait_state->cv.notify_one();
+		});
 	}
-	for (auto &worker : workers) {
-		worker.get();
-	}
+	std::unique_lock<std::mutex> lock(wait_state->mutex);
+	wait_state->cv.wait(lock, [&]() { return wait_state->remaining == 0; });
 }
 
 bool ReadRuntimeOptions(ClientContext &context, const duckdb_ai::CompletionOptions &base_options, bool has_model_arg,
@@ -1481,11 +1939,17 @@ bool ReadRuntimeOptions(ClientContext &context, const duckdb_ai::CompletionOptio
                         const StringVectorReader *provider_reader, idx_t row, duckdb_ai::CompletionOptions &options) {
 	options = base_options;
 	duckdb_ai::AttachProviderRuntimeState(options, context);
-	if (has_model_arg && !model_reader->Read(row, options.model)) {
-		return false;
+	if (has_model_arg) {
+		if (!model_reader->Read(row, options.model)) {
+			return false;
+		}
+		options.explicit_model = true;
 	}
-	if (has_provider_arg && !provider_reader->Read(row, options.provider)) {
-		return false;
+	if (has_provider_arg) {
+		if (!provider_reader->Read(row, options.provider)) {
+			return false;
+		}
+		options.explicit_provider = true;
 	}
 	return true;
 }
@@ -2311,6 +2775,16 @@ std::string BuildRerankPrompt(const std::string &query, const std::string &candi
 	return "Query:\n" + query + "\n\nCandidate:\n" + candidate;
 }
 
+std::string BuildScoreSystemPrompt() {
+	return "Score how well the input satisfies the supplied criteria on a scale from 0 to 1. Return only a JSON "
+	       "object with one numeric field named score. Use 0 when it does not satisfy the criteria and 1 when it fully "
+	       "satisfies them.";
+}
+
+std::string BuildScorePrompt(const std::string &input, const std::string &criteria) {
+	return "Criteria:\n" + criteria + "\n\nInput:\n" + input;
+}
+
 bool ParseRerankScore(const std::string &input, double &score) {
 	auto trimmed = StripMarkdownJsonFence(input);
 	if (trimmed.size() >= 2 && trimmed.front() == '"' && trimmed.back() == '"') {
@@ -2336,9 +2810,22 @@ bool ParseRerankScore(const std::string &input, double &score) {
 	return true;
 }
 
+bool ParseStructuredScore(const std::string &input, double &score) {
+	std::vector<duckdb_ai::JsonExtractedValue> fields;
+	std::string error;
+	if (!duckdb_ai::ExtractJsonObjectFields(StripMarkdownJsonFence(input), {"score"}, fields, error) ||
+	    fields.size() != 1 || fields[0].kind != duckdb_ai::JsonExtractedKind::NUMBER ||
+	    !std::isfinite(fields[0].number_value) || fields[0].number_value < 0 || fields[0].number_value > 1) {
+		return false;
+	}
+	score = fields[0].number_value;
+	return true;
+}
+
 void AiRerankFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &bind_data = func_expr.bind_info->Cast<AiCompletionBindData>();
+	auto generic_score = func_expr.function.name == "ai_score";
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<double>(result);
@@ -2384,10 +2871,18 @@ void AiRerankFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	}
 
 	RunProviderJobs(jobs, [&](ProviderDoubleJob &job) {
-		AppendSystemPrompt(job.options, BuildRerankSystemPrompt());
-		auto output = duckdb_ai::Complete(BuildRerankPrompt(job.left, job.right), job.options).text;
-		if (!ParseRerankScore(output, job.output)) {
-			throw InvalidInputException("ai_rerank expected a numeric score from 0 to 1, got: %s", output);
+		if (generic_score) {
+			job.options.response_format = "json_schema";
+			job.options.response_schema =
+			    R"({"type":"object","properties":{"score":{"type":"number","minimum":0,"maximum":1}},"required":["score"],"additionalProperties":false})";
+		}
+		AppendSystemPrompt(job.options, generic_score ? BuildScoreSystemPrompt() : BuildRerankSystemPrompt());
+		auto prompt = generic_score ? BuildScorePrompt(job.left, job.right) : BuildRerankPrompt(job.left, job.right);
+		auto output = duckdb_ai::Complete(prompt, job.options).text;
+		auto parsed = generic_score ? ParseStructuredScore(output, job.output) : ParseRerankScore(output, job.output);
+		if (!parsed) {
+			throw InvalidInputException("%s expected a numeric score from 0 to 1, got: %s", func_expr.function.name,
+			                            output);
 		}
 	});
 
@@ -2407,36 +2902,96 @@ void AiRerankFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	}
 }
 
-void PrecomputeConstantSimilarityEmbeddings(std::vector<ProviderDoubleJob> &jobs, bool left_side) {
-	std::vector<SimilarityEmbeddingCacheEntry> cache;
-	for (auto &job : jobs) {
-		if (job.exception) {
+void PrecomputeSimilarityEmbeddings(ClientContext &context, std::vector<ProviderDoubleJob> &jobs) {
+	auto query_cache = SimilarityCache(context);
+	std::vector<bool> grouped(jobs.size(), false);
+	for (idx_t group_start = 0; group_start < jobs.size(); group_start++) {
+		if (grouped[group_start] || jobs[group_start].exception) {
 			continue;
 		}
-		auto &input = left_side ? job.left : job.right;
-		auto cache_entry = std::find_if(cache.begin(), cache.end(), [&](const SimilarityEmbeddingCacheEntry &entry) {
-			return entry.input == input && CompletionOptionsEqual(entry.options, job.options);
-		});
-		try {
-			if (cache_entry == cache.end()) {
-				SimilarityEmbeddingCacheEntry entry;
-				entry.input = input;
-				entry.options = job.options;
-				entry.values = duckdb_ai::Embed(input, job.options).values;
-				cache.push_back(std::move(entry));
-				cache_entry = cache.end() - 1;
+		std::vector<idx_t> group_rows;
+		for (idx_t row = group_start; row < jobs.size(); row++) {
+			if (!grouped[row] && !jobs[row].exception &&
+			    CompletionOptionsEqual(jobs[group_start].options, jobs[row].options)) {
+				grouped[row] = true;
+				group_rows.push_back(row);
 			}
-			if (left_side) {
-				job.has_left_embedding = true;
-				job.left_embedding = cache_entry->values;
-			} else {
-				job.has_right_embedding = true;
-				job.right_embedding = cache_entry->values;
+		}
+
+		std::vector<std::string> unique_inputs;
+		std::unordered_map<std::string, idx_t> input_indexes;
+		for (auto row : group_rows) {
+			for (auto *input : {&jobs[row].left, &jobs[row].right}) {
+				if (input_indexes.find(*input) == input_indexes.end()) {
+					input_indexes[*input] = unique_inputs.size();
+					unique_inputs.push_back(*input);
+				}
+			}
+		}
+
+		try {
+			std::unique_lock<std::mutex> cache_lock(query_cache->mutex);
+			SimilarityOptionCache *option_cache = nullptr;
+			for (auto &candidate : query_cache->option_groups) {
+				if (CompletionOptionsEqual(candidate.options, jobs[group_start].options)) {
+					option_cache = &candidate;
+					break;
+				}
+			}
+			if (!option_cache) {
+				SimilarityOptionCache candidate;
+				candidate.options = jobs[group_start].options;
+				query_cache->option_groups.push_back(std::move(candidate));
+				option_cache = &query_cache->option_groups.back();
+			}
+
+			std::vector<const std::vector<double> *> resolved_embeddings(unique_inputs.size(), nullptr);
+			std::vector<std::string> missing_inputs;
+			std::vector<idx_t> missing_indexes;
+			for (idx_t input_index = 0; input_index < unique_inputs.size(); input_index++) {
+				auto cached = option_cache->embeddings.find(unique_inputs[input_index]);
+				if (cached != option_cache->embeddings.end()) {
+					resolved_embeddings[input_index] = &cached->second;
+					duckdb_ai::RecordEmbeddingCacheHit(unique_inputs[input_index],
+					                                   NumericCast<int64_t>(cached->second.size()),
+					                                   jobs[group_start].options);
+				} else {
+					missing_indexes.push_back(input_index);
+					missing_inputs.push_back(unique_inputs[input_index]);
+				}
+			}
+
+			auto embeddings = duckdb_ai::EmbedMany(missing_inputs, jobs[group_start].options);
+			if (embeddings.size() != missing_inputs.size()) {
+				throw InvalidInputException("AI embedding provider returned %llu embeddings for %llu inputs",
+				                            static_cast<unsigned long long>(embeddings.size()),
+				                            static_cast<unsigned long long>(missing_inputs.size()));
+			}
+			for (idx_t missing_index = 0; missing_index < missing_inputs.size(); missing_index++) {
+				auto input_index = missing_indexes[missing_index];
+				auto estimated_bytes = missing_inputs[missing_index].size() +
+				                       embeddings[missing_index].values.size() * sizeof(double) + 64;
+				if (query_cache->estimated_bytes + estimated_bytes <= MAX_SIMILARITY_QUERY_CACHE_BYTES) {
+					auto inserted = option_cache->embeddings.emplace(missing_inputs[missing_index],
+					                                                 std::move(embeddings[missing_index].values));
+					resolved_embeddings[input_index] = &inserted.first->second;
+					query_cache->estimated_bytes += estimated_bytes;
+				} else {
+					resolved_embeddings[input_index] = &embeddings[missing_index].values;
+				}
+			}
+			for (auto row : group_rows) {
+				jobs[row].left_embedding = *resolved_embeddings[input_indexes[jobs[row].left]];
+				jobs[row].right_embedding = *resolved_embeddings[input_indexes[jobs[row].right]];
+				jobs[row].has_left_embedding = true;
+				jobs[row].has_right_embedding = true;
 			}
 		} catch (std::exception &ex) {
-			job.exception = std::current_exception();
-			job.error_message = ex.what();
-			if (job.fail_on_error) {
+			for (auto row : group_rows) {
+				jobs[row].exception = std::current_exception();
+				jobs[row].error_message = ex.what();
+			}
+			if (jobs[group_start].fail_on_error) {
 				throw;
 			}
 		}
@@ -2450,8 +3005,6 @@ void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<double>(result);
 	auto &result_validity = FlatVector::Validity(result);
-	auto left_is_constant = args.data[0].GetVectorType() == VectorType::CONSTANT_VECTOR;
-	auto right_is_constant = args.data[1].GetVectorType() == VectorType::CONSTANT_VECTOR;
 	StringVectorReader left_reader(args, 0);
 	StringVectorReader right_reader(args, 1);
 	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
@@ -2492,22 +3045,13 @@ void AiSimilarityFunction(DataChunk &args, ExpressionState &state, Vector &resul
 		}
 	}
 
-	if (left_is_constant) {
-		PrecomputeConstantSimilarityEmbeddings(jobs, true);
-	}
-	if (right_is_constant) {
-		PrecomputeConstantSimilarityEmbeddings(jobs, false);
-	}
+	PrecomputeSimilarityEmbeddings(state.GetContext(), jobs);
 
 	RunProviderJobs(jobs, [&](ProviderDoubleJob &job) {
 		if (job.exception) {
 			return;
 		}
-		auto left_embedding =
-		    job.has_left_embedding ? job.left_embedding : duckdb_ai::Embed(job.left, job.options).values;
-		auto right_embedding =
-		    job.has_right_embedding ? job.right_embedding : duckdb_ai::Embed(job.right, job.options).values;
-		job.output = CosineSimilarity(left_embedding, right_embedding);
+		job.output = CosineSimilarity(job.left_embedding, job.right_embedding);
 	});
 
 	for (auto &job : jobs) {
@@ -2707,6 +3251,20 @@ unique_ptr<FunctionData> AiTaskBindInternal(ClientContext &context, ScalarFuncti
 				throw BinderException("%s supports at most two positional options: model and provider",
 				                      bound_function.name);
 			}
+			continue;
+		}
+		if (task == AiTaskKind::CLASSIFY &&
+		    (alias == "label_descriptions" || alias == "instructions" || alias == "examples")) {
+			auto value = EvaluateConstantOption(context, *arguments[i], alias, LogicalType::VARCHAR);
+			auto text = StringValue::Get(value);
+			if (alias == "label_descriptions") {
+				bind_data->label_descriptions = std::move(text);
+			} else if (alias == "instructions") {
+				bind_data->instructions = std::move(text);
+			} else {
+				bind_data->examples = std::move(text);
+			}
+			bound_function.arguments.emplace_back(LogicalType::VARCHAR);
 			continue;
 		}
 		ApplyNamedOption(context, bind_data->options, *arguments[i], alias);
@@ -2945,36 +3503,25 @@ void AiAggregateAppendBytes(AiAggregateState &state, ArenaAllocator &allocator, 
 void AiAggregateAppend(AiAggregateState &state, ArenaAllocator &allocator, const char *data, idx_t size,
                        const AiAggregateBindData &bind_data) {
 	state.row_count++;
-	if (state.size >= bind_data.max_context_chars) {
-		state.truncated = true;
-		return;
+	if (state.size > 0 && !bind_data.separator.empty()) {
+		AiAggregateAppendBytes(state, allocator, bind_data.separator.c_str(), bind_data.separator.size());
 	}
-
-	auto separator_size = state.size == 0 ? 0 : bind_data.separator.size();
-	auto available = bind_data.max_context_chars - state.size;
-	if (separator_size >= available) {
-		state.truncated = true;
-		return;
-	}
-	if (separator_size > 0) {
-		AiAggregateAppendBytes(state, allocator, bind_data.separator.c_str(), separator_size);
-		available -= separator_size;
-	}
-
-	auto append_size = MinValue<idx_t>(size, available);
-	AiAggregateAppendBytes(state, allocator, data, append_size);
-	if (append_size < size) {
-		state.truncated = true;
-	}
+	AiAggregateAppendBytes(state, allocator, data, size);
 }
 
-std::string BuildAiAggregatePrompt(const AiAggregateBindData &bind_data, const AiAggregateState &state) {
-	std::string values;
-	if (state.dataptr && state.size > 0) {
-		values.assign(state.dataptr, state.size);
-	}
+std::string BuildAiAggregatePrompt(const AiAggregateBindData &bind_data, const std::string &values, idx_t row_count,
+                                   bool intermediate) {
 	std::string prompt;
-	if (bind_data.kind == AiAggregateKind::SUMMARIZE) {
+	if (intermediate && bind_data.kind == AiAggregateKind::SUMMARIZE) {
+		prompt = "Create a compact intermediate summary of this portion of a larger SQL aggregate. Preserve facts, "
+		         "numbers, qualifications, and exceptions needed by the final summary. Return only the intermediate "
+		         "summary.\n\nInput values:\n";
+	} else if (intermediate) {
+		prompt = "Extract and compact all evidence from this portion of a larger SQL aggregate that is relevant to the "
+		         "instruction. Preserve facts, numbers, qualifications, and exceptions. Do not answer beyond the "
+		         "provided evidence. Return only the compacted evidence.\n\nInstruction:\n" +
+		         bind_data.instruction + "\n\nInput values:\n";
+	} else if (bind_data.kind == AiAggregateKind::SUMMARIZE) {
 		prompt =
 		    "Summarize the following SQL aggregate input values concisely. Return only the summary.\n\nInput values:\n";
 	} else {
@@ -2984,11 +3531,113 @@ std::string BuildAiAggregatePrompt(const AiAggregateBindData &bind_data, const A
 		    bind_data.instruction + "\n\nInput values:\n";
 	}
 	prompt += values;
-	if (state.truncated) {
-		prompt += "\n\nNote: the input values were truncated to fit the configured context limit.";
-	}
-	prompt += "\n\nInput row count: " + std::to_string(state.row_count);
+	prompt += "\n\nInput row count: " + std::to_string(row_count);
 	return prompt;
+}
+
+idx_t Utf8SafeChunkEnd(const std::string &input, idx_t start, idx_t requested_end) {
+	auto end = MinValue<idx_t>(requested_end, input.size());
+	while (end > start && end < input.size() && (static_cast<unsigned char>(input[end]) & 0xc0) == 0x80) {
+		end--;
+	}
+	return end == start ? MinValue<idx_t>(requested_end, input.size()) : end;
+}
+
+std::vector<std::string> SplitAggregateValues(const std::string &values, idx_t max_chars) {
+	std::vector<std::string> chunks;
+	for (idx_t start = 0; start < values.size();) {
+		auto end = Utf8SafeChunkEnd(values, start, start + max_chars);
+		chunks.push_back(values.substr(start, end - start));
+		start = end;
+	}
+	return chunks;
+}
+
+std::vector<std::string> PackAggregateValues(const std::vector<std::string> &values, const std::string &separator,
+                                             idx_t max_chars) {
+	std::vector<std::string> chunks;
+	std::string packed;
+	for (auto &value : values) {
+		if (value.size() > max_chars) {
+			if (!packed.empty()) {
+				chunks.push_back(std::move(packed));
+				packed.clear();
+			}
+			auto split = SplitAggregateValues(value, max_chars);
+			chunks.insert(chunks.end(), std::make_move_iterator(split.begin()), std::make_move_iterator(split.end()));
+			continue;
+		}
+		if (!packed.empty() && packed.size() + separator.size() + value.size() > max_chars) {
+			chunks.push_back(std::move(packed));
+			packed.clear();
+		}
+		if (!packed.empty()) {
+			packed += separator;
+		}
+		packed += value;
+	}
+	if (!packed.empty()) {
+		chunks.push_back(std::move(packed));
+	}
+	return chunks;
+}
+
+std::string RunHierarchicalAggregate(const AiAggregateBindData &bind_data, const std::string &values, idx_t row_count) {
+	auto root_operation_id = bind_data.options.query_id + ":aggregate";
+	if (values.size() <= bind_data.max_context_chars) {
+		auto options = bind_data.options;
+		options.parent_operation_id = root_operation_id;
+		options.operation_id = root_operation_id + ":final";
+		return duckdb_ai::Complete(BuildAiAggregatePrompt(bind_data, values, row_count, false), options).text;
+	}
+	if (bind_data.overflow_policy == "error") {
+		throw InvalidInputException("AI aggregate input has %llu bytes, exceeding max_context_chars=%llu",
+		                            static_cast<unsigned long long>(values.size()),
+		                            static_cast<unsigned long long>(bind_data.max_context_chars));
+	}
+
+	auto chunks = SplitAggregateValues(values, bind_data.max_context_chars);
+	for (idx_t level = 0; chunks.size() > 1; level++) {
+		if (level >= 32) {
+			throw InvalidInputException("AI aggregate hierarchical reduction did not converge after 32 levels");
+		}
+		std::vector<ProviderStringJob> jobs;
+		jobs.reserve(chunks.size());
+		for (idx_t i = 0; i < chunks.size(); i++) {
+			ProviderStringJob job;
+			job.row = i;
+			job.input = std::move(chunks[i]);
+			job.options = bind_data.options;
+			job.options.function_name += "_map";
+			job.options.parent_operation_id = root_operation_id;
+			job.options.operation_id = root_operation_id + ":map:" + std::to_string(level) + ":" + std::to_string(i);
+			job.fail_on_error = bind_data.options.fail_on_error;
+			jobs.push_back(std::move(job));
+		}
+		RunProviderJobs(jobs, [&](ProviderStringJob &job) {
+			job.output =
+			    duckdb_ai::Complete(BuildAiAggregatePrompt(bind_data, job.input, row_count, true), job.options).text;
+		});
+		std::vector<std::string> partials;
+		partials.reserve(jobs.size());
+		for (auto &job : jobs) {
+			if (job.exception) {
+				std::rethrow_exception(job.exception);
+			}
+			if (job.output.empty()) {
+				throw InvalidInputException("AI aggregate provider returned an empty intermediate result");
+			}
+			partials.push_back(std::move(job.output));
+		}
+		chunks = PackAggregateValues(partials, bind_data.separator, bind_data.max_context_chars);
+		if (chunks.empty()) {
+			throw InvalidInputException("AI aggregate hierarchical reduction produced no intermediate results");
+		}
+	}
+	auto options = bind_data.options;
+	options.parent_operation_id = root_operation_id;
+	options.operation_id = root_operation_id + ":final";
+	return duckdb_ai::Complete(BuildAiAggregatePrompt(bind_data, chunks[0], row_count, false), options).text;
 }
 
 struct AiAggregateOperation {
@@ -2997,7 +3646,6 @@ struct AiAggregateOperation {
 		state.size = 0;
 		state.alloc_size = 0;
 		state.row_count = 0;
-		state.truncated = false;
 		state.dataptr = nullptr;
 	}
 
@@ -3019,7 +3667,6 @@ struct AiAggregateOperation {
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		if (!source.dataptr) {
 			target.row_count += source.row_count;
-			target.truncated = target.truncated || source.truncated;
 			return;
 		}
 		auto &bind_data = aggr_input_data.bind_data->Cast<AiAggregateBindData>();
@@ -3032,7 +3679,6 @@ struct AiAggregateOperation {
 			AiAggregateAppend(target, aggr_input_data.allocator, source.dataptr, source.size, bind_data);
 			target.row_count = before_count + source.row_count;
 		}
-		target.truncated = target.truncated || source.truncated;
 	}
 
 	template <class T, class STATE>
@@ -3043,8 +3689,11 @@ struct AiAggregateOperation {
 		}
 		auto &bind_data = finalize_data.input.bind_data->Cast<AiAggregateBindData>();
 		try {
-			auto prompt = BuildAiAggregatePrompt(bind_data, state);
-			auto output = duckdb_ai::Complete(prompt, bind_data.options).text;
+			std::string values;
+			if (state.dataptr && state.size > 0) {
+				values.assign(state.dataptr, state.size);
+			}
+			auto output = RunHierarchicalAggregate(bind_data, values, state.row_count);
 			target = finalize_data.ReturnString(string_t(output));
 		} catch (std::exception &ex) {
 			if (bind_data.options.fail_on_error) {
@@ -3102,6 +3751,20 @@ std::string BuildTaskUserPrompt(AiTaskKind task, const std::string &input, const
 std::string BuildMultiLabelClassifySystemPrompt(const std::string &labels) {
 	return "Classify the following text into zero or more of these labels: " + labels +
 	       ". Return only a JSON array of chosen labels. Use [] when none apply.";
+}
+
+std::string BuildClassificationGuidance(const AiTaskBindData &bind_data) {
+	std::string guidance;
+	if (!bind_data.label_descriptions.empty()) {
+		guidance += "\nLabel descriptions:\n" + bind_data.label_descriptions;
+	}
+	if (!bind_data.instructions.empty()) {
+		guidance += "\nAdditional classification instructions:\n" + bind_data.instructions;
+	}
+	if (!bind_data.examples.empty()) {
+		guidance += "\nExamples:\n" + bind_data.examples;
+	}
+	return guidance;
 }
 
 bool IsAsciiWhitespace(char c) {
@@ -3598,7 +4261,11 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 			job.output = duckdb_ai::Redact(job.input, job.options).text;
 			return;
 		}
-		AppendSystemPrompt(job.options, BuildTaskSystemPrompt(bind_data.task, job.parameter));
+		auto system_prompt = BuildTaskSystemPrompt(bind_data.task, job.parameter);
+		if (bind_data.task == AiTaskKind::CLASSIFY) {
+			system_prompt += BuildClassificationGuidance(bind_data);
+		}
+		AppendSystemPrompt(job.options, system_prompt);
 		auto prompt = BuildTaskUserPrompt(bind_data.task, job.input, job.parameter);
 		job.output = duckdb_ai::Complete(prompt, job.options).text;
 	});
@@ -3676,7 +4343,8 @@ void AiClassifyLabelsFunction(DataChunk &args, ExpressionState &state, Vector &r
 	}
 
 	RunProviderJobs(jobs, [&](ProviderStringListJob &job) {
-		AppendSystemPrompt(job.options, BuildMultiLabelClassifySystemPrompt(job.parameter));
+		AppendSystemPrompt(job.options,
+		                   BuildMultiLabelClassifySystemPrompt(job.parameter) + BuildClassificationGuidance(bind_data));
 		auto prompt = BuildTaskUserPrompt(AiTaskKind::CLASSIFY, job.input, job.parameter);
 		auto output = StripMarkdownJsonFence(duckdb_ai::Complete(prompt, job.options).text);
 		std::string error;
@@ -3705,6 +4373,493 @@ void AiClassifyLabelsFunction(DataChunk &args, ExpressionState &state, Vector &r
 		}
 	}
 }
+
+LogicalType AiClassifyResultReturnType() {
+	child_list_t<LogicalType> children;
+	children.emplace_back("value", LogicalType::LIST(LogicalType::VARCHAR));
+	children.emplace_back("error", LogicalType::VARCHAR);
+	children.emplace_back("metadata", LogicalType::VARCHAR);
+	return LogicalType::STRUCT(std::move(children));
+}
+
+unique_ptr<FunctionData> AiClassifyResultBind(ClientContext &context, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = AiClassifyLabelsBind(context, bound_function, arguments);
+	auto &task_bind_data = bind_data->Cast<AiTaskBindData>();
+	task_bind_data.options.on_error = "capture";
+	task_bind_data.options.fail_on_error = false;
+	bound_function.SetReturnType(AiClassifyResultReturnType());
+	return bind_data;
+}
+
+std::string JsonEscapeSqlText(const std::string &input) {
+	std::string output;
+	for (auto c : input) {
+		switch (c) {
+		case '\\':
+			output += "\\\\";
+			break;
+		case '"':
+			output += "\\\"";
+			break;
+		case '\n':
+			output += "\\n";
+			break;
+		case '\r':
+			output += "\\r";
+			break;
+		case '\t':
+			output += "\\t";
+			break;
+		default:
+			output.push_back(c);
+			break;
+		}
+	}
+	return output;
+}
+
+Value AiClassifyResultValue(const LogicalType &result_type, const std::vector<std::string> &labels,
+                            const std::string &error, const std::string &metadata) {
+	vector<Value> children;
+	if (error.empty()) {
+		vector<Value> label_values;
+		for (auto &label : labels) {
+			label_values.emplace_back(label);
+		}
+		children.push_back(Value::LIST(LogicalType::VARCHAR, std::move(label_values)));
+		children.emplace_back(LogicalType::VARCHAR);
+		children.emplace_back(metadata);
+	} else {
+		children.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
+		children.emplace_back(error);
+		children.emplace_back(LogicalType::VARCHAR);
+	}
+	return Value::STRUCT(result_type, std::move(children));
+}
+
+void AiClassifyResultFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &bind_data = func_expr.bind_info->Cast<AiTaskBindData>();
+	auto result_type = AiClassifyResultReturnType();
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, 0);
+	auto label_reader = OptionalStringReader(args, !bind_data.parameter_is_label_list, 1);
+	unique_ptr<StringListVectorReader> label_list_reader;
+	if (bind_data.parameter_is_label_list) {
+		label_list_reader = make_uniq<StringListVectorReader>(args, 1);
+	}
+	auto model_reader = OptionalStringReader(args, bind_data.has_model_arg, bind_data.model_index);
+	auto provider_reader = OptionalStringReader(args, bind_data.has_provider_arg, bind_data.provider_index);
+	std::vector<ProviderStringListJob> jobs;
+	std::vector<SecretResolutionCacheEntry> secret_cache;
+	for (idx_t row = 0; row < args.size(); row++) {
+		std::string input;
+		std::string labels;
+		auto read_labels =
+		    bind_data.parameter_is_label_list ? label_list_reader->Read(row, labels) : label_reader->Read(row, labels);
+		if (!input_reader.Read(row, input) || !read_labels) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+		duckdb_ai::CompletionOptions options;
+		if (!ReadRuntimeOptions(state.GetContext(), bind_data.options, bind_data.has_model_arg, model_reader.get(),
+		                        bind_data.has_provider_arg, provider_reader.get(), row, options)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
+		try {
+			ApplyAiProviderSecretCached(state.GetContext(), options, secret_cache);
+			ProviderStringListJob job;
+			job.row = row;
+			job.options = options;
+			job.fail_on_error = false;
+			job.input = std::move(input);
+			job.parameter = std::move(labels);
+			jobs.push_back(std::move(job));
+		} catch (std::exception &ex) {
+			result.SetValue(row, AiClassifyResultValue(result_type, {}, ex.what(), ""));
+		}
+	}
+	RunProviderJobs(jobs, [&](ProviderStringListJob &job) {
+		AppendSystemPrompt(job.options,
+		                   BuildMultiLabelClassifySystemPrompt(job.parameter) + BuildClassificationGuidance(bind_data));
+		auto output = StripMarkdownJsonFence(
+		    duckdb_ai::Complete(BuildTaskUserPrompt(AiTaskKind::CLASSIFY, job.input, job.parameter), job.options).text);
+		std::string error;
+		if (!duckdb_ai::ExtractJsonStringArray(output, job.output, error)) {
+			throw InvalidInputException("ai_classify_result expected a JSON array of strings: %s", error);
+		}
+	});
+	for (auto &job : jobs) {
+		if (job.exception) {
+			result.SetValue(job.row, AiClassifyResultValue(result_type, {}, job.error_message, ""));
+			continue;
+		}
+		auto config = duckdb_ai::ResolveProvider(job.options);
+		auto metadata = "{\"provider\":\"" + JsonEscapeSqlText(config.provider) + "\",\"model\":\"" +
+		                JsonEscapeSqlText(config.model) + "\",\"multi_label\":true}";
+		result.SetValue(job.row, AiClassifyResultValue(result_type, job.output, "", metadata));
+	}
+}
+
+std::vector<std::string> ReadClassifierLabels(ClientContext &context, Expression &expression) {
+	if (expression.return_type.id() != LogicalTypeId::LIST) {
+		throw BinderException("ai_build_classifier labels must be a constant VARCHAR[]");
+	}
+	auto value = EvaluateConstantOption(context, expression, "labels", LogicalType::LIST(LogicalType::VARCHAR));
+	std::vector<std::string> labels;
+	std::set<std::string> seen;
+	for (auto &child : ListValue::GetChildren(value)) {
+		if (child.IsNull()) {
+			throw BinderException("ai_build_classifier labels must not contain NULL");
+		}
+		auto label_value = child;
+		auto label = StringValue::Get(label_value.DefaultCastAs(LogicalType::VARCHAR));
+		if (label.empty() || !seen.insert(LowerAscii(label)).second) {
+			throw BinderException("ai_build_classifier labels must be non-empty and unique");
+		}
+		labels.push_back(std::move(label));
+	}
+	if (labels.size() < 2) {
+		throw BinderException("ai_build_classifier requires at least two labels");
+	}
+	return labels;
+}
+
+unique_ptr<FunctionData> ClassifierBuildBind(ClientContext &context, AggregateFunction &function,
+                                             vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() < 2) {
+		throw BinderException("ai_build_classifier requires input text and a constant VARCHAR[] label list");
+	}
+	auto bind_data = make_uniq<ClassifierBuildBindData>();
+	ApplySettings(context, bind_data->label_options, AiModelSettingKind::TASK);
+	ApplySettings(context, bind_data->embedding_options, AiModelSettingKind::EMBEDDING);
+	StampProviderFunction(bind_data->label_options, "ai_build_classifier_label");
+	StampProviderFunction(bind_data->embedding_options, "ai_build_classifier_embed");
+	duckdb_ai::AttachProviderRuntimeState(bind_data->label_options, context);
+	duckdb_ai::AttachProviderRuntimeState(bind_data->embedding_options, context);
+	bind_data->labels = ReadClassifierLabels(context, *arguments[1]);
+	vector<idx_t> erase_indexes {1};
+	for (idx_t i = 2; i < arguments.size(); i++) {
+		auto alias = LowerAscii(arguments[i]->GetAlias());
+		if (alias.empty()) {
+			throw BinderException("ai_build_classifier options must use named arguments");
+		}
+		if (alias == "optimization") {
+			auto value = LowerAscii(EvaluateConstantString(context, *arguments[i], alias));
+			if (value != "minimize_cost") {
+				throw BinderException("ai_build_classifier optimization must be minimize_cost");
+			}
+		} else if (alias == "sample_size") {
+			auto value = EvaluateConstantOption(context, *arguments[i], alias, LogicalType::BIGINT);
+			auto sample_size = BigIntValue::Get(value);
+			if (sample_size < 8 || sample_size > 10000) {
+				throw BinderException("ai_build_classifier sample_size must be between 8 and 10000");
+			}
+			bind_data->sample_size = NumericCast<idx_t>(sample_size);
+		} else if (alias == "quality_threshold" || alias == "confidence_margin") {
+			auto value = EvaluateConstantOption(context, *arguments[i], alias, LogicalType::DOUBLE);
+			auto number = DoubleValue::Get(value);
+			if (!std::isfinite(number) || number < 0 || number > 1) {
+				throw BinderException("ai_build_classifier %s must be between 0 and 1", alias);
+			}
+			if (alias == "quality_threshold") {
+				bind_data->quality_threshold = number;
+			} else {
+				bind_data->confidence_margin = number;
+			}
+		} else if (alias == "embedding_model" || alias == "embedding_provider" || alias == "embedding_profile") {
+			auto value = EvaluateConstantString(context, *arguments[i], alias);
+			if (alias == "embedding_model") {
+				bind_data->embedding_options.model = value;
+				bind_data->embedding_options.explicit_model = true;
+			} else if (alias == "embedding_provider") {
+				bind_data->embedding_options.provider = value;
+				bind_data->embedding_options.explicit_provider = true;
+			} else {
+				bind_data->embedding_options.secret_name = value;
+			}
+		} else {
+			ApplyNamedOption(context, bind_data->label_options, *arguments[i], alias);
+		}
+		erase_indexes.push_back(i);
+	}
+	ApplyAiProviderSecret(context, bind_data->label_options);
+	ApplyAiProviderSecret(context, bind_data->embedding_options);
+	for (idx_t offset = erase_indexes.size(); offset > 0; offset--) {
+		Function::EraseArgument(function, arguments, erase_indexes[offset - 1]);
+	}
+	function.SetReturnType(LogicalType::VARCHAR);
+	return std::move(bind_data);
+}
+
+void ClassifierEnsureCapacity(ClassifierBuildState &state, ArenaAllocator &allocator, idx_t required_size) {
+	if (state.alloc_size >= required_size) {
+		return;
+	}
+	auto new_size = state.alloc_size == 0 ? MaxValue<idx_t>(64, required_size) : state.alloc_size;
+	while (new_size < required_size) {
+		new_size *= 2;
+	}
+	if (!state.dataptr) {
+		state.dataptr = char_ptr_cast(allocator.Allocate(new_size));
+	} else {
+		state.dataptr = char_ptr_cast(allocator.Reallocate(data_ptr_cast(state.dataptr), state.alloc_size, new_size));
+	}
+	state.alloc_size = new_size;
+}
+
+void ClassifierAppendSample(ClassifierBuildState &state, ArenaAllocator &allocator, const char *data, idx_t size,
+                            idx_t sample_size) {
+	state.row_count++;
+	if (state.sample_count >= sample_size) {
+		return;
+	}
+	ClassifierEnsureCapacity(state, allocator, state.size + sizeof(uint64_t) + size);
+	auto length = static_cast<uint64_t>(size);
+	memcpy(state.dataptr + state.size, &length, sizeof(uint64_t));
+	state.size += sizeof(uint64_t);
+	memcpy(state.dataptr + state.size, data, size);
+	state.size += size;
+	state.sample_count++;
+}
+
+std::vector<std::string> ClassifierSamples(const ClassifierBuildState &state) {
+	std::vector<std::string> samples;
+	idx_t offset = 0;
+	while (offset + sizeof(uint64_t) <= state.size && samples.size() < state.sample_count) {
+		uint64_t length;
+		memcpy(&length, state.dataptr + offset, sizeof(uint64_t));
+		offset += sizeof(uint64_t);
+		if (length > state.size - offset) {
+			throw InternalException("ai_build_classifier aggregate state is corrupt");
+		}
+		samples.emplace_back(state.dataptr + offset, NumericCast<idx_t>(length));
+		offset += NumericCast<idx_t>(length);
+	}
+	return samples;
+}
+
+std::string JoinClassifierLabels(const std::vector<std::string> &labels) {
+	std::string result;
+	for (idx_t i = 0; i < labels.size(); i++) {
+		if (i > 0) {
+			result += ", ";
+		}
+		result += labels[i];
+	}
+	return result;
+}
+
+idx_t ClassifierLabelIndex(const std::vector<std::string> &labels, const std::string &input) {
+	auto normalized = LowerAscii(TrimAscii(StripMarkdownJsonFence(input)));
+	if (normalized.size() >= 2 && normalized.front() == '"' && normalized.back() == '"') {
+		normalized = normalized.substr(1, normalized.size() - 2);
+	}
+	for (idx_t i = 0; i < labels.size(); i++) {
+		if (LowerAscii(labels[i]) == normalized) {
+			return i;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+std::string BuildClassifierArtifact(const ClassifierBuildBindData &bind_data, const ClassifierBuildState &state) {
+	auto samples = ClassifierSamples(state);
+	std::vector<ProviderStringJob> label_jobs;
+	for (idx_t i = 0; i < samples.size(); i++) {
+		ProviderStringJob job;
+		job.row = i;
+		job.input = samples[i];
+		job.options = bind_data.label_options;
+		job.fail_on_error = bind_data.label_options.fail_on_error;
+		label_jobs.push_back(std::move(job));
+	}
+	auto labels_text = JoinClassifierLabels(bind_data.labels);
+	RunProviderJobs(label_jobs, [&](ProviderStringJob &job) {
+		AppendSystemPrompt(job.options, BuildTaskSystemPrompt(AiTaskKind::CLASSIFY, labels_text));
+		job.output =
+		    duckdb_ai::Complete(BuildTaskUserPrompt(AiTaskKind::CLASSIFY, job.input, labels_text), job.options).text;
+	});
+	std::vector<std::string> labelled_samples;
+	std::vector<idx_t> labelled_classes;
+	for (auto &job : label_jobs) {
+		if (job.exception) {
+			if (job.fail_on_error) {
+				std::rethrow_exception(job.exception);
+			}
+			continue;
+		}
+		auto label_index = ClassifierLabelIndex(bind_data.labels, job.output);
+		if (label_index == DConstants::INVALID_INDEX) {
+			if (job.fail_on_error) {
+				throw InvalidInputException("ai_build_classifier received an unknown label: %s", job.output);
+			}
+			continue;
+		}
+		labelled_samples.push_back(std::move(job.input));
+		labelled_classes.push_back(label_index);
+	}
+	if (labelled_samples.empty()) {
+		throw InvalidInputException("ai_build_classifier could not label any sampled rows");
+	}
+	auto embeddings = duckdb_ai::EmbedMany(labelled_samples, bind_data.embedding_options);
+	auto dimensions = embeddings.empty() ? 0 : embeddings[0].values.size();
+	std::vector<idx_t> class_totals(bind_data.labels.size(), 0);
+	for (auto label : labelled_classes) {
+		class_totals[label]++;
+	}
+	std::vector<bool> validation_rows(embeddings.size(), false);
+	for (idx_t i = 0; i < embeddings.size(); i++) {
+		validation_rows[i] = i % 5 == 0 && class_totals[labelled_classes[i]] > 1;
+	}
+	std::vector<std::vector<double>> centroids(bind_data.labels.size(), std::vector<double>(dimensions, 0));
+	std::vector<idx_t> counts(bind_data.labels.size(), 0);
+	for (idx_t i = 0; i < embeddings.size(); i++) {
+		if (embeddings[i].values.size() != dimensions) {
+			throw InvalidInputException("ai_build_classifier embedding dimensions are inconsistent");
+		}
+		if (validation_rows[i]) {
+			continue;
+		}
+		counts[labelled_classes[i]]++;
+		for (idx_t dimension = 0; dimension < dimensions; dimension++) {
+			centroids[labelled_classes[i]][dimension] += embeddings[i].values[dimension];
+		}
+	}
+	for (idx_t label = 0; label < centroids.size(); label++) {
+		if (counts[label] == 0) {
+			continue;
+		}
+		for (auto &value : centroids[label]) {
+			value /= static_cast<double>(counts[label]);
+		}
+	}
+	idx_t correct = 0;
+	idx_t evaluated = 0;
+	for (idx_t i = 0; i < embeddings.size(); i++) {
+		if (!validation_rows[i]) {
+			continue;
+		}
+		double best_score = -std::numeric_limits<double>::infinity();
+		idx_t best_label = DConstants::INVALID_INDEX;
+		for (idx_t label = 0; label < centroids.size(); label++) {
+			if (counts[label] == 0) {
+				continue;
+			}
+			auto score = CosineSimilarity(embeddings[i].values, centroids[label]);
+			if (score > best_score) {
+				best_score = score;
+				best_label = label;
+			}
+		}
+		correct += best_label == labelled_classes[i] ? 1 : 0;
+		evaluated++;
+	}
+	auto accuracy = evaluated == 0 ? 0 : static_cast<double>(correct) / static_cast<double>(evaluated);
+	auto all_classes_present = std::all_of(counts.begin(), counts.end(), [](idx_t count) { return count > 0; });
+	auto usable = all_classes_present && accuracy >= bind_data.quality_threshold;
+	auto embedding_config = duckdb_ai::ResolveProvider(bind_data.embedding_options);
+	std::ostringstream artifact;
+	artifact << std::setprecision(17);
+	artifact << "{\"version\":1,\"optimization\":\"minimize_cost\",\"usable\":" << (usable ? "true" : "false")
+	         << ",\"accuracy\":" << accuracy << ",\"quality_threshold\":" << bind_data.quality_threshold
+	         << ",\"validation_count\":" << evaluated << ",\"confidence_margin\":" << bind_data.confidence_margin
+	         << ",\"sample_count\":" << labelled_samples.size() << ",\"total_count\":" << state.row_count
+	         << ",\"embedding\":{\"provider\":\"" << JsonEscapeSqlText(embedding_config.provider) << "\",\"model\":\""
+	         << JsonEscapeSqlText(embedding_config.model) << "\",\"profile\":\""
+	         << JsonEscapeSqlText(bind_data.embedding_options.secret_name) << "\",\"base_url\":\""
+	         << JsonEscapeSqlText(bind_data.embedding_options.base_url) << "\",\"options\":\""
+	         << JsonEscapeSqlText(bind_data.embedding_options.model_options) << "\"},\"labels\":[";
+	for (idx_t label = 0; label < bind_data.labels.size(); label++) {
+		if (label > 0) {
+			artifact << ',';
+		}
+		artifact << '"' << JsonEscapeSqlText(bind_data.labels[label]) << '"';
+	}
+	artifact << "],\"centroids\":[";
+	for (idx_t label = 0; label < centroids.size(); label++) {
+		if (label > 0) {
+			artifact << ',';
+		}
+		artifact << '[';
+		for (idx_t dimension = 0; dimension < centroids[label].size(); dimension++) {
+			if (dimension > 0) {
+				artifact << ',';
+			}
+			artifact << centroids[label][dimension];
+		}
+		artifact << ']';
+	}
+	artifact << "]}";
+	return artifact.str();
+}
+
+struct ClassifierBuildOperation {
+	template <class STATE>
+	static void Initialize(STATE &state) {
+		state.size = 0;
+		state.alloc_size = 0;
+		state.sample_count = 0;
+		state.row_count = 0;
+		state.dataptr = nullptr;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
+		auto &bind_data = unary_input.input.bind_data->Cast<ClassifierBuildBindData>();
+		ClassifierAppendSample(state, unary_input.input.allocator, input.GetData(), input.GetSize(),
+		                       bind_data.sample_size);
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggregate_input) {
+		auto &bind_data = aggregate_input.bind_data->Cast<ClassifierBuildBindData>();
+		auto samples = ClassifierSamples(source);
+		target.row_count += source.row_count;
+		for (auto &sample : samples) {
+			if (target.sample_count >= bind_data.sample_size) {
+				break;
+			}
+			auto before = target.row_count;
+			ClassifierAppendSample(target, aggregate_input.allocator, sample.data(), sample.size(),
+			                       bind_data.sample_size);
+			target.row_count = before;
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (state.row_count == 0) {
+			finalize_data.ReturnNull();
+			return;
+		}
+		auto &bind_data = finalize_data.input.bind_data->Cast<ClassifierBuildBindData>();
+		try {
+			auto artifact = BuildClassifierArtifact(bind_data, state);
+			target = finalize_data.ReturnString(string_t(artifact));
+		} catch (std::exception &) {
+			if (bind_data.label_options.fail_on_error) {
+				throw;
+			}
+			finalize_data.ReturnNull();
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
 
 bool ParseAiBooleanResult(const std::string &input, bool &value) {
 	auto normalized = LowerAscii(TrimAscii(input));
@@ -4887,6 +6042,1275 @@ void AiSecretsFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &o
 	output.SetCardinality(count);
 }
 
+unique_ptr<FunctionData> AiModelsBind(ClientContext &, TableFunctionBindInput &, vector<LogicalType> &return_types,
+                                      vector<string> &names) {
+	AddTableColumns(return_types, names,
+	                {{"name", LogicalType::VARCHAR},
+	                 {"provider", LogicalType::VARCHAR},
+	                 {"model", LogicalType::VARCHAR},
+	                 {"location", LogicalType::VARCHAR},
+	                 {"credential", LogicalType::VARCHAR},
+	                 {"model_type", LogicalType::VARCHAR},
+	                 {"capabilities", LogicalType::VARCHAR},
+	                 {"options", LogicalType::VARCHAR},
+	                 {"max_batch_inputs", LogicalType::BIGINT},
+	                 {"max_batch_tokens", LogicalType::BIGINT},
+	                 {"max_request_bytes", LogicalType::BIGINT},
+	                 {"context_tokens", LogicalType::BIGINT},
+	                 {"embedding_dimensions", LogicalType::BIGINT},
+	                 {"native_batch_jobs", LogicalType::BOOLEAN},
+	                 {"input_token_price_per_million", LogicalType::DOUBLE},
+	                 {"output_token_price_per_million", LogicalType::DOUBLE},
+	                 {"storage", LogicalType::VARCHAR},
+	                 {"persistent", LogicalType::BOOLEAN},
+	                 {"validation_status", LogicalType::VARCHAR}});
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> AiModelsInit(ClientContext &context, TableFunctionInitInput &) {
+	auto result = make_uniq<AiModelsScanData>();
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	result->models = SecretManager::Get(context).AllSecrets(transaction);
+	return std::move(result);
+}
+
+void AiModelsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<AiModelsScanData>();
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	auto &secret_manager = SecretManager::Get(context);
+	idx_t count = 0;
+	while (data.offset < data.models.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.models[data.offset++];
+		if (!entry.secret || entry.secret->GetType() != "duckdb_ai_model") {
+			continue;
+		}
+		auto secret = dynamic_cast<const KeyValueSecret *>(entry.secret.get());
+		if (!secret) {
+			continue;
+		}
+		std::string provider;
+		std::string model;
+		std::string location;
+		std::string credential;
+		std::string model_type;
+		std::string capabilities;
+		std::string options;
+		TryReadSecretString(*secret, "provider", provider);
+		TryReadSecretString(*secret, "model", model);
+		TryReadSecretString(*secret, "location", location);
+		TryReadSecretString(*secret, "credential", credential);
+		TryReadSecretString(*secret, "model_type", model_type);
+		TryReadSecretString(*secret, "capabilities", capabilities);
+		TryReadSecretString(*secret, "options", options);
+		std::string validation_status = "valid";
+		duckdb_ai::ProviderCapabilities runtime_capabilities;
+		bool has_runtime_capabilities = false;
+		duckdb_ai::CompletionOptions inspected_options;
+		try {
+			inspected_options.provider = provider;
+			inspected_options.model = model;
+			inspected_options.base_url = location;
+			inspected_options.model_options = options;
+			duckdb_ai::ApplyModelProfileOptions(inspected_options);
+			runtime_capabilities = duckdb_ai::GetProviderCapabilities(inspected_options);
+			has_runtime_capabilities = true;
+			if (!credential.empty()) {
+				auto credential_entry = secret_manager.GetSecretByName(transaction, credential);
+				if (!credential_entry || !credential_entry->secret ||
+				    credential_entry->secret->GetType() != "duckdb_ai") {
+					validation_status = "missing_credential";
+				}
+			}
+		} catch (std::exception &ex) {
+			validation_status = "invalid: " + std::string(ex.what());
+		}
+		double input_price = -1;
+		double output_price = -1;
+		if (inspected_options.has_input_token_price_per_million) {
+			input_price = inspected_options.input_token_price_per_million;
+		}
+		if (inspected_options.has_output_token_price_per_million) {
+			output_price = inspected_options.output_token_price_per_million;
+		}
+		if (input_price < 0 || output_price < 0) {
+			auto operation =
+			    model_type == "embedding" || LowerAscii(capabilities).find("embedding") != std::string::npos
+			        ? std::string("embedding")
+			        : std::string("completion");
+			for (auto &price : duckdb_ai::ModelPrices()) {
+				if (duckdb_ai::NormalizeProviderName(price.provider) == duckdb_ai::NormalizeProviderName(provider) &&
+				    LowerAscii(price.model) == LowerAscii(model) && price.operation == operation) {
+					if (input_price < 0) {
+						input_price = price.input_token_price_per_million;
+					}
+					if (output_price < 0) {
+						output_price = price.output_token_price_per_million;
+					}
+					break;
+				}
+			}
+		}
+		auto name = entry.secret->GetName();
+		auto prefix = ExternalModelSecretName("");
+		if (StartsWith(name, prefix)) {
+			name = name.substr(prefix.size());
+		}
+		idx_t col = 0;
+		output.SetValue(col++, count, Value(name));
+		output.SetValue(col++, count, Value(provider));
+		output.SetValue(col++, count, Value(model));
+		output.SetValue(col++, count, location.empty() ? Value() : Value(location));
+		output.SetValue(col++, count, credential.empty() ? Value() : Value(credential));
+		output.SetValue(col++, count, model_type.empty() ? Value() : Value(model_type));
+		output.SetValue(col++, count, capabilities.empty() ? Value() : Value(capabilities));
+		output.SetValue(col++, count, options.empty() ? Value() : Value(options));
+		output.SetValue(col++, count,
+		                has_runtime_capabilities ? Value::BIGINT(runtime_capabilities.max_batch_inputs) : Value());
+		output.SetValue(col++, count,
+		                has_runtime_capabilities ? Value::BIGINT(runtime_capabilities.max_batch_tokens) : Value());
+		output.SetValue(col++, count,
+		                has_runtime_capabilities ? Value::BIGINT(runtime_capabilities.max_request_bytes) : Value());
+		output.SetValue(col++, count,
+		                has_runtime_capabilities && runtime_capabilities.context_tokens >= 0
+		                    ? Value::BIGINT(runtime_capabilities.context_tokens)
+		                    : Value());
+		output.SetValue(col++, count,
+		                has_runtime_capabilities && runtime_capabilities.embedding_dimensions >= 0
+		                    ? Value::BIGINT(runtime_capabilities.embedding_dimensions)
+		                    : Value());
+		output.SetValue(col++, count,
+		                has_runtime_capabilities ? Value::BOOLEAN(runtime_capabilities.native_batch_jobs) : Value());
+		output.SetValue(col++, count, input_price >= 0 ? Value::DOUBLE(input_price) : Value());
+		output.SetValue(col++, count, output_price >= 0 ? Value::DOUBLE(output_price) : Value());
+		output.SetValue(col++, count, Value(entry.storage_mode));
+		output.SetValue(col++, count, Value::BOOLEAN(entry.persist_type == SecretPersistType::PERSISTENT));
+		output.SetValue(col++, count, Value(validation_status));
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+std::string ExternalModelInputString(const Value &input) {
+	if (input.IsNull()) {
+		return "";
+	}
+	auto value = input;
+	return StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
+}
+
+unique_ptr<FunctionData> ExternalModelBind(ClientContext &, TableFunctionBindInput &input,
+                                           vector<LogicalType> &return_types, vector<string> &names) {
+	if (input.inputs.size() != 9) {
+		throw BinderException("CREATE EXTERNAL MODEL internal plan expected nine arguments");
+	}
+	auto bind_data = make_uniq<ExternalModelBindData>();
+	bind_data->name = ExternalModelInputString(input.inputs[0]);
+	bind_data->provider = duckdb_ai::NormalizeProviderName(ExternalModelInputString(input.inputs[1]));
+	bind_data->model = ExternalModelInputString(input.inputs[2]);
+	bind_data->location = ExternalModelInputString(input.inputs[3]);
+	bind_data->credential = ExternalModelInputString(input.inputs[4]);
+	bind_data->model_type = LowerAscii(ExternalModelInputString(input.inputs[5]));
+	bind_data->capabilities = ExternalModelInputString(input.inputs[6]);
+	bind_data->options = ExternalModelInputString(input.inputs[7]);
+	auto replace_value = input.inputs[8].DefaultCastAs(LogicalType::BOOLEAN);
+	bind_data->replace = BooleanValue::Get(replace_value);
+	if (bind_data->name.empty() || bind_data->provider.empty() || bind_data->model.empty()) {
+		throw BinderException("CREATE EXTERNAL MODEL requires a name, provider, and model");
+	}
+	if (!bind_data->options.empty()) {
+		std::string error;
+		if (!duckdb_ai::ValidateJsonDocument(bind_data->options, error)) {
+			throw BinderException("CREATE EXTERNAL MODEL options must be valid JSON: %s", error);
+		}
+	}
+	AddTableColumns(return_types, names, {{"model_name", LogicalType::VARCHAR}, {"created", LogicalType::BOOLEAN}});
+	return std::move(bind_data);
+}
+
+void ExternalModelFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<AiClearUsageScanData>();
+	if (state.emitted) {
+		return;
+	}
+	auto &bind_data = data_p.bind_data->Cast<ExternalModelBindData>();
+	CreateSecretInput input;
+	input.type = "duckdb_ai_model";
+	input.provider = "config";
+	input.name = ExternalModelSecretName(bind_data.name);
+	input.on_conflict = bind_data.replace ? OnCreateConflict::REPLACE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
+	input.persist_type = SecretPersistType::DEFAULT;
+	input.options["ai_provider"] = Value(bind_data.provider);
+	input.options["model"] = Value(bind_data.model);
+	if (!bind_data.location.empty()) {
+		input.options["location"] = Value(bind_data.location);
+	}
+	if (!bind_data.credential.empty()) {
+		input.options["credential"] = Value(bind_data.credential);
+	}
+	if (!bind_data.model_type.empty()) {
+		input.options["model_type"] = Value(bind_data.model_type);
+	}
+	if (!bind_data.capabilities.empty()) {
+		input.options["capabilities"] = Value(bind_data.capabilities);
+	}
+	if (!bind_data.options.empty()) {
+		input.options["options"] = Value(bind_data.options);
+	}
+	SecretManager::Get(context).CreateSecret(context, input);
+	output.SetValue(0, 0, Value(bind_data.name));
+	output.SetValue(1, 0, Value::BOOLEAN(true));
+	output.SetCardinality(1);
+	state.emitted = true;
+}
+
+TableFunction ExternalModelTableFunction() {
+	auto init = [](ClientContext &, TableFunctionInitInput &) -> unique_ptr<GlobalTableFunctionState> {
+		return make_uniq<AiClearUsageScanData>();
+	};
+	return TableFunction("duckdb_ai_create_external_model",
+	                     {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                      LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                      LogicalType::BOOLEAN},
+	                     ExternalModelFunction, ExternalModelBind, init);
+}
+
+struct ExternalModelDefinition {
+	std::string name;
+	std::string provider;
+	std::string model;
+	std::string location;
+	std::string credential;
+	std::string model_type;
+	std::string capabilities;
+	std::string options;
+};
+
+ExternalModelDefinition GetExternalModel(ClientContext &context, const std::string &name) {
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	auto entry = SecretManager::Get(context).GetSecretByName(transaction, ExternalModelSecretName(name));
+	if (!entry || !entry->secret || entry->secret->GetType() != "duckdb_ai_model") {
+		throw InvalidInputException("External model \"%s\" was not found", name);
+	}
+	auto secret = dynamic_cast<const KeyValueSecret *>(entry->secret.get());
+	if (!secret) {
+		throw InternalException("External model \"%s\" has an invalid catalog representation", name);
+	}
+	ExternalModelDefinition result;
+	result.name = name;
+	TryReadSecretString(*secret, "provider", result.provider);
+	TryReadSecretString(*secret, "model", result.model);
+	TryReadSecretString(*secret, "location", result.location);
+	TryReadSecretString(*secret, "credential", result.credential);
+	TryReadSecretString(*secret, "model_type", result.model_type);
+	TryReadSecretString(*secret, "capabilities", result.capabilities);
+	TryReadSecretString(*secret, "options", result.options);
+	return result;
+}
+
+unique_ptr<FunctionData> ControlPlaneBind(ClientContext &context, TableFunctionBindInput &input,
+                                          vector<LogicalType> &return_types, vector<string> &names,
+                                          ControlPlaneOperation operation) {
+	if (input.inputs.size() != 1 || input.inputs[0].IsNull()) {
+		throw BinderException("AI control-plane functions require one non-NULL profile or operation id");
+	}
+	auto bind_data = make_uniq<ControlPlaneBindData>(operation);
+	bind_data->argument = ExternalModelInputString(input.inputs[0]);
+	ApplySettings(context, bind_data->options);
+	duckdb_ai::AttachProviderRuntimeState(bind_data->options, context);
+	if (operation == ControlPlaneOperation::PROVISION) {
+		for (auto &parameter : input.named_parameters) {
+			auto name = LowerAscii(parameter.first);
+			auto value = parameter.second;
+			if (name == "dry_run") {
+				value = value.DefaultCastAs(LogicalType::BOOLEAN);
+				bind_data->dry_run = BooleanValue::Get(value);
+			} else if (name == "max_hourly_cost_usd") {
+				value = value.DefaultCastAs(LogicalType::DOUBLE);
+				bind_data->max_hourly_cost_usd = DoubleValue::Get(value);
+				bind_data->has_max_hourly_cost = true;
+			} else {
+				throw BinderException("Unsupported ai_provision_endpoint option \"%s\"", name);
+			}
+		}
+		if (!bind_data->dry_run && (!bind_data->has_max_hourly_cost || !std::isfinite(bind_data->max_hourly_cost_usd) ||
+		                            bind_data->max_hourly_cost_usd <= 0)) {
+			throw BinderException("ai_provision_endpoint requires max_hourly_cost_usd > 0 when dry_run is false");
+		}
+	}
+	AddTableColumns(return_types, names,
+	                {{"operation_id", LogicalType::VARCHAR},
+	                 {"status", LogicalType::VARCHAR},
+	                 {"endpoint_url", LogicalType::VARCHAR},
+	                 {"estimated_hourly_cost_usd", LogicalType::DOUBLE},
+	                 {"action_required", LogicalType::VARCHAR},
+	                 {"response", LogicalType::VARCHAR}});
+	return std::move(bind_data);
+}
+
+unique_ptr<FunctionData> ProvisionEndpointBind(ClientContext &context, TableFunctionBindInput &input,
+                                               vector<LogicalType> &return_types, vector<string> &names) {
+	return ControlPlaneBind(context, input, return_types, names, ControlPlaneOperation::PROVISION);
+}
+
+unique_ptr<FunctionData> EndpointStatusBind(ClientContext &context, TableFunctionBindInput &input,
+                                            vector<LogicalType> &return_types, vector<string> &names) {
+	return ControlPlaneBind(context, input, return_types, names, ControlPlaneOperation::STATUS);
+}
+
+unique_ptr<FunctionData> DeprovisionEndpointBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	return ControlPlaneBind(context, input, return_types, names, ControlPlaneOperation::DEPROVISION);
+}
+
+using SqlYyjsonDoc = std::unique_ptr<duckdb_yyjson::yyjson_doc, decltype(&duckdb_yyjson::yyjson_doc_free)>;
+
+SqlYyjsonDoc ParseSqlJson(const std::string &input) {
+	duckdb_yyjson::yyjson_read_err error;
+	auto doc = duckdb_yyjson::yyjson_read_opts(const_cast<char *>(input.data()), input.size(),
+	                                           duckdb_yyjson::YYJSON_READ_NOFLAG, nullptr, &error);
+	return SqlYyjsonDoc(doc, duckdb_yyjson::yyjson_doc_free);
+}
+
+std::string SqlJsonString(duckdb_yyjson::yyjson_val *root, const char *name) {
+	if (!root || !duckdb_yyjson::yyjson_is_obj(root)) {
+		return "";
+	}
+	auto value = duckdb_yyjson::yyjson_obj_get(root, name);
+	if (!value || !duckdb_yyjson::yyjson_is_str(value)) {
+		return "";
+	}
+	return std::string(duckdb_yyjson::yyjson_get_str(value), duckdb_yyjson::yyjson_get_len(value));
+}
+
+bool SqlJsonDouble(duckdb_yyjson::yyjson_val *root, const char *name, double &result) {
+	if (!root || !duckdb_yyjson::yyjson_is_obj(root)) {
+		return false;
+	}
+	auto value = duckdb_yyjson::yyjson_obj_get(root, name);
+	if (!value || !duckdb_yyjson::yyjson_is_num(value)) {
+		return false;
+	}
+	result = duckdb_yyjson::yyjson_get_num(value);
+	return std::isfinite(result);
+}
+
+void ControlPlaneFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<AiClearUsageScanData>();
+	if (state.emitted) {
+		return;
+	}
+	auto &bind_data = data_p.bind_data->Cast<ControlPlaneBindData>();
+	std::string response;
+	std::string operation_id;
+	std::string status;
+	std::string endpoint_url;
+	std::string action_required;
+	double estimated_cost = 0;
+	bool has_estimated_cost = false;
+	if (bind_data.operation == ControlPlaneOperation::PROVISION && bind_data.dry_run) {
+		auto model = GetExternalModel(context, bind_data.argument);
+		status = "planned";
+		endpoint_url = model.location;
+		action_required = "rerun with dry_run := false and an explicit max_hourly_cost_usd ceiling";
+		response = "{\"profile\":\"" + JsonEscapeSqlText(model.name) + "\",\"provider\":\"" +
+		           JsonEscapeSqlText(model.provider) + "\",\"model\":\"" + JsonEscapeSqlText(model.model) +
+		           "\",\"dry_run\":true}";
+	} else {
+		std::string path;
+		std::string payload;
+		if (bind_data.operation == ControlPlaneOperation::PROVISION) {
+			auto model = GetExternalModel(context, bind_data.argument);
+			path = "/v1/endpoints/provision";
+			payload = "{\"profile\":\"" + JsonEscapeSqlText(model.name) + "\",\"provider\":\"" +
+			          JsonEscapeSqlText(model.provider) + "\",\"model\":\"" + JsonEscapeSqlText(model.model) +
+			          "\",\"location\":\"" + JsonEscapeSqlText(model.location) + "\",\"credential\":\"" +
+			          JsonEscapeSqlText(model.credential) +
+			          "\",\"max_hourly_cost_usd\":" + std::to_string(bind_data.max_hourly_cost_usd) + "}";
+		} else if (bind_data.operation == ControlPlaneOperation::STATUS) {
+			path = "/v1/endpoints/status";
+			payload = "{\"operation_id\":\"" + JsonEscapeSqlText(bind_data.argument) + "\"}";
+		} else {
+			auto model = GetExternalModel(context, bind_data.argument);
+			path = "/v1/endpoints/deprovision";
+			payload = "{\"profile\":\"" + JsonEscapeSqlText(model.name) + "\"}";
+		}
+		response = duckdb_ai::ControlPlaneRequest(path, payload, bind_data.options);
+		auto doc = ParseSqlJson(response);
+		auto root = doc ? duckdb_yyjson::yyjson_doc_get_root(doc.get()) : nullptr;
+		operation_id = SqlJsonString(root, "operation_id");
+		status = SqlJsonString(root, "status");
+		endpoint_url = SqlJsonString(root, "endpoint_url");
+		action_required = SqlJsonString(root, "action_required");
+		has_estimated_cost = SqlJsonDouble(root, "estimated_hourly_cost_usd", estimated_cost);
+	}
+	idx_t col = 0;
+	output.SetValue(col++, 0, operation_id.empty() ? Value() : Value(operation_id));
+	output.SetValue(col++, 0, status.empty() ? Value() : Value(status));
+	output.SetValue(col++, 0, endpoint_url.empty() ? Value() : Value(endpoint_url));
+	output.SetValue(col++, 0, has_estimated_cost ? Value::DOUBLE(estimated_cost) : Value());
+	output.SetValue(col++, 0, action_required.empty() ? Value() : Value(action_required));
+	output.SetValue(col++, 0, Value(response));
+	output.SetCardinality(1);
+	state.emitted = true;
+}
+
+std::string Base64Encode(const std::string &input) {
+	static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	std::string output;
+	output.reserve(((input.size() + 2) / 3) * 4);
+	for (idx_t i = 0; i < input.size(); i += 3) {
+		auto a = static_cast<unsigned char>(input[i]);
+		auto b = i + 1 < input.size() ? static_cast<unsigned char>(input[i + 1]) : 0;
+		auto c = i + 2 < input.size() ? static_cast<unsigned char>(input[i + 2]) : 0;
+		auto packed = (static_cast<uint32_t>(a) << 16) | (static_cast<uint32_t>(b) << 8) | c;
+		output.push_back(alphabet[(packed >> 18) & 0x3f]);
+		output.push_back(alphabet[(packed >> 12) & 0x3f]);
+		output.push_back(i + 1 < input.size() ? alphabet[(packed >> 6) & 0x3f] : '=');
+		output.push_back(i + 2 < input.size() ? alphabet[packed & 0x3f] : '=');
+	}
+	return output;
+}
+
+std::string SqlJsonValueText(duckdb_yyjson::yyjson_val *root, const char *name) {
+	if (!root || !duckdb_yyjson::yyjson_is_obj(root)) {
+		return "";
+	}
+	auto value = duckdb_yyjson::yyjson_obj_get(root, name);
+	if (!value || duckdb_yyjson::yyjson_is_null(value)) {
+		return "";
+	}
+	if (duckdb_yyjson::yyjson_is_str(value)) {
+		return std::string(duckdb_yyjson::yyjson_get_str(value), duckdb_yyjson::yyjson_get_len(value));
+	}
+	auto serialized = duckdb_yyjson::yyjson_val_write(value, duckdb_yyjson::YYJSON_WRITE_NOFLAG, nullptr);
+	if (!serialized) {
+		return "";
+	}
+	std::string result(serialized);
+	std::free(serialized);
+	return result;
+}
+
+int64_t SqlJsonInteger(duckdb_yyjson::yyjson_val *root, const char *name) {
+	if (!root || !duckdb_yyjson::yyjson_is_obj(root)) {
+		return -1;
+	}
+	auto value = duckdb_yyjson::yyjson_obj_get(root, name);
+	if (!value || !duckdb_yyjson::yyjson_is_int(value)) {
+		return -1;
+	}
+	if (duckdb_yyjson::yyjson_is_uint(value)) {
+		auto unsigned_value = duckdb_yyjson::yyjson_get_uint(value);
+		if (unsigned_value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+			return -1;
+		}
+		return static_cast<int64_t>(unsigned_value);
+	}
+	return duckdb_yyjson::yyjson_get_sint(value);
+}
+
+unique_ptr<FunctionData> DocumentParseBind(ClientContext &context, TableFunctionBindInput &input,
+                                           vector<LogicalType> &return_types, vector<string> &names) {
+	if (input.inputs.size() != 3 || input.inputs[0].IsNull() || input.inputs[1].IsNull() || input.inputs[2].IsNull()) {
+		throw BinderException("ai_parse_document requires non-NULL content, mime_type, and parser_profile arguments");
+	}
+	auto bind_data = make_uniq<DocumentParseBindData>();
+	auto content = input.inputs[0].DefaultCastAs(LogicalType::BLOB);
+	bind_data->content = StringValue::Get(content);
+	bind_data->mime_type = ExternalModelInputString(input.inputs[1]);
+	bind_data->parser_profile = ExternalModelInputString(input.inputs[2]);
+	ApplySettings(context, bind_data->options);
+	StampProviderFunction(bind_data->options, "ai_parse_document");
+	duckdb_ai::AttachProviderRuntimeState(bind_data->options, context);
+	for (auto &parameter : input.named_parameters) {
+		auto name = LowerAscii(parameter.first);
+		if (name == "pages") {
+			auto value = parameter.second;
+			bind_data->pages = value.IsNull() ? "" : StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
+		} else if (!ApplyCompletionValueOption(bind_data->options, "ai_parse_document", name, parameter.second, true,
+		                                       false)) {
+			throw BinderException("Unsupported ai_parse_document option \"%s\"", name);
+		}
+	}
+	AddTableColumns(return_types, names,
+	                {{"document_id", LogicalType::VARCHAR},
+	                 {"page", LogicalType::BIGINT},
+	                 {"element_index", LogicalType::BIGINT},
+	                 {"element_type", LogicalType::VARCHAR},
+	                 {"text", LogicalType::VARCHAR},
+	                 {"markdown", LogicalType::VARCHAR},
+	                 {"bbox", LogicalType::VARCHAR},
+	                 {"confidence", LogicalType::DOUBLE},
+	                 {"metadata", LogicalType::VARCHAR},
+	                 {"error", LogicalType::VARCHAR}});
+	return std::move(bind_data);
+}
+
+unique_ptr<GlobalTableFunctionState> DocumentParseInit(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<DocumentParseScanData>();
+}
+
+void LoadDocumentElements(const DocumentParseBindData &bind_data, DocumentParseScanData &state) {
+	if (state.loaded) {
+		return;
+	}
+	state.loaded = true;
+	try {
+		auto payload = "{\"content_base64\":\"" + Base64Encode(bind_data.content) + "\",\"mime_type\":\"" +
+		               JsonEscapeSqlText(bind_data.mime_type) + "\",\"parser_profile\":\"" +
+		               JsonEscapeSqlText(bind_data.parser_profile) + "\",\"pages\":\"" +
+		               JsonEscapeSqlText(bind_data.pages) + "\"}";
+		auto response = duckdb_ai::ControlPlaneRequest("/v1/documents/parse", payload, bind_data.options);
+		auto doc = ParseSqlJson(response);
+		auto root = doc ? duckdb_yyjson::yyjson_doc_get_root(doc.get()) : nullptr;
+		auto document_id = SqlJsonString(root, "document_id");
+		auto elements =
+		    root && duckdb_yyjson::yyjson_is_obj(root) ? duckdb_yyjson::yyjson_obj_get(root, "elements") : nullptr;
+		if (!elements || !duckdb_yyjson::yyjson_is_arr(elements)) {
+			throw IOException("AI document parser response must contain an elements array");
+		}
+		if (elements && duckdb_yyjson::yyjson_is_arr(elements)) {
+			duckdb_yyjson::yyjson_val *element;
+			size_t index;
+			size_t max;
+			yyjson_arr_foreach(elements, index, max, element) {
+				DocumentElement result;
+				result.document_id = document_id;
+				if (!duckdb_yyjson::yyjson_is_obj(element)) {
+					result.error = "AI document parser element must be an object";
+					state.elements.push_back(std::move(result));
+					continue;
+				}
+				result.page = SqlJsonInteger(element, "page");
+				result.element_index = SqlJsonInteger(element, "element_index");
+				result.element_type = SqlJsonString(element, "element_type");
+				result.text = SqlJsonString(element, "text");
+				result.markdown = SqlJsonString(element, "markdown");
+				result.bbox = SqlJsonValueText(element, "bbox");
+				result.metadata = SqlJsonValueText(element, "metadata");
+				result.error = SqlJsonString(element, "error");
+				result.has_confidence = SqlJsonDouble(element, "confidence", result.confidence);
+				state.elements.push_back(std::move(result));
+			}
+		}
+		if (state.elements.empty()) {
+			auto error = SqlJsonString(root, "error");
+			DocumentElement result;
+			result.document_id = document_id;
+			result.error = error.empty() ? "AI document parser returned no elements" : error;
+			state.elements.push_back(std::move(result));
+		}
+	} catch (std::exception &ex) {
+		if (bind_data.options.fail_on_error) {
+			throw;
+		}
+		DocumentElement result;
+		result.error = ex.what();
+		state.elements.push_back(std::move(result));
+	}
+}
+
+void DocumentParseFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<DocumentParseBindData>();
+	auto &data = data_p.global_state->Cast<DocumentParseScanData>();
+	LoadDocumentElements(bind_data, data);
+	idx_t count = 0;
+	while (data.offset < data.elements.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &element = data.elements[data.offset++];
+		idx_t col = 0;
+		output.SetValue(col++, count, element.document_id.empty() ? Value() : Value(element.document_id));
+		output.SetValue(col++, count, element.page < 0 ? Value() : Value::BIGINT(element.page));
+		output.SetValue(col++, count, element.element_index < 0 ? Value() : Value::BIGINT(element.element_index));
+		output.SetValue(col++, count, element.element_type.empty() ? Value() : Value(element.element_type));
+		output.SetValue(col++, count, element.text.empty() ? Value() : Value(element.text));
+		output.SetValue(col++, count, element.markdown.empty() ? Value() : Value(element.markdown));
+		output.SetValue(col++, count, element.bbox.empty() ? Value() : Value(element.bbox));
+		output.SetValue(col++, count, element.has_confidence ? Value::DOUBLE(element.confidence) : Value());
+		output.SetValue(col++, count, element.metadata.empty() ? Value() : Value(element.metadata));
+		output.SetValue(col++, count, element.error.empty() ? Value() : Value(element.error));
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+struct ParsedClassifierArtifact {
+	bool usable = false;
+	double accuracy = 0;
+	double confidence_margin = 0.05;
+	std::vector<std::string> labels;
+	std::vector<std::vector<double>> centroids;
+	duckdb_ai::CompletionOptions embedding_options;
+};
+
+struct OptimizedClassifierRow {
+	idx_t row = 0;
+	std::string input;
+	ParsedClassifierArtifact artifact;
+	std::vector<double> embedding;
+	std::string local_error;
+	double best_score = 0;
+	double score_margin = 0;
+	idx_t best_label = DConstants::INVALID_INDEX;
+};
+
+bool RequiredJsonBoolean(duckdb_yyjson::yyjson_val *root, const char *name) {
+	auto value = root && duckdb_yyjson::yyjson_is_obj(root) ? duckdb_yyjson::yyjson_obj_get(root, name) : nullptr;
+	if (!value || !duckdb_yyjson::yyjson_is_bool(value)) {
+		throw InvalidInputException("classifier artifact field \"%s\" must be a boolean", name);
+	}
+	return duckdb_yyjson::yyjson_get_bool(value);
+}
+
+double RequiredJsonNumber(duckdb_yyjson::yyjson_val *root, const char *name) {
+	double result;
+	if (!SqlJsonDouble(root, name, result)) {
+		throw InvalidInputException("classifier artifact field \"%s\" must be a finite number", name);
+	}
+	return result;
+}
+
+ParsedClassifierArtifact ParseClassifierArtifact(ClientContext &context, const std::string &input) {
+	auto doc = ParseSqlJson(input);
+	auto root = doc ? duckdb_yyjson::yyjson_doc_get_root(doc.get()) : nullptr;
+	if (!root || !duckdb_yyjson::yyjson_is_obj(root) || SqlJsonInteger(root, "version") != 1 ||
+	    SqlJsonString(root, "optimization") != "minimize_cost") {
+		throw InvalidInputException("invalid ai_build_classifier artifact");
+	}
+	ParsedClassifierArtifact result;
+	result.usable = RequiredJsonBoolean(root, "usable");
+	result.accuracy = RequiredJsonNumber(root, "accuracy");
+	result.confidence_margin = RequiredJsonNumber(root, "confidence_margin");
+	if (result.confidence_margin < 0 || result.confidence_margin > 1) {
+		throw InvalidInputException("classifier artifact confidence_margin must be between 0 and 1");
+	}
+	auto labels = duckdb_yyjson::yyjson_obj_get(root, "labels");
+	if (!labels || !duckdb_yyjson::yyjson_is_arr(labels)) {
+		throw InvalidInputException("classifier artifact labels must be an array");
+	}
+	duckdb_yyjson::yyjson_val *entry;
+	size_t index;
+	size_t max;
+	yyjson_arr_foreach(labels, index, max, entry) {
+		if (!duckdb_yyjson::yyjson_is_str(entry)) {
+			throw InvalidInputException("classifier artifact labels must contain only strings");
+		}
+		result.labels.emplace_back(duckdb_yyjson::yyjson_get_str(entry), duckdb_yyjson::yyjson_get_len(entry));
+	}
+	auto centroids = duckdb_yyjson::yyjson_obj_get(root, "centroids");
+	if (!centroids || !duckdb_yyjson::yyjson_is_arr(centroids)) {
+		throw InvalidInputException("classifier artifact centroids must be an array");
+	}
+	yyjson_arr_foreach(centroids, index, max, entry) {
+		if (!duckdb_yyjson::yyjson_is_arr(entry)) {
+			throw InvalidInputException("classifier artifact centroids must be numeric arrays");
+		}
+		std::vector<double> centroid;
+		duckdb_yyjson::yyjson_val *coordinate;
+		size_t coordinate_index;
+		size_t coordinate_max;
+		yyjson_arr_foreach(entry, coordinate_index, coordinate_max, coordinate) {
+			if (!duckdb_yyjson::yyjson_is_num(coordinate)) {
+				throw InvalidInputException("classifier artifact centroids must contain only numbers");
+			}
+			auto value = duckdb_yyjson::yyjson_get_num(coordinate);
+			if (!std::isfinite(value)) {
+				throw InvalidInputException("classifier artifact centroid values must be finite");
+			}
+			centroid.push_back(value);
+		}
+		result.centroids.push_back(std::move(centroid));
+	}
+	if (result.labels.size() < 2 || result.labels.size() != result.centroids.size() || result.centroids[0].empty()) {
+		throw InvalidInputException("classifier artifact must contain matching labels and non-empty centroids");
+	}
+	for (auto &centroid : result.centroids) {
+		if (centroid.size() != result.centroids[0].size()) {
+			throw InvalidInputException("classifier artifact centroid dimensions are inconsistent");
+		}
+	}
+	auto embedding = duckdb_yyjson::yyjson_obj_get(root, "embedding");
+	if (!embedding || !duckdb_yyjson::yyjson_is_obj(embedding)) {
+		throw InvalidInputException("classifier artifact embedding configuration is missing");
+	}
+	ApplySettings(context, result.embedding_options, AiModelSettingKind::EMBEDDING);
+	result.embedding_options.provider = SqlJsonString(embedding, "provider");
+	result.embedding_options.model = SqlJsonString(embedding, "model");
+	result.embedding_options.secret_name = SqlJsonString(embedding, "profile");
+	result.embedding_options.base_url = SqlJsonString(embedding, "base_url");
+	result.embedding_options.model_options = SqlJsonString(embedding, "options");
+	if (result.embedding_options.provider.empty() || result.embedding_options.model.empty()) {
+		throw InvalidInputException("classifier artifact embedding provider and model are required");
+	}
+	if (result.accuracy < 0 || result.accuracy > 1) {
+		throw InvalidInputException("classifier artifact accuracy must be between 0 and 1");
+	}
+	StampProviderFunction(result.embedding_options, "ai_classify_optimized_embed");
+	duckdb_ai::AttachProviderRuntimeState(result.embedding_options, context);
+	return result;
+}
+
+LogicalType AiOptimizedClassifierReturnType() {
+	child_list_t<LogicalType> children;
+	children.emplace_back("value", LogicalType::VARCHAR);
+	children.emplace_back("used_fallback", LogicalType::BOOLEAN);
+	children.emplace_back("confidence", LogicalType::DOUBLE);
+	children.emplace_back("error", LogicalType::VARCHAR);
+	children.emplace_back("metadata", LogicalType::VARCHAR);
+	return LogicalType::STRUCT(std::move(children));
+}
+
+Value AiOptimizedClassifierResultValue(const LogicalType &result_type, const std::string &value, bool used_fallback,
+                                       double confidence, bool has_confidence, const std::string &error,
+                                       const std::string &metadata) {
+	vector<Value> children;
+	children.push_back(value.empty() ? Value(LogicalType::VARCHAR) : Value(value));
+	children.push_back(Value::BOOLEAN(used_fallback));
+	children.push_back(has_confidence ? Value::DOUBLE(confidence) : Value(LogicalType::DOUBLE));
+	children.push_back(error.empty() ? Value(LogicalType::VARCHAR) : Value(error));
+	children.push_back(metadata.empty() ? Value(LogicalType::VARCHAR) : Value(metadata));
+	return Value::STRUCT(result_type, std::move(children));
+}
+
+unique_ptr<FunctionData> AiOptimizedClassifierBind(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() < 2) {
+		throw BinderException("ai_classify_optimized requires input and classifier artifact arguments");
+	}
+	auto bind_data = make_uniq<OptimizedClassifierBindData>();
+	ApplySettings(context, bind_data->fallback_options, AiModelSettingKind::TASK);
+	StampProviderFunction(bind_data->fallback_options, "ai_classify_optimized_fallback");
+	duckdb_ai::AttachProviderRuntimeState(bind_data->fallback_options, context);
+	for (idx_t i = 2; i < arguments.size(); i++) {
+		auto alias = LowerAscii(arguments[i]->GetAlias());
+		if (alias.empty()) {
+			throw BinderException("ai_classify_optimized options must use named arguments");
+		}
+		if (alias == "fallback_profile") {
+			bind_data->fallback_options.secret_name = EvaluateConstantString(context, *arguments[i], alias);
+			bound_function.arguments.emplace_back(LogicalType::VARCHAR);
+			continue;
+		}
+		LogicalType option_type;
+		if (!TryGetOptionType(alias, option_type)) {
+			throw BinderException("Unsupported ai_classify_optimized option \"%s\"", alias);
+		}
+		ApplyNamedOption(context, bind_data->fallback_options, *arguments[i], alias);
+		bound_function.arguments.emplace_back(option_type);
+	}
+	bind_data->fallback_options.on_error = "capture";
+	bind_data->fallback_options.fail_on_error = false;
+	ApplyAiProviderSecret(context, bind_data->fallback_options);
+	bound_function.SetReturnType(AiOptimizedClassifierReturnType());
+	return std::move(bind_data);
+}
+
+std::string OptimizedClassifierMetadata(const OptimizedClassifierRow &row, const std::string &path,
+                                        const std::string &reason, const std::string &provider = "",
+                                        const std::string &model = "") {
+	std::ostringstream output;
+	output << std::setprecision(17) << "{\"path\":\"" << JsonEscapeSqlText(path)
+	       << "\",\"artifact_accuracy\":" << row.artifact.accuracy;
+	if (!reason.empty()) {
+		output << ",\"reason\":\"" << JsonEscapeSqlText(reason) << '"';
+	}
+	if (row.best_label != DConstants::INVALID_INDEX) {
+		output << ",\"cosine_score\":" << row.best_score << ",\"centroid_margin\":" << row.score_margin;
+	}
+	if (!provider.empty()) {
+		output << ",\"provider\":\"" << JsonEscapeSqlText(provider) << '"';
+	}
+	if (!model.empty()) {
+		output << ",\"model\":\"" << JsonEscapeSqlText(model) << '"';
+	}
+	output << '}';
+	return output.str();
+}
+
+void AiOptimizedClassifierFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &bind_data = func_expr.bind_info->Cast<OptimizedClassifierBindData>();
+	auto result_type = AiOptimizedClassifierReturnType();
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+	StringVectorReader input_reader(args, 0);
+	StringVectorReader artifact_reader(args, 1);
+	std::vector<OptimizedClassifierRow> rows;
+	std::vector<SecretResolutionCacheEntry> embedding_secret_cache;
+	for (idx_t row_index = 0; row_index < args.size(); row_index++) {
+		std::string input;
+		std::string artifact;
+		if (!input_reader.Read(row_index, input) || !artifact_reader.Read(row_index, artifact)) {
+			result_validity.SetInvalid(row_index);
+			continue;
+		}
+		try {
+			OptimizedClassifierRow row;
+			row.row = row_index;
+			row.input = std::move(input);
+			row.artifact = ParseClassifierArtifact(state.GetContext(), artifact);
+			row.artifact.embedding_options.query_id = bind_data.fallback_options.query_id + ":embed";
+			if (!row.artifact.usable) {
+				row.local_error = "artifact quality threshold was not met";
+			} else {
+				ApplyAiProviderSecretCached(state.GetContext(), row.artifact.embedding_options, embedding_secret_cache);
+			}
+			rows.push_back(std::move(row));
+		} catch (std::exception &ex) {
+			auto metadata = "{\"path\":\"error\",\"reason\":\"invalid classifier artifact\"}";
+			result.SetValue(row_index,
+			                AiOptimizedClassifierResultValue(result_type, "", false, 0, false, ex.what(), metadata));
+		}
+	}
+
+	std::vector<bool> grouped(rows.size(), false);
+	for (idx_t group_start = 0; group_start < rows.size(); group_start++) {
+		if (grouped[group_start] || !rows[group_start].local_error.empty()) {
+			continue;
+		}
+		std::vector<idx_t> group_rows;
+		std::vector<std::string> unique_inputs;
+		std::unordered_map<std::string, idx_t> input_indexes;
+		for (idx_t row = group_start; row < rows.size(); row++) {
+			if (grouped[row] || !rows[row].local_error.empty() ||
+			    !CompletionOptionsEqual(rows[group_start].artifact.embedding_options,
+			                            rows[row].artifact.embedding_options)) {
+				continue;
+			}
+			grouped[row] = true;
+			group_rows.push_back(row);
+			if (input_indexes.find(rows[row].input) == input_indexes.end()) {
+				input_indexes[rows[row].input] = unique_inputs.size();
+				unique_inputs.push_back(rows[row].input);
+			}
+		}
+		try {
+			auto embeddings = duckdb_ai::EmbedMany(unique_inputs, rows[group_start].artifact.embedding_options);
+			if (embeddings.size() != unique_inputs.size()) {
+				throw InvalidInputException("embedding provider returned the wrong number of classifier embeddings");
+			}
+			for (auto row : group_rows) {
+				rows[row].embedding = embeddings[input_indexes[rows[row].input]].values;
+			}
+		} catch (std::exception &ex) {
+			for (auto row : group_rows) {
+				rows[row].local_error = std::string("local embedding failed: ") + ex.what();
+			}
+		}
+	}
+
+	std::vector<ProviderStringJob> fallback_jobs;
+	std::unordered_map<idx_t, idx_t> fallback_row_indexes;
+	std::vector<SecretResolutionCacheEntry> fallback_secret_cache;
+	for (idx_t row_index = 0; row_index < rows.size(); row_index++) {
+		auto &row = rows[row_index];
+		if (row.local_error.empty()) {
+			try {
+				double best = -std::numeric_limits<double>::infinity();
+				double second = -std::numeric_limits<double>::infinity();
+				for (idx_t label = 0; label < row.artifact.centroids.size(); label++) {
+					auto score = CosineSimilarity(row.embedding, row.artifact.centroids[label]);
+					if (score > best) {
+						second = best;
+						best = score;
+						row.best_label = label;
+					} else if (score > second) {
+						second = score;
+					}
+				}
+				row.best_score = best;
+				row.score_margin = best - second;
+				if (row.score_margin >= row.artifact.confidence_margin) {
+					auto metadata = OptimizedClassifierMetadata(row, "local", "");
+					result.SetValue(row.row,
+					                AiOptimizedClassifierResultValue(result_type, row.artifact.labels[row.best_label],
+					                                                 false, row.best_score, true, "", metadata));
+					continue;
+				}
+				row.local_error = "centroid margin below confidence threshold";
+			} catch (std::exception &ex) {
+				row.local_error = std::string("local classification failed: ") + ex.what();
+			}
+		}
+		try {
+			auto options = bind_data.fallback_options;
+			ApplyAiProviderSecretCached(state.GetContext(), options, fallback_secret_cache);
+			ProviderStringJob job;
+			job.row = row.row;
+			job.input = row.input;
+			job.parameter = JoinClassifierLabels(row.artifact.labels);
+			job.options = std::move(options);
+			job.fail_on_error = false;
+			fallback_row_indexes[job.row] = row_index;
+			fallback_jobs.push_back(std::move(job));
+		} catch (std::exception &ex) {
+			auto metadata = OptimizedClassifierMetadata(row, "fallback", row.local_error);
+			result.SetValue(row.row,
+			                AiOptimizedClassifierResultValue(result_type, "", true, 0, false, ex.what(), metadata));
+		}
+	}
+
+	RunProviderJobs(fallback_jobs, [&](ProviderStringJob &job) {
+		AppendSystemPrompt(job.options, BuildTaskSystemPrompt(AiTaskKind::CLASSIFY, job.parameter));
+		job.output =
+		    duckdb_ai::Complete(BuildTaskUserPrompt(AiTaskKind::CLASSIFY, job.input, job.parameter), job.options).text;
+	});
+	for (auto &job : fallback_jobs) {
+		auto &row = rows[fallback_row_indexes[job.row]];
+		auto config = duckdb_ai::ResolveProvider(job.options);
+		auto metadata = OptimizedClassifierMetadata(row, "fallback", row.local_error, config.provider, config.model);
+		if (job.exception) {
+			result.SetValue(job.row, AiOptimizedClassifierResultValue(result_type, "", true, 0, false,
+			                                                          job.error_message, metadata));
+			continue;
+		}
+		auto label = ClassifierLabelIndex(row.artifact.labels, job.output);
+		if (label == DConstants::INVALID_INDEX) {
+			result.SetValue(job.row, AiOptimizedClassifierResultValue(
+			                             result_type, "", true, 0, false,
+			                             "fallback classifier returned a label outside the artifact", metadata));
+			continue;
+		}
+		result.SetValue(job.row, AiOptimizedClassifierResultValue(result_type, row.artifact.labels[label], true, 0,
+		                                                          false, "", metadata));
+	}
+}
+
+uint64_t StableTextHash(const std::string &input) {
+	uint64_t hash = 1469598103934665603ULL;
+	for (auto c : input) {
+		hash ^= static_cast<unsigned char>(c);
+		hash *= 1099511628211ULL;
+	}
+	return hash;
+}
+
+vector<idx_t> Utf8ByteOffsets(const std::string &input) {
+	vector<idx_t> offsets;
+	for (idx_t offset = 0; offset < input.size();) {
+		offsets.push_back(offset);
+		auto lead = static_cast<unsigned char>(input[offset]);
+		idx_t width = 1;
+		if ((lead & 0xe0) == 0xc0) {
+			width = 2;
+		} else if ((lead & 0xf0) == 0xe0) {
+			width = 3;
+		} else if ((lead & 0xf8) == 0xf0) {
+			width = 4;
+		}
+		offset = MinValue<idx_t>(input.size(), offset + width);
+	}
+	offsets.push_back(input.size());
+	return offsets;
+}
+
+bool IsChunkWhitespace(char value) {
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n';
+}
+
+idx_t FindRecursiveChunkEnd(const std::string &input, const vector<idx_t> &offsets, idx_t start, idx_t target) {
+	auto minimum = start + MaxValue<idx_t>(1, (target - start) / 2);
+	auto find_boundary = [&](uint8_t kind) {
+		auto lower_bound = kind == 0 ? start : minimum;
+		for (idx_t candidate = target; candidate > lower_bound; candidate--) {
+			auto byte = offsets[candidate];
+			if (kind == 0 && byte > 0 && input[byte - 1] == '\f') {
+				return candidate;
+			}
+			if (kind == 0 && byte >= 2 && input[byte - 1] == '\n' && input[byte - 2] == '\n') {
+				return candidate;
+			}
+			if (kind == 1 && byte > 0 && (input[byte - 1] == '.' || input[byte - 1] == '!' || input[byte - 1] == '?') &&
+			    (byte == input.size() || IsChunkWhitespace(input[byte]))) {
+				return candidate;
+			}
+			if (kind == 2 && byte > 0 && input[byte - 1] == '\n') {
+				return candidate;
+			}
+			if (kind == 3 && byte > 0 && IsChunkWhitespace(input[byte - 1])) {
+				return candidate;
+			}
+		}
+		return idx_t(0);
+	};
+	for (uint8_t kind = 0; kind < 4; kind++) {
+		auto boundary = find_boundary(kind);
+		if (boundary > start) {
+			return boundary;
+		}
+	}
+	return target;
+}
+
+std::string MarkdownHeadingAt(const std::string &input, idx_t byte_offset) {
+	std::string heading;
+	for (idx_t line_start = 0; line_start <= byte_offset && line_start < input.size();) {
+		auto newline = input.find('\n', line_start);
+		auto page_break = input.find('\f', line_start);
+		auto line_end = MinValue<idx_t>(newline == std::string::npos ? input.size() : newline,
+		                                page_break == std::string::npos ? input.size() : page_break);
+		if (line_end == std::string::npos) {
+			line_end = input.size();
+		}
+		auto marker_end = line_start;
+		while (marker_end < line_end && input[marker_end] == '#' && marker_end - line_start < 6) {
+			marker_end++;
+		}
+		if (marker_end > line_start && marker_end < line_end && input[marker_end] == ' ') {
+			heading = TrimAscii(input.substr(marker_end + 1, line_end - marker_end - 1));
+		}
+		if (line_end >= byte_offset || line_end == input.size()) {
+			break;
+		}
+		line_start = line_end + 1;
+	}
+	return heading;
+}
+
+vector<AiTextChunk> BuildTextChunks(const std::string &input, std::string source_id, idx_t chunk_size,
+                                    double overlap_percent, const std::string &strategy) {
+	vector<AiTextChunk> chunks;
+	if (input.empty()) {
+		return chunks;
+	}
+	if (source_id.empty()) {
+		source_id = StringUtil::Format("source_%016llx", static_cast<unsigned long long>(StableTextHash(input)));
+	}
+	auto offsets = Utf8ByteOffsets(input);
+	auto codepoints = offsets.size() - 1;
+	auto overlap = static_cast<idx_t>(std::floor(static_cast<double>(chunk_size) * overlap_percent / 100.0));
+	auto settings_hash = StableTextHash(source_id + "|" + input + "|" + strategy + "|" + std::to_string(chunk_size) +
+	                                    "|" + std::to_string(overlap_percent));
+	for (idx_t start = 0, chunk_index = 0; start < codepoints; chunk_index++) {
+		auto end = MinValue<idx_t>(codepoints, start + chunk_size);
+		if (strategy == "recursive" && end < codepoints) {
+			end = FindRecursiveChunkEnd(input, offsets, start, end);
+		}
+		if (end <= start) {
+			end = MinValue<idx_t>(codepoints, start + chunk_size);
+		}
+		auto byte_start = offsets[start];
+		auto byte_end = offsets[end];
+		AiTextChunk chunk;
+		chunk.source_id = source_id;
+		chunk.chunk_id =
+		    StringUtil::Format("%s:%016llx:%llu", source_id, static_cast<unsigned long long>(settings_hash),
+		                       static_cast<unsigned long long>(chunk_index));
+		chunk.chunk_index = chunk_index;
+		chunk.start_offset = start;
+		chunk.end_offset = end;
+		chunk.text = input.substr(byte_start, byte_end - byte_start);
+		chunk.heading = MarkdownHeadingAt(input, byte_start);
+		chunk.page = 1 + NumericCast<idx_t>(std::count(input.begin(), input.begin() + byte_start, '\f'));
+		chunks.push_back(std::move(chunk));
+		if (end == codepoints) {
+			break;
+		}
+		auto next_start = end > overlap ? end - overlap : end;
+		start = next_start > start ? next_start : end;
+	}
+	return chunks;
+}
+
+std::string OptionalNamedString(const named_parameter_map_t &parameters, const std::string &name) {
+	auto entry = parameters.find(name);
+	if (entry == parameters.end() || entry->second.IsNull()) {
+		return "";
+	}
+	auto value = entry->second;
+	return StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
+}
+
+unique_ptr<FunctionData> AiChunkBindInternal(ClientContext &context, TableFunctionBindInput &input,
+                                             vector<LogicalType> &return_types, vector<string> &names,
+                                             bool prep_search) {
+	if (input.inputs.size() != 1) {
+		throw BinderException("%s requires one VARCHAR input", prep_search ? "ai_prep_search" : "ai_generate_chunks");
+	}
+	auto bind_data = make_uniq<AiChunkBindData>();
+	bind_data->prep_search = prep_search;
+	auto input_value = input.inputs[0];
+	if (!input_value.IsNull()) {
+		bind_data->input = StringValue::Get(input_value.DefaultCastAs(LogicalType::VARCHAR));
+	}
+	if (prep_search) {
+		ApplySettings(context, bind_data->options, AiModelSettingKind::TASK);
+		StampProviderFunction(bind_data->options, "ai_prep_search");
+		duckdb_ai::AttachProviderRuntimeState(bind_data->options, context);
+	}
+	for (auto &parameter : input.named_parameters) {
+		auto name = LowerAscii(parameter.first);
+		auto value = parameter.second;
+		if (name == "chunk_size") {
+			if (value.IsNull()) {
+				throw BinderException("chunk_size must not be NULL");
+			}
+			value = value.DefaultCastAs(LogicalType::BIGINT);
+			auto chunk_size = BigIntValue::Get(value);
+			if (chunk_size <= 0 || chunk_size > 10000000) {
+				throw BinderException("chunk_size must be between 1 and 10000000");
+			}
+			bind_data->chunk_size = NumericCast<idx_t>(chunk_size);
+		} else if (name == "overlap_percent") {
+			value = value.DefaultCastAs(LogicalType::DOUBLE);
+			bind_data->overlap_percent = DoubleValue::Get(value);
+			if (!std::isfinite(bind_data->overlap_percent) || bind_data->overlap_percent < 0 ||
+			    bind_data->overlap_percent > 50) {
+				throw BinderException("overlap_percent must be between 0 and 50");
+			}
+		} else if (name == "strategy") {
+			bind_data->strategy = LowerAscii(OptionalNamedString(input.named_parameters, parameter.first));
+			if (bind_data->strategy != "fixed" && bind_data->strategy != "recursive") {
+				throw BinderException("strategy must be fixed or recursive");
+			}
+		} else if (name == "source_id") {
+			bind_data->source_id = OptionalNamedString(input.named_parameters, parameter.first);
+		} else if (prep_search && name == "title") {
+			bind_data->title = OptionalNamedString(input.named_parameters, parameter.first);
+		} else if (prep_search && name == "metadata") {
+			bind_data->metadata = OptionalNamedString(input.named_parameters, parameter.first);
+			std::string error;
+			if (!bind_data->metadata.empty() && !duckdb_ai::ValidateJsonDocument(bind_data->metadata, error)) {
+				throw BinderException("ai_prep_search metadata must be valid JSON: %s", error);
+			}
+		} else if (prep_search && name == "enrich") {
+			value = value.DefaultCastAs(LogicalType::BOOLEAN);
+			bind_data->enrich = BooleanValue::Get(value);
+		} else if (!prep_search ||
+		           !ApplyCompletionValueOption(bind_data->options, "ai_prep_search", name, value, true, false)) {
+			throw BinderException("Unsupported %s option \"%s\"", prep_search ? "ai_prep_search" : "ai_generate_chunks",
+			                      name);
+		}
+	}
+	if (bind_data->enrich) {
+		ApplyAiProviderSecret(context, bind_data->options);
+	}
+	bind_data->chunks = BuildTextChunks(bind_data->input, bind_data->source_id, bind_data->chunk_size,
+	                                    bind_data->overlap_percent, bind_data->strategy);
+	if (!bind_data->chunks.empty()) {
+		bind_data->source_id = bind_data->chunks[0].source_id;
+	}
+	if (prep_search) {
+		AddTableColumns(return_types, names,
+		                {{"source_id", LogicalType::VARCHAR},
+		                 {"chunk_id", LogicalType::VARCHAR},
+		                 {"chunk_index", LogicalType::UBIGINT},
+		                 {"chunk_to_retrieve", LogicalType::VARCHAR},
+		                 {"chunk_to_embed", LogicalType::VARCHAR},
+		                 {"heading", LogicalType::VARCHAR},
+		                 {"page", LogicalType::UBIGINT},
+		                 {"start_offset", LogicalType::UBIGINT},
+		                 {"end_offset", LogicalType::UBIGINT},
+		                 {"metadata", LogicalType::JSON()},
+		                 {"error", LogicalType::VARCHAR}});
+	} else {
+		AddTableColumns(return_types, names,
+		                {{"source_id", LogicalType::VARCHAR},
+		                 {"chunk_id", LogicalType::VARCHAR},
+		                 {"chunk_index", LogicalType::UBIGINT},
+		                 {"start_offset", LogicalType::UBIGINT},
+		                 {"end_offset", LogicalType::UBIGINT},
+		                 {"chunk_length", LogicalType::UBIGINT},
+		                 {"estimated_tokens", LogicalType::BIGINT},
+		                 {"chunk", LogicalType::VARCHAR}});
+	}
+	return std::move(bind_data);
+}
+
+unique_ptr<FunctionData> AiGenerateChunksBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	return AiChunkBindInternal(context, input, return_types, names, false);
+}
+
+unique_ptr<FunctionData> AiPrepSearchBind(ClientContext &context, TableFunctionBindInput &input,
+                                          vector<LogicalType> &return_types, vector<string> &names) {
+	return AiChunkBindInternal(context, input, return_types, names, true);
+}
+
+unique_ptr<GlobalTableFunctionState> AiChunkInit(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<AiChunkScanData>();
+}
+
+void PrepareSearchContext(ClientContext &context, const AiChunkBindData &bind_data, AiChunkScanData &state) {
+	if (state.prepared) {
+		return;
+	}
+	state.prepared = true;
+	if (!bind_data.enrich) {
+		duckdb_ai::RecordLocalUsageEvent(&context, "ai_prep_search", NumericCast<int64_t>(bind_data.input.size()),
+		                                 NumericCast<int64_t>(bind_data.chunks.size()));
+		return;
+	}
+	try {
+		auto options = bind_data.options;
+		AppendSystemPrompt(options,
+		                   "Create a concise document-level retrieval context. Preserve the subject, entities, dates, "
+		                   "and terminology needed to disambiguate individual chunks. Return only the context.");
+		state.document_context = duckdb_ai::Complete(bind_data.input, options).text;
+	} catch (std::exception &ex) {
+		if (bind_data.options.fail_on_error) {
+			throw;
+		}
+		state.enrichment_error = ex.what();
+	}
+}
+
+std::string ChunkEmbeddingText(const AiChunkBindData &bind_data, const AiChunkScanData &state,
+                               const AiTextChunk &chunk) {
+	std::string output;
+	if (!bind_data.title.empty()) {
+		output += "Document: " + bind_data.title + "\n";
+	}
+	if (!state.document_context.empty()) {
+		output += "Document context: " + state.document_context + "\n";
+	}
+	if (!chunk.heading.empty()) {
+		output += "Section: " + chunk.heading + "\n";
+	}
+	if (!output.empty()) {
+		output += "Content:\n";
+	}
+	output += chunk.text;
+	return output;
+}
+
+void AiChunkFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<AiChunkBindData>();
+	auto &data = data_p.global_state->Cast<AiChunkScanData>();
+	if (bind_data.prep_search) {
+		PrepareSearchContext(context, bind_data, data);
+	} else if (!data.prepared) {
+		duckdb_ai::RecordLocalUsageEvent(&context, "ai_generate_chunks", NumericCast<int64_t>(bind_data.input.size()),
+		                                 NumericCast<int64_t>(bind_data.chunks.size()));
+		data.prepared = true;
+	}
+	idx_t count = 0;
+	while (data.offset < bind_data.chunks.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &chunk = bind_data.chunks[data.offset++];
+		idx_t col = 0;
+		output.SetValue(col++, count, Value(chunk.source_id));
+		output.SetValue(col++, count, Value(chunk.chunk_id));
+		output.SetValue(col++, count, Value::UBIGINT(chunk.chunk_index));
+		if (bind_data.prep_search) {
+			output.SetValue(col++, count, Value(chunk.text));
+			output.SetValue(col++, count, Value(ChunkEmbeddingText(bind_data, data, chunk)));
+			output.SetValue(col++, count, chunk.heading.empty() ? Value() : Value(chunk.heading));
+			output.SetValue(col++, count, Value::UBIGINT(chunk.page));
+			output.SetValue(col++, count, Value::UBIGINT(chunk.start_offset));
+			output.SetValue(col++, count, Value::UBIGINT(chunk.end_offset));
+			output.SetValue(col++, count, bind_data.metadata.empty() ? Value() : Value(bind_data.metadata));
+			output.SetValue(col++, count, data.enrichment_error.empty() ? Value() : Value(data.enrichment_error));
+		} else {
+			output.SetValue(col++, count, Value::UBIGINT(chunk.start_offset));
+			output.SetValue(col++, count, Value::UBIGINT(chunk.end_offset));
+			output.SetValue(col++, count, Value::UBIGINT(chunk.end_offset - chunk.start_offset));
+			output.SetValue(col++, count, Value::BIGINT(duckdb_ai::EstimateTokenCount(chunk.text)));
+			output.SetValue(col++, count, Value(chunk.text));
+		}
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
 unique_ptr<FunctionData> AiUsageBind(ClientContext &, TableFunctionBindInput &, vector<LogicalType> &return_types,
                                      vector<string> &names) {
 	AddTableColumns(return_types, names,
@@ -4895,6 +7319,8 @@ unique_ptr<FunctionData> AiUsageBind(ClientContext &, TableFunctionBindInput &, 
 	                 {"event", LogicalType::VARCHAR},
 	                 {"function_name", LogicalType::VARCHAR},
 	                 {"query_id", LogicalType::VARCHAR},
+	                 {"operation_id", LogicalType::VARCHAR},
+	                 {"parent_operation_id", LogicalType::VARCHAR},
 	                 {"provider", LogicalType::VARCHAR},
 	                 {"protocol", LogicalType::VARCHAR},
 	                 {"model", LogicalType::VARCHAR},
@@ -4936,6 +7362,8 @@ void AiUsageFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &out
 		output.SetValue(col++, count, Value(event.event));
 		output.SetValue(col++, count, event.function_name.empty() ? Value() : Value(event.function_name));
 		output.SetValue(col++, count, event.query_id.empty() ? Value() : Value(event.query_id));
+		output.SetValue(col++, count, event.operation_id.empty() ? Value() : Value(event.operation_id));
+		output.SetValue(col++, count, event.parent_operation_id.empty() ? Value() : Value(event.parent_operation_id));
 		output.SetValue(col++, count, Value(event.provider));
 		output.SetValue(col++, count, Value(event.protocol));
 		output.SetValue(col++, count, Value(event.model));
@@ -4963,6 +7391,97 @@ void AiUsageFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &out
 		} else {
 			output.SetValue(col++, count, Value());
 		}
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+unique_ptr<FunctionData> AiUsageSummaryBind(ClientContext &, TableFunctionBindInput &,
+                                            vector<LogicalType> &return_types, vector<string> &names) {
+	AddTableColumns(return_types, names,
+	                {{"query_id", LogicalType::VARCHAR},
+	                 {"provider", LogicalType::VARCHAR},
+	                 {"model", LogicalType::VARCHAR},
+	                 {"calls", LogicalType::UBIGINT},
+	                 {"batch_count", LogicalType::UBIGINT},
+	                 {"retries", LogicalType::UBIGINT},
+	                 {"failures", LogicalType::UBIGINT},
+	                 {"cache_hits", LogicalType::UBIGINT},
+	                 {"total_tokens", LogicalType::BIGINT},
+	                 {"elapsed_ms", LogicalType::BIGINT},
+	                 {"estimated_cost_usd", LogicalType::DOUBLE},
+	                 {"retained_events", LogicalType::UBIGINT},
+	                 {"dropped_events", LogicalType::UBIGINT},
+	                 {"queued_log_events", LogicalType::UBIGINT},
+	                 {"dropped_log_events", LogicalType::UBIGINT}});
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> AiUsageSummaryInit(ClientContext &context, TableFunctionInitInput &) {
+	auto state = make_uniq<AiUsageSummaryScanData>();
+	state->stats = duckdb_ai::UsageStats(context);
+	auto events = duckdb_ai::UsageEvents(context);
+	std::unordered_map<std::string, idx_t> indexes;
+	for (auto &event : events) {
+		auto query_id = event.query_id.empty() ? std::string("local") : event.query_id;
+		auto entry = indexes.find(query_id);
+		if (entry == indexes.end()) {
+			AiUsageSummaryRow row;
+			row.query_id = query_id;
+			row.provider = event.provider;
+			row.model = event.model;
+			indexes[query_id] = state->rows.size();
+			state->rows.push_back(std::move(row));
+			entry = indexes.find(query_id);
+		}
+		auto &row = state->rows[entry->second];
+		row.calls++;
+		row.retries += NumericCast<uint64_t>(MaxValue<int64_t>(0, event.retries));
+		if (!event.operation_id.empty()) {
+			row.operation_ids.insert(event.operation_id);
+		}
+		row.failures += event.status == "error" ? 1 : 0;
+		row.cache_hits += event.cache_hit ? 1 : 0;
+		row.total_tokens += MaxValue<int64_t>(0, event.total_tokens);
+		row.elapsed_ms += MaxValue<int64_t>(0, event.elapsed_ms);
+		row.estimated_cost_usd += MaxValue<double>(0, event.estimated_cost_usd);
+		if (row.provider != event.provider) {
+			row.provider = "mixed";
+		}
+		if (row.model != event.model) {
+			row.model = "mixed";
+		}
+	}
+	if (state->rows.empty()) {
+		AiUsageSummaryRow row;
+		row.query_id = "local";
+		row.provider = "local";
+		state->rows.push_back(std::move(row));
+	}
+	return std::move(state);
+}
+
+void AiUsageSummaryFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<AiUsageSummaryScanData>();
+	idx_t count = 0;
+	while (data.offset < data.rows.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &row = data.rows[data.offset++];
+		idx_t col = 0;
+		output.SetValue(col++, count, Value(row.query_id));
+		output.SetValue(col++, count, Value(row.provider));
+		output.SetValue(col++, count, row.model.empty() ? Value() : Value(row.model));
+		output.SetValue(col++, count, Value::UBIGINT(row.calls));
+		output.SetValue(col++, count, Value::UBIGINT(row.operation_ids.size()));
+		output.SetValue(col++, count, Value::UBIGINT(row.retries));
+		output.SetValue(col++, count, Value::UBIGINT(row.failures));
+		output.SetValue(col++, count, Value::UBIGINT(row.cache_hits));
+		output.SetValue(col++, count, Value::BIGINT(row.total_tokens));
+		output.SetValue(col++, count, Value::BIGINT(row.elapsed_ms));
+		output.SetValue(col++, count, Value::DOUBLE(row.estimated_cost_usd));
+		output.SetValue(col++, count, Value::UBIGINT(data.stats.retained_events));
+		output.SetValue(col++, count, Value::UBIGINT(data.stats.dropped_events));
+		output.SetValue(col++, count, Value::UBIGINT(data.stats.queued_log_events));
+		output.SetValue(col++, count, Value::UBIGINT(data.stats.dropped_log_events));
 		count++;
 	}
 	output.SetCardinality(count);
@@ -4996,6 +7515,7 @@ void AiClearCacheFunction(ClientContext &context, TableFunctionInput &data_p, Da
 	}
 	duckdb_ai::ClearResponseCache(context);
 	ClearPromptQueryCache(context);
+	ClearSimilarityCache(context);
 	output.SetValue(0, 0, Value::BOOLEAN(true));
 	output.SetCardinality(1);
 	data.emitted = true;
@@ -5160,6 +7680,22 @@ void RegisterAiProviderSecretType(ExtensionLoader &loader, const std::string &ty
 
 void RegisterAiProviderSecret(ExtensionLoader &loader) {
 	RegisterAiProviderSecretType(loader, "duckdb_ai");
+
+	SecretType model_type;
+	model_type.name = "duckdb_ai_model";
+	model_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+	model_type.default_provider = "config";
+	model_type.extension = "duckdb_ai";
+	loader.RegisterSecretType(std::move(model_type));
+
+	CreateSecretFunction model_function;
+	model_function.secret_type = "duckdb_ai_model";
+	model_function.provider = "config";
+	model_function.function = CreateAiModelSecretFromConfig;
+	for (auto name : {"ai_provider", "model", "location", "credential", "model_type", "capabilities", "options"}) {
+		model_function.named_parameters[name] = LogicalType::VARCHAR;
+	}
+	loader.RegisterFunction(std::move(model_function));
 }
 
 struct AiFunctionDocumentation {
@@ -5193,6 +7729,8 @@ static const AiFunctionDocumentation AI_FUNCTION_DOCUMENTATION[] = {
      "SELECT ai_similarity('duck', 'goose');"},
     {"ai_rerank", "Uses a completion model to score candidate relevance to a query from 0 to 1.",
      "SELECT ai_rerank('best analytics database', 'DuckDB is an in-process analytics database');"},
+    {"ai_score", "Uses a completion model to score how well input satisfies criteria from 0 to 1.",
+     "SELECT ai_score('DuckDB runs in process', 'describes an embedded database');"},
     {"ai_summarize", "Summarizes text with a completion model.", "SELECT ai_summarize(review) FROM reviews;"},
     {"ai_sentiment", "Classifies text sentiment as positive, neutral, or negative.",
      "SELECT ai_sentiment(review) FROM reviews;"},
@@ -5206,6 +7744,11 @@ static const AiFunctionDocumentation AI_FUNCTION_DOCUMENTATION[] = {
      "SELECT ai_classify(review, 'positive, negative, mixed') FROM reviews;"},
     {"ai_classify_labels", "Chooses zero or more labels from a comma-separated VARCHAR or VARCHAR[] label list.",
      "SELECT ai_classify_labels(review, ['shipping', 'pricing', 'quality']) FROM reviews;"},
+    {"ai_classify_result", "Classifies into zero or more labels and returns STRUCT(value, error, metadata).",
+     "SELECT ai_classify_result(review, ['shipping', 'pricing', 'quality']) FROM reviews;"},
+    {"ai_classify_optimized",
+     "Uses a persisted centroid classifier artifact and falls back to an LLM when local confidence is insufficient.",
+     "SELECT ai_classify_optimized(review, classifier) FROM reviews;"},
     {"ai_extract", "Extracts requested information from text.",
      "SELECT ai_extract('Anna is 31', 'the age of the person');"},
     {"ai_filter", "Evaluates a natural-language predicate against text and returns BOOLEAN.",
@@ -5214,6 +7757,9 @@ static const AiFunctionDocumentation AI_FUNCTION_DOCUMENTATION[] = {
      "SELECT ai_agg(review, 'List the top complaints') FROM reviews;"},
     {"ai_summarize_agg", "Summarizes grouped text values with one completion call.",
      "SELECT ai_summarize_agg(review) FROM reviews;"},
+    {"ai_build_classifier",
+     "Builds an experimental persisted classifier artifact using sampled LLM labels and batched embeddings.",
+     "SELECT ai_build_classifier(review, ['positive', 'negative'], optimization := 'minimize_cost') FROM reviews;"},
     {"ai_sql",
      "Generates one read-only DuckDB SELECT statement from a natural-language question.\n"
      "With fix_attempts := N it verifies the SQL binds against the catalog and self-corrects using the bind error.",
@@ -5243,15 +7789,31 @@ static const AiFunctionDocumentation AI_FUNCTION_DOCUMENTATION[] = {
     {"ai_count_tokens", "Returns a local approximate token count for text.", "SELECT ai_count_tokens('hello world');"},
     {"ai_recommended_batch_size", "Returns a conservative row batch size for rate-limited AI jobs.",
      "SELECT ai_recommended_batch_size(200, 100, 100000);"},
+    {"ai_generate_chunks", "Splits text into deterministic fixed or recursive Unicode-aware chunks.",
+     "SELECT * FROM ai_generate_chunks('First paragraph. Second paragraph.');"},
+    {"ai_prep_search", "Creates retrieval and context-enriched embedding chunks from text or Markdown.",
+     "SELECT * FROM ai_prep_search('# Guide\nDuckDB runs in process.', title := 'Guide');"},
     {"ai_provider_base_url", "Returns the default base URL for a supported provider.",
      "SELECT ai_provider_base_url('openai');"},
     {"ai_provider_protocol", "Returns the internal protocol used for a supported provider.",
      "SELECT ai_provider_protocol('openai');"},
     {"ai_usage", "Returns recent per-database AI usage events.", "SELECT * FROM ai_usage();"},
+    {"ai_usage_summary", "Returns query-level AI usage totals and bounded-buffer drop counters.",
+     "SELECT * FROM ai_usage_summary();"},
     {"ai_clear_usage", "Clears the per-database usage event buffer.", "SELECT * FROM ai_clear_usage();"},
     {"ai_clear_cache", "Clears per-database in-memory response and generated-SQL caches.",
      "SELECT * FROM ai_clear_cache();"},
     {"ai_secrets", "Lists configured duckdb_ai secrets with credentials redacted.", "SELECT * FROM ai_secrets();"},
+    {"ai_models", "Lists registered external model profiles without credential material.",
+     "SELECT * FROM ai_models();"},
+    {"ai_provision_endpoint", "Plans or explicitly submits guarded endpoint provisioning through the control plane.",
+     "SELECT * FROM ai_provision_endpoint('support_model');"},
+    {"ai_endpoint_status", "Returns the current state of an asynchronous endpoint operation.",
+     "SELECT * FROM ai_endpoint_status('operation-id');"},
+    {"ai_deprovision_endpoint", "Explicitly submits endpoint deprovisioning through the control plane.",
+     "SELECT * FROM ai_deprovision_endpoint('support_model');"},
+    {"ai_parse_document", "Parses a BLOB through a normalized remote document-parser profile.",
+     "SELECT * FROM ai_parse_document(read_blob('document.pdf').content, 'application/pdf', 'documents');"},
     {"ai_model_prices", "Returns the built-in provider/model pricing catalog.", "SELECT * FROM ai_model_prices();"},
 };
 
@@ -5413,6 +7975,31 @@ void RegisterAiAggregateFunction(ExtensionLoader &loader, const std::string &nam
 	RegisterDocumentedFunction(loader, std::move(functions));
 }
 
+void RegisterClassifierBuildFunction(ExtensionLoader &loader) {
+	AggregateFunctionSet functions("ai_build_classifier");
+	for (idx_t argument_count = 2; argument_count <= 32; argument_count++) {
+		vector<LogicalType> arguments;
+		arguments.emplace_back(LogicalType::VARCHAR);
+		for (idx_t i = 1; i < argument_count; i++) {
+			arguments.emplace_back(LogicalType::ANY);
+		}
+		auto function = AggregateFunction(
+		    "ai_build_classifier", std::move(arguments), LogicalType::VARCHAR,
+		    AggregateFunction::StateSize<ClassifierBuildState>,
+		    AggregateFunction::StateInitialize<ClassifierBuildState, ClassifierBuildOperation>,
+		    AggregateFunction::UnaryScatterUpdate<ClassifierBuildState, string_t, ClassifierBuildOperation>,
+		    AggregateFunction::StateCombine<ClassifierBuildState, ClassifierBuildOperation>,
+		    AggregateFunction::StateFinalize<ClassifierBuildState, string_t, ClassifierBuildOperation>,
+		    FunctionNullHandling::DEFAULT_NULL_HANDLING,
+		    AggregateFunction::UnaryUpdate<ClassifierBuildState, string_t, ClassifierBuildOperation>,
+		    ClassifierBuildBind);
+		function.SetFallible();
+		function.SetVolatile();
+		functions.AddFunction(std::move(function));
+	}
+	RegisterDocumentedFunction(loader, std::move(functions));
+}
+
 void AddCompletionNamedParameters(TableFunction &function, bool include_response_options,
                                   bool include_log_payload_options) {
 	static const char *completion_options[] = {"model",
@@ -5562,12 +8149,228 @@ void RegisterPromptQueryFunction(ExtensionLoader &loader, const std::string &nam
 	RegisterDocumentedFunction(loader, std::move(ai_query_data));
 }
 
+struct ExternalModelParseData : public ParserExtensionParseData {
+	std::string name;
+	case_insensitive_map_t<std::string> options;
+	bool replace = false;
+
+	unique_ptr<ParserExtensionParseData> Copy() const override {
+		auto result = make_uniq<ExternalModelParseData>();
+		result->name = name;
+		result->options = options;
+		result->replace = replace;
+		return std::move(result);
+	}
+
+	string ToString() const override {
+		return "CREATE EXTERNAL MODEL " + name;
+	}
+};
+
+class ExternalModelSqlScanner {
+public:
+	explicit ExternalModelSqlScanner(const std::string &query_p) : query(query_p) {
+	}
+
+	void SkipWhitespace() {
+		while (position < query.size() && std::isspace(static_cast<unsigned char>(query[position]))) {
+			position++;
+		}
+	}
+
+	bool ConsumeKeyword(const std::string &keyword) {
+		SkipWhitespace();
+		if (position + keyword.size() > query.size() ||
+		    !StringUtil::CIEquals(query.substr(position, keyword.size()), keyword)) {
+			return false;
+		}
+		auto end = position + keyword.size();
+		if (end < query.size() && (std::isalnum(static_cast<unsigned char>(query[end])) || query[end] == '_')) {
+			return false;
+		}
+		position = end;
+		return true;
+	}
+
+	bool Consume(char expected) {
+		SkipWhitespace();
+		if (position >= query.size() || query[position] != expected) {
+			return false;
+		}
+		position++;
+		return true;
+	}
+
+	std::string Identifier() {
+		SkipWhitespace();
+		if (position >= query.size()) {
+			throw ParserException("Expected an external model identifier");
+		}
+		if (query[position] == '"') {
+			position++;
+			std::string value;
+			while (position < query.size()) {
+				if (query[position] == '"') {
+					if (position + 1 < query.size() && query[position + 1] == '"') {
+						value.push_back('"');
+						position += 2;
+						continue;
+					}
+					position++;
+					return value;
+				}
+				value.push_back(query[position++]);
+			}
+			throw ParserException("Unterminated quoted external model identifier");
+		}
+		auto start = position;
+		while (position < query.size() &&
+		       (std::isalnum(static_cast<unsigned char>(query[position])) || query[position] == '_')) {
+			position++;
+		}
+		if (start == position) {
+			throw ParserException("Expected an external model identifier");
+		}
+		return query.substr(start, position - start);
+	}
+
+	std::string ValueText() {
+		SkipWhitespace();
+		if (position >= query.size()) {
+			throw ParserException("Expected an external model option value");
+		}
+		if (query[position] == '\'') {
+			position++;
+			std::string value;
+			while (position < query.size()) {
+				if (query[position] == '\'') {
+					if (position + 1 < query.size() && query[position + 1] == '\'') {
+						value.push_back('\'');
+						position += 2;
+						continue;
+					}
+					position++;
+					return value;
+				}
+				value.push_back(query[position++]);
+			}
+			throw ParserException("Unterminated external model option string");
+		}
+		auto start = position;
+		while (position < query.size() && query[position] != ',' && query[position] != ')') {
+			position++;
+		}
+		auto value = query.substr(start, position - start);
+		StringUtil::Trim(value);
+		if (value.empty()) {
+			throw ParserException("Expected an external model option value");
+		}
+		return value;
+	}
+
+	bool Finished() {
+		SkipWhitespace();
+		if (position < query.size() && query[position] == ';') {
+			position++;
+			SkipWhitespace();
+		}
+		return position == query.size();
+	}
+
+private:
+	const std::string &query;
+	idx_t position = 0;
+};
+
+class ExternalModelParserExtension : public ParserExtension {
+public:
+	ExternalModelParserExtension() {
+		parse_function = Parse;
+		plan_function = Plan;
+	}
+
+	static ParserExtensionParseResult Parse(ParserExtensionInfo *, const string &query) {
+		try {
+			ExternalModelSqlScanner scanner(query);
+			if (!scanner.ConsumeKeyword("create")) {
+				return ParserExtensionParseResult();
+			}
+			auto data = make_uniq<ExternalModelParseData>();
+			if (scanner.ConsumeKeyword("or")) {
+				if (!scanner.ConsumeKeyword("replace")) {
+					return ParserExtensionParseResult();
+				}
+				data->replace = true;
+			}
+			if (!scanner.ConsumeKeyword("external") || !scanner.ConsumeKeyword("model")) {
+				return ParserExtensionParseResult();
+			}
+			data->name = scanner.Identifier();
+			if (!scanner.ConsumeKeyword("with") || !scanner.Consume('(')) {
+				return ParserExtensionParseResult("CREATE EXTERNAL MODEL requires WITH (...)");
+			}
+			while (true) {
+				auto key = LowerAscii(scanner.Identifier());
+				if (!scanner.Consume('=')) {
+					return ParserExtensionParseResult("Expected '=' after external model option " + key);
+				}
+				if (key == "base_url" || key == "endpoint") {
+					key = "location";
+				}
+				static const std::set<std::string> supported = {"provider",   "model",        "location", "credential",
+				                                                "model_type", "capabilities", "options"};
+				if (supported.find(key) == supported.end()) {
+					return ParserExtensionParseResult("Unsupported external model option: " + key);
+				}
+				if (data->options.find(key) != data->options.end()) {
+					return ParserExtensionParseResult("Duplicate external model option: " + key);
+				}
+				data->options[key] = scanner.ValueText();
+				if (scanner.Consume(')')) {
+					break;
+				}
+				if (!scanner.Consume(',')) {
+					return ParserExtensionParseResult("Expected ',' or ')' in external model options");
+				}
+			}
+			if (!scanner.Finished()) {
+				return ParserExtensionParseResult("Unexpected text after CREATE EXTERNAL MODEL");
+			}
+			if (data->options.find("provider") == data->options.end() ||
+			    data->options.find("model") == data->options.end()) {
+				return ParserExtensionParseResult("CREATE EXTERNAL MODEL requires provider and model options");
+			}
+			return ParserExtensionParseResult(std::move(data));
+		} catch (std::exception &ex) {
+			return ParserExtensionParseResult(ex.what());
+		}
+	}
+
+	static ParserExtensionPlanResult Plan(ParserExtensionInfo *, ClientContext &,
+	                                      unique_ptr<ParserExtensionParseData> parse_data) {
+		auto &data = static_cast<ExternalModelParseData &>(*parse_data);
+		auto get = [&](const std::string &key) {
+			auto entry = data.options.find(key);
+			return entry == data.options.end() ? std::string() : entry->second;
+		};
+		ParserExtensionPlanResult result;
+		result.function = ExternalModelTableFunction();
+		result.parameters = {Value(data.name),           Value(get("provider")),   Value(get("model")),
+		                     Value(get("location")),     Value(get("credential")), Value(get("model_type")),
+		                     Value(get("capabilities")), Value(get("options")),    Value::BOOLEAN(data.replace)};
+		result.return_type = StatementReturnType::QUERY_RESULT;
+		return result;
+	}
+};
+
 } // namespace
 
 static void LoadInternal(ExtensionLoader &loader) {
 	duckdb_ai::InitializeProviderRuntime();
 	RegisterSettings(loader);
 	RegisterAiProviderSecret(loader);
+	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+	ParserExtension::Register(config, ExternalModelParserExtension());
 
 	RegisterCompletionFunction(loader, "ai_complete", AiCompleteBind);
 	RegisterTryCompletionFunction(loader);
@@ -5609,6 +8412,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ai_rerank.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	RegisterDocumentedFunction(loader, std::move(ai_rerank));
 
+	auto ai_score = ScalarFunction("ai_score", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::DOUBLE,
+	                               AiRerankFunction, AiRerankBind);
+	ai_score.varargs = LogicalType::ANY;
+	ai_score.SetFallible();
+	ai_score.SetVolatile();
+	ai_score.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	RegisterDocumentedFunction(loader, std::move(ai_score));
+
 	RegisterTaskFunction(loader, "ai_summarize", {LogicalType::VARCHAR}, AiSummarizeBind);
 	RegisterTaskFunction(loader, "ai_sentiment", {LogicalType::VARCHAR}, AiSentimentBind);
 	RegisterTaskFunction(loader, "ai_fix_grammar", {LogicalType::VARCHAR}, AiFixGrammarBind);
@@ -5616,11 +8427,55 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterTaskFunction(loader, "ai_translate", {LogicalType::VARCHAR, LogicalType::VARCHAR}, AiTranslateBind);
 	RegisterClassifyFunction(loader);
 	RegisterClassifyLabelsFunction(loader);
+	auto ai_classify_result =
+	    ScalarFunction("ai_classify_result", {LogicalType::VARCHAR, LogicalType::ANY}, AiClassifyResultReturnType(),
+	                   AiClassifyResultFunction, AiClassifyResultBind);
+	ai_classify_result.varargs = LogicalType::ANY;
+	ai_classify_result.SetFallible();
+	ai_classify_result.SetVolatile();
+	ai_classify_result.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	RegisterDocumentedFunction(loader, std::move(ai_classify_result));
+	auto ai_classify_optimized =
+	    ScalarFunction("ai_classify_optimized", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   AiOptimizedClassifierReturnType(), AiOptimizedClassifierFunction, AiOptimizedClassifierBind);
+	ai_classify_optimized.varargs = LogicalType::ANY;
+	ai_classify_optimized.SetFallible();
+	ai_classify_optimized.SetVolatile();
+	ai_classify_optimized.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	RegisterDocumentedFunction(loader, std::move(ai_classify_optimized));
 	RegisterTaskFunction(loader, "ai_extract", {LogicalType::VARCHAR, LogicalType::VARCHAR}, AiExtractBind);
 	RegisterAiFilterFunction(loader);
 
 	RegisterAiAggregateFunction(loader, "ai_agg", AiAggBind, 2, 10);
 	RegisterAiAggregateFunction(loader, "ai_summarize_agg", AiSummarizeAggBind, 1, 9);
+	RegisterClassifierBuildFunction(loader);
+
+	auto ai_generate_chunks =
+	    TableFunction("ai_generate_chunks", {LogicalType::VARCHAR}, AiChunkFunction, AiGenerateChunksBind, AiChunkInit);
+	ai_generate_chunks.named_parameters["chunk_size"] = LogicalType::BIGINT;
+	ai_generate_chunks.named_parameters["overlap_percent"] = LogicalType::DOUBLE;
+	ai_generate_chunks.named_parameters["strategy"] = LogicalType::VARCHAR;
+	ai_generate_chunks.named_parameters["source_id"] = LogicalType::VARCHAR;
+	RegisterDocumentedFunction(loader, std::move(ai_generate_chunks));
+
+	auto ai_prep_search =
+	    TableFunction("ai_prep_search", {LogicalType::VARCHAR}, AiChunkFunction, AiPrepSearchBind, AiChunkInit);
+	ai_prep_search.named_parameters["chunk_size"] = LogicalType::BIGINT;
+	ai_prep_search.named_parameters["overlap_percent"] = LogicalType::DOUBLE;
+	ai_prep_search.named_parameters["strategy"] = LogicalType::VARCHAR;
+	ai_prep_search.named_parameters["source_id"] = LogicalType::VARCHAR;
+	ai_prep_search.named_parameters["title"] = LogicalType::VARCHAR;
+	ai_prep_search.named_parameters["metadata"] = LogicalType::VARCHAR;
+	ai_prep_search.named_parameters["enrich"] = LogicalType::BOOLEAN;
+	AddCompletionNamedParameters(ai_prep_search, false, false);
+	RegisterDocumentedFunction(loader, std::move(ai_prep_search));
+
+	auto ai_parse_document =
+	    TableFunction("ai_parse_document", {LogicalType::BLOB, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                  DocumentParseFunction, DocumentParseBind, DocumentParseInit);
+	ai_parse_document.named_parameters["pages"] = LogicalType::VARCHAR;
+	AddCompletionNamedParameters(ai_parse_document, false, false);
+	RegisterDocumentedFunction(loader, std::move(ai_parse_document));
 
 	RegisterPromptSqlFunction(loader, "ai_sql");
 
@@ -5667,11 +8522,23 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	RegisterDocumentedFunction(loader, TableFunction("ai_usage", {}, AiUsageFunction, AiUsageBind, AiUsageInit));
 	RegisterDocumentedFunction(
+	    loader, TableFunction("ai_usage_summary", {}, AiUsageSummaryFunction, AiUsageSummaryBind, AiUsageSummaryInit));
+	RegisterDocumentedFunction(
 	    loader, TableFunction("ai_clear_usage", {}, AiClearUsageFunction, AiClearUsageBind, AiClearUsageInit));
 	RegisterDocumentedFunction(
 	    loader, TableFunction("ai_clear_cache", {}, AiClearCacheFunction, AiClearUsageBind, AiClearUsageInit));
 	RegisterDocumentedFunction(loader,
 	                           TableFunction("ai_secrets", {}, AiSecretsFunction, AiSecretsBind, AiSecretsInit));
+	RegisterDocumentedFunction(loader, TableFunction("ai_models", {}, AiModelsFunction, AiModelsBind, AiModelsInit));
+	auto ai_provision_endpoint = TableFunction("ai_provision_endpoint", {LogicalType::VARCHAR}, ControlPlaneFunction,
+	                                           ProvisionEndpointBind, AiClearUsageInit);
+	ai_provision_endpoint.named_parameters["dry_run"] = LogicalType::BOOLEAN;
+	ai_provision_endpoint.named_parameters["max_hourly_cost_usd"] = LogicalType::DOUBLE;
+	RegisterDocumentedFunction(loader, std::move(ai_provision_endpoint));
+	RegisterDocumentedFunction(loader, TableFunction("ai_endpoint_status", {LogicalType::VARCHAR}, ControlPlaneFunction,
+	                                                 EndpointStatusBind, AiClearUsageInit));
+	RegisterDocumentedFunction(loader, TableFunction("ai_deprovision_endpoint", {LogicalType::VARCHAR},
+	                                                 ControlPlaneFunction, DeprovisionEndpointBind, AiClearUsageInit));
 	RegisterDocumentedFunction(
 	    loader, TableFunction("ai_model_prices", {}, AiModelPricesFunction, AiModelPricesBind, AiModelPricesInit));
 }

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -1,11 +1,14 @@
 #include "duckdb_ai_provider.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/object_cache.hpp"
+#include "re2/re2.h"
 #include "yyjson.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cctype>
 #include <cmath>
@@ -24,7 +27,6 @@
 #include <memory>
 #include <mutex>
 #include <random>
-#include <regex>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
@@ -91,13 +93,15 @@ void StopUsageLogWorker(ProviderRuntimeState &state);
 
 const size_t MAX_USAGE_EVENTS = 1024;
 const size_t MAX_USAGE_LOG_QUEUE = 4096;
-//! Maximum inputs per batched embedding request. Keeps request payloads bounded and stays well
-//! below provider per-request input limits (OpenAI allows up to 2048 inputs).
-const size_t MAX_EMBED_BATCH_INPUTS = 512;
+//! Bound untrusted provider and telemetry responses before appending them to an
+//! in-memory string. This still accommodates large batched embedding responses.
+constexpr size_t DEFAULT_MAX_HTTP_RESPONSE_BYTES = 64ULL * 1024ULL * 1024ULL;
+constexpr size_t MAX_HTTP_RESPONSE_BYTES_LIMIT = 1024ULL * 1024ULL * 1024ULL;
 constexpr int64_t MAX_TOKEN_LIMIT_PER_MINUTE = 10000000000LL;
 constexpr int64_t MAX_PROVIDER_CHUNK_WORKERS = 64;
 constexpr int64_t DEFAULT_COMPLETION_OUTPUT_TOKEN_ESTIMATE = 512;
 std::once_flag curl_global_init_once;
+std::atomic<uint64_t> next_operation_id {1};
 const size_t DEFAULT_MAX_RESPONSE_CACHE_ENTRIES = 1024;
 
 struct ProviderRuntimeState : public ObjectCacheEntry {
@@ -118,6 +122,7 @@ struct ProviderRuntimeState : public ObjectCacheEntry {
 	std::mutex usage_mutex;
 	std::vector<UsageEvent> usage_events;
 	uint64_t next_usage_event_id = 1;
+	uint64_t dropped_usage_events = 0;
 
 	std::mutex provider_control_mutex;
 	std::condition_variable provider_control_cv;
@@ -139,6 +144,7 @@ struct ProviderRuntimeState : public ObjectCacheEntry {
 	std::thread usage_log_worker;
 	bool usage_log_worker_started = false;
 	bool usage_log_shutdown = false;
+	uint64_t dropped_usage_log_events = 0;
 };
 
 ProviderRuntimeState fallback_runtime_state;
@@ -158,6 +164,27 @@ std::string LowerAscii(std::string input) {
 	std::transform(input.begin(), input.end(), input.begin(),
 	               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
 	return input;
+}
+
+CompletionOptions RequestOperationOptions(const CompletionOptions &options) {
+	auto result = options;
+	if (result.operation_id.empty()) {
+		if (result.parent_operation_id.empty()) {
+			result.parent_operation_id = result.query_id;
+		}
+		auto prefix = result.query_id.empty() ? std::string("ai") : result.query_id;
+		result.operation_id = prefix + ":op:" + std::to_string(next_operation_id.fetch_add(1));
+	}
+	return result;
+}
+
+CompletionOptions ChildOperationOptions(const CompletionOptions &options) {
+	auto result = options;
+	if (result.parent_operation_id.empty()) {
+		result.parent_operation_id = result.operation_id.empty() ? result.query_id : result.operation_id;
+	}
+	result.operation_id.clear();
+	return RequestOperationOptions(result);
 }
 
 std::string NormalizeProviderNameInternal(const std::string &provider_input) {
@@ -372,13 +399,23 @@ std::string UrlHost(const std::string &url) {
 	if (scheme_end == std::string::npos) {
 		throw InvalidInputException("AI provider URL must include a scheme: %s", url);
 	}
+	auto scheme = LowerAscii(url.substr(0, scheme_end));
+	if (scheme != "http" && scheme != "https") {
+		throw InvalidInputException("AI provider URL scheme must be http or https");
+	}
+	for (auto c : url) {
+		auto value = static_cast<unsigned char>(c);
+		if (value <= 0x20 || value == 0x7f || c == '\\') {
+			throw InvalidInputException("AI provider URL contains prohibited characters");
+		}
+	}
 	auto host_start = scheme_end + 3;
-	auto path_start = url.find('/', host_start);
+	auto path_start = url.find_first_of("/?#", host_start);
 	auto authority =
 	    url.substr(host_start, path_start == std::string::npos ? std::string::npos : path_start - host_start);
 	auto at_pos = authority.rfind('@');
 	if (at_pos != std::string::npos) {
-		authority = authority.substr(at_pos + 1);
+		throw InvalidInputException("AI provider URL must not include credentials");
 	}
 	if (authority.empty()) {
 		throw InvalidInputException("AI provider URL must include a host: %s", url);
@@ -388,9 +425,16 @@ std::string UrlHost(const std::string &url) {
 		if (bracket_end == std::string::npos) {
 			throw InvalidInputException("AI provider URL has an invalid IPv6 host: %s", url);
 		}
+		auto remainder = authority.substr(bracket_end + 1);
+		if (!remainder.empty() && remainder.front() != ':') {
+			throw InvalidInputException("AI provider URL has an invalid IPv6 authority: %s", url);
+		}
 		return LowerAscii(authority.substr(1, bracket_end - 1));
 	}
-	auto colon_pos = authority.find(':');
+	auto colon_pos = authority.rfind(':');
+	if (colon_pos != std::string::npos && authority.find(':') != colon_pos) {
+		throw InvalidInputException("AI provider URL must bracket IPv6 hosts: %s", url);
+	}
 	auto host = colon_pos == std::string::npos ? authority : authority.substr(0, colon_pos);
 	if (host.empty()) {
 		throw InvalidInputException("AI provider URL must include a host: %s", url);
@@ -462,11 +506,11 @@ std::string AllowedHosts(const CompletionOptions &options) {
 }
 
 void EnforceAllowedHost(const std::string &url, const CompletionOptions &options) {
+	auto host = UrlHost(url);
 	auto allowed_hosts = SplitCommaList(AllowedHosts(options));
 	if (allowed_hosts.empty()) {
 		return;
 	}
-	auto host = UrlHost(url);
 	for (auto &allowed_host : allowed_hosts) {
 		if (HostMatchesAllowedPattern(host, allowed_host)) {
 			return;
@@ -568,7 +612,8 @@ bool StartsWith(const std::string &value, const std::string &prefix) {
 }
 
 bool HasHttpScheme(const std::string &value) {
-	return StartsWith(value, "https://") || StartsWith(value, "http://");
+	auto lower_value = LowerAscii(value);
+	return StartsWith(lower_value, "https://") || StartsWith(lower_value, "http://");
 }
 
 std::string AzureOpenAIBaseUrl(std::string value) {
@@ -1218,6 +1263,15 @@ bool YyjsonDirectInteger(duckdb_yyjson::yyjson_val *object, const char *key, int
 	return true;
 }
 
+bool YyjsonDirectDouble(duckdb_yyjson::yyjson_val *object, const char *key, double &result) {
+	auto value = YyjsonObjectGet(object, key);
+	if (!value || !duckdb_yyjson::yyjson_is_num(value)) {
+		return false;
+	}
+	result = duckdb_yyjson::yyjson_get_num(value);
+	return true;
+}
+
 int64_t YyjsonIntegerOrMissing(duckdb_yyjson::yyjson_val *object, const char *key) {
 	int64_t result = -1;
 	YyjsonDirectInteger(object, key, result);
@@ -1477,7 +1531,9 @@ bool SchemaNonNegativeIntegerField(const JsonValue &schema, const std::string &f
 	if (!SchemaNumberField(schema, field, number_value)) {
 		return false;
 	}
-	if (number_value < 0 || std::floor(number_value) != number_value) {
+	if (!std::isfinite(number_value) || number_value < 0 ||
+	    number_value > static_cast<double>(std::numeric_limits<int64_t>::max()) ||
+	    std::floor(number_value) != number_value) {
 		return false;
 	}
 	value = static_cast<int64_t>(number_value);
@@ -1676,10 +1732,10 @@ void ExtractSchemaPropertyList(const JsonValue &schema, std::vector<JsonSchemaPr
 
 bool RegexMatches(const std::string &value, const std::string &pattern, const std::string &path, std::string &error) {
 	static std::mutex regex_cache_mutex;
-	static std::unordered_map<std::string, std::shared_ptr<std::regex>> regex_cache;
+	static std::unordered_map<std::string, std::shared_ptr<duckdb_re2::RE2>> regex_cache;
 	constexpr size_t max_regex_cache_entries = 256;
 	try {
-		std::shared_ptr<std::regex> regex;
+		std::shared_ptr<duckdb_re2::RE2> regex;
 		{
 			std::lock_guard<std::mutex> lock(regex_cache_mutex);
 			auto entry = regex_cache.find(pattern);
@@ -1687,14 +1743,18 @@ bool RegexMatches(const std::string &value, const std::string &pattern, const st
 				if (regex_cache.size() >= max_regex_cache_entries) {
 					regex_cache.clear();
 				}
-				regex = std::make_shared<std::regex>(pattern);
+				regex = std::make_shared<duckdb_re2::RE2>(pattern);
+				if (!regex->ok()) {
+					error = path + " schema pattern is invalid: " + regex->error();
+					return false;
+				}
 				regex_cache.emplace(pattern, regex);
 			} else {
 				regex = entry->second;
 			}
 		}
-		return std::regex_search(value, *regex);
-	} catch (std::regex_error &ex) {
+		return duckdb_re2::RE2::PartialMatch(duckdb_re2::StringPiece(value.data(), value.size()), *regex);
+	} catch (std::exception &ex) {
 		error = path + " schema pattern is invalid: " + ex.what();
 		return false;
 	}
@@ -2044,10 +2104,56 @@ int64_t FindJsonIntegerValue(const std::string &body, const std::string &key) {
 	return -1;
 }
 
+size_t MaxHttpResponseBytes() {
+	auto configured = GetEnv("DUCKDB_AI_MAX_RESPONSE_BYTES");
+	if (configured.empty()) {
+		return DEFAULT_MAX_HTTP_RESPONSE_BYTES;
+	}
+	try {
+		size_t parsed = 0;
+		auto value = std::stoull(configured, &parsed);
+		if (parsed != configured.size() || value == 0 || value > MAX_HTTP_RESPONSE_BYTES_LIMIT) {
+			throw InvalidInputException("DUCKDB_AI_MAX_RESPONSE_BYTES must be between 1 and %llu",
+			                            static_cast<unsigned long long>(MAX_HTTP_RESPONSE_BYTES_LIMIT));
+		}
+		return static_cast<size_t>(value);
+	} catch (InvalidInputException &) {
+		throw;
+	} catch (...) {
+		throw InvalidInputException("DUCKDB_AI_MAX_RESPONSE_BYTES must be an integer between 1 and %llu",
+		                            static_cast<unsigned long long>(MAX_HTTP_RESPONSE_BYTES_LIMIT));
+	}
+}
+
+struct ResponseWriteState {
+	explicit ResponseWriteState(size_t max_bytes_p) : max_bytes(max_bytes_p) {
+	}
+
+	std::string body;
+	size_t max_bytes;
+	bool limit_exceeded = false;
+};
+
 size_t WriteCallback(char *ptr, size_t size, size_t nmemb, void *userdata) {
-	auto response = reinterpret_cast<std::string *>(userdata);
-	response->append(ptr, size * nmemb);
-	return size * nmemb;
+	auto response = reinterpret_cast<ResponseWriteState *>(userdata);
+	if (size != 0 && nmemb > std::numeric_limits<size_t>::max() / size) {
+		response->limit_exceeded = true;
+		return 0;
+	}
+	auto incoming_bytes = size * nmemb;
+	if (incoming_bytes > response->max_bytes || response->body.size() > response->max_bytes - incoming_bytes) {
+		response->limit_exceeded = true;
+		return 0;
+	}
+	response->body.append(ptr, incoming_bytes);
+	return incoming_bytes;
+}
+
+void ValidateHttpHeader(const std::string &header) {
+	if (header.find('\r') != std::string::npos || header.find('\n') != std::string::npos ||
+	    header.find('\0') != std::string::npos) {
+		throw InvalidInputException("AI HTTP header value contains prohibited control characters");
+	}
 }
 
 bool ClientInterrupted(ClientContext *context) {
@@ -2421,22 +2527,34 @@ HttpResponse HttpPost(const std::string &url, const std::string &payload, const 
 	int64_t total_elapsed_ms = 0;
 	for (long attempt = 0; attempt <= retry_count; attempt++) {
 		auto curl = ThreadLocalCurlHandle();
-		std::string response_body;
+		ResponseWriteState response(MaxHttpResponseBytes());
 		CurlHeaderCapture header_capture;
 		CurlProgressState progress_state {client_context};
 		struct curl_slist *header_list = nullptr;
 		for (auto &header : headers) {
-			header_list = curl_slist_append(header_list, header.c_str());
+			ValidateHttpHeader(header);
+		}
+		for (auto &header : headers) {
+			auto appended_headers = curl_slist_append(header_list, header.c_str());
+			if (!appended_headers) {
+				curl_slist_free_all(header_list);
+				throw OutOfMemoryException("Could not allocate AI provider request headers");
+			}
+			header_list = appended_headers;
 		}
 
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 		curl_easy_setopt(curl, CURLOPT_POST, 1L);
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(payload.size()));
+		if (payload.size() > static_cast<size_t>(std::numeric_limits<curl_off_t>::max())) {
+			curl_slist_free_all(header_list);
+			throw InvalidInputException("AI provider request payload is too large");
+		}
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.size()));
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
 		curl_easy_setopt(curl, CURLOPT_SHARE, SharedCurlHandle());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, HeaderCallback);
 		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &header_capture);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
@@ -2459,6 +2577,10 @@ HttpResponse HttpPost(const std::string &url, const std::string &payload, const 
 		curl_slist_free_all(header_list);
 
 		total_elapsed_ms += std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+		if (response.limit_exceeded) {
+			throw InvalidInputException("AI HTTP response exceeded DUCKDB_AI_MAX_RESPONSE_BYTES (%llu bytes)",
+			                            static_cast<unsigned long long>(response.max_bytes));
+		}
 		if (attempt < retry_count && (result != CURLE_OK || IsRetryableHttpStatus(status))) {
 			if (result == CURLE_ABORTED_BY_CALLBACK && ClientInterrupted(client_context)) {
 				throw InterruptException();
@@ -2473,11 +2595,12 @@ HttpResponse HttpPost(const std::string &url, const std::string &payload, const 
 			throw IOException("AI provider request failed: %s", curl_easy_strerror(result));
 		}
 		if (throw_http_errors && (status < 200 || status >= 300)) {
-			throw IOException("AI provider returned HTTP %ld: %s", status, response_body);
+			throw IOException("AI provider returned HTTP %ld: %s", status, response.body);
 		}
-		auto response = HttpResponse(response_body, status, total_elapsed_ms, header_capture.retry_after_ms);
-		response.retries = attempt;
-		return response;
+		auto http_response =
+		    HttpResponse(std::move(response.body), status, total_elapsed_ms, header_capture.retry_after_ms);
+		http_response.retries = attempt;
+		return http_response;
 	}
 	throw InternalException("AI provider retry loop exited unexpectedly");
 }
@@ -2521,6 +2644,7 @@ void EnqueueUsageLog(ProviderRuntimeState &state, UsageLogJob job) {
 		StartUsageLogWorkerLocked(state);
 		if (state.usage_log_queue.size() >= MAX_USAGE_LOG_QUEUE) {
 			state.usage_log_queue.pop_front();
+			state.dropped_usage_log_events++;
 		}
 		state.usage_log_queue.push_back(std::move(job));
 	}
@@ -2568,6 +2692,8 @@ HttpResponse ProviderHttpPost(const std::string &url, const std::string &payload
 			}
 			return response;
 		} catch (InterruptException &) {
+			throw;
+		} catch (InvalidInputException &) {
 			throw;
 		} catch (std::exception &) {
 			if (attempt >= retry_count) {
@@ -3885,8 +4011,9 @@ void PushUsageEvent(ProviderRuntimeState &state, UsageEvent event) {
 	event.event_id = state.next_usage_event_id++;
 	state.usage_events.push_back(std::move(event));
 	if (state.usage_events.size() > MAX_USAGE_EVENTS) {
-		state.usage_events.erase(state.usage_events.begin(),
-		                         state.usage_events.begin() + (state.usage_events.size() - MAX_USAGE_EVENTS));
+		auto dropped = state.usage_events.size() - MAX_USAGE_EVENTS;
+		state.usage_events.erase(state.usage_events.begin(), state.usage_events.begin() + dropped);
+		state.dropped_usage_events += dropped;
 	}
 }
 
@@ -3897,6 +4024,8 @@ void RecordUsageEvent(const ProviderConfig &config, const std::string &prompt, c
 	event.event = "ai_completion";
 	event.function_name = options.function_name;
 	event.query_id = options.query_id;
+	event.operation_id = options.operation_id;
+	event.parent_operation_id = options.parent_operation_id;
 	event.provider = config.provider;
 	event.protocol = config.protocol;
 	event.model = config.model;
@@ -3926,6 +4055,8 @@ void RecordFailedUsageEvent(const ProviderConfig &config, const std::string &pro
 	event.event = "ai_completion";
 	event.function_name = options.function_name;
 	event.query_id = options.query_id;
+	event.operation_id = options.operation_id;
+	event.parent_operation_id = options.parent_operation_id;
 	event.provider = config.provider;
 	event.protocol = config.protocol;
 	event.model = config.model;
@@ -3949,19 +4080,21 @@ void RecordFailedUsageEvent(const ProviderConfig &config, const std::string &pro
 }
 
 void RecordEmbeddingUsageEvent(const ProviderConfig &config, const std::string &input, const EmbeddingResult &result,
-                               const CompletionOptions &options) {
+                               const CompletionOptions &options, int64_t dimensions = -1) {
 	UsageEvent event;
 	event.created_at = CurrentTimestamp();
 	event.event = "ai_embedding";
 	event.function_name = options.function_name;
 	event.query_id = options.query_id;
+	event.operation_id = options.operation_id;
+	event.parent_operation_id = options.parent_operation_id;
 	event.provider = config.provider;
 	event.protocol = config.protocol;
 	event.model = config.model;
 	event.prompt_chars = static_cast<int64_t>(input.size());
 	event.response_chars = 0;
 	event.input_chars = static_cast<int64_t>(input.size());
-	event.dimensions = static_cast<int64_t>(result.values.size());
+	event.dimensions = dimensions >= 0 ? dimensions : static_cast<int64_t>(result.values.size());
 	event.prompt_tokens = result.prompt_tokens;
 	event.completion_tokens = -1;
 	event.total_tokens = result.total_tokens;
@@ -3985,6 +4118,8 @@ void RecordFailedEmbeddingUsageEvent(const ProviderConfig &config, const std::st
 	event.event = "ai_embedding";
 	event.function_name = options.function_name;
 	event.query_id = options.query_id;
+	event.operation_id = options.operation_id;
+	event.parent_operation_id = options.parent_operation_id;
 	event.provider = config.provider;
 	event.protocol = config.protocol;
 	event.model = config.model;
@@ -4298,6 +4433,33 @@ std::string SerializeEmbeddingCacheBody(const ProviderConfig &config, const Embe
 	return body;
 }
 
+void ValidateEmbeddingInputLimits(const std::string &input, const ProviderCapabilities &capabilities) {
+	auto input_tokens = EstimateTokenCount(input);
+	if (input_tokens > capabilities.max_batch_tokens) {
+		throw InvalidInputException(
+		    "AI embedding input has %lld estimated tokens; external model request limit is %lld",
+		    static_cast<long long>(input_tokens), static_cast<long long>(capabilities.max_batch_tokens));
+	}
+	if (capabilities.context_tokens > 0 && input_tokens > capabilities.context_tokens) {
+		throw InvalidInputException(
+		    "AI embedding input has %lld estimated tokens; external model context limit is %lld",
+		    static_cast<long long>(input_tokens), static_cast<long long>(capabilities.context_tokens));
+	}
+	if (NumericCast<int64_t>(input.size()) + 64 > capabilities.max_request_bytes) {
+		throw InvalidInputException("AI embedding input exceeds external model max_request_bytes");
+	}
+}
+
+std::string EmbeddingDimensionError(const EmbeddingResult &result, const ProviderCapabilities &capabilities) {
+	if (capabilities.embedding_dimensions <= 0 ||
+	    NumericCast<int64_t>(result.values.size()) == capabilities.embedding_dimensions) {
+		return "";
+	}
+	return StringUtil::Format("AI embedding provider returned %llu dimensions; external model expects %lld",
+	                          static_cast<unsigned long long>(result.values.size()),
+	                          static_cast<long long>(capabilities.embedding_dimensions));
+}
+
 //! Fetch a provider response, going through the response cache and in-flight request coalescing
 //! when caching is enabled. Sets cache_key_out whenever the response cache is consulted so
 //! callers can evict entries that later fail response parsing.
@@ -4373,6 +4535,18 @@ std::vector<EmbeddingResult> EmbedBatchRequest(const ProviderConfig &config, con
 		}
 		throw;
 	}
+	auto capabilities = GetProviderCapabilities(options);
+	if (capabilities.embedding_dimensions > 0) {
+		for (auto &result : results) {
+			auto error = EmbeddingDimensionError(result, capabilities);
+			if (!error.empty()) {
+				for (auto &input : inputs) {
+					RecordFailedEmbeddingUsageEvent(config, input, options, response.status, error, response.retries);
+				}
+				throw InvalidInputException("%s", error);
+			}
+		}
+	}
 	for (idx_t i = 0; i < results.size(); i++) {
 		RecordEmbeddingUsageEvent(config, inputs[i], results[i], options);
 		MaybePostEmbeddingLog(config, inputs[i], results[i], options);
@@ -4409,6 +4583,97 @@ std::string ProviderProtocol(const std::string &provider) {
 	return ProviderDefaults(provider).protocol;
 }
 
+ProviderCapabilities GetProviderCapabilities(const CompletionOptions &options) {
+	auto config = ResolveProviderConfig(options, false);
+	ProviderCapabilities capabilities;
+	capabilities.provider = config.provider;
+	capabilities.protocol = config.protocol;
+	// These are deliberately conservative transport limits. Provider account tiers and
+	// model-specific limits can be lower, in which case EmbedMany recursively splits a
+	// rejected payload instead of failing the whole vector.
+	capabilities.max_batch_inputs = 512;
+	capabilities.max_batch_tokens = 100000;
+	capabilities.max_request_bytes = 8 * 1024 * 1024;
+	capabilities.context_tokens = -1;
+	capabilities.embedding_dimensions = -1;
+	capabilities.native_batch_jobs = false;
+	if (config.protocol == "ollama_embed") {
+		capabilities.max_batch_inputs = 128;
+		capabilities.max_batch_tokens = 32768;
+		capabilities.max_request_bytes = 4 * 1024 * 1024;
+	}
+	if (!options.model_options.empty()) {
+		std::string error;
+		auto document = ReadYyjsonDocument(options.model_options, error);
+		auto root = document ? duckdb_yyjson::yyjson_doc_get_root(document.get()) : nullptr;
+		if (!root || !duckdb_yyjson::yyjson_is_obj(root)) {
+			throw InvalidInputException("External model options must be a JSON object: %s", error);
+		}
+		auto apply_limit = [&](const char *name, int64_t &target, int64_t maximum) {
+			int64_t value;
+			if (!YyjsonDirectInteger(root, name, value)) {
+				return false;
+			}
+			if (value <= 0 || value > maximum) {
+				throw InvalidInputException("External model option \"%s\" must be between 1 and %lld", name,
+				                            static_cast<long long>(maximum));
+			}
+			target = value;
+			return true;
+		};
+		if (!apply_limit("max_batch_inputs", capabilities.max_batch_inputs, 1000000)) {
+			apply_limit("max_inputs", capabilities.max_batch_inputs, 1000000);
+		}
+		apply_limit("max_batch_tokens", capabilities.max_batch_tokens, 1000000000);
+		apply_limit("max_request_bytes", capabilities.max_request_bytes,
+		            static_cast<int64_t>(MAX_HTTP_RESPONSE_BYTES_LIMIT));
+		if (!apply_limit("context_size", capabilities.context_tokens, 1000000000)) {
+			apply_limit("max_input_tokens", capabilities.context_tokens, 1000000000);
+		}
+		apply_limit("embedding_dimensions", capabilities.embedding_dimensions, 1000000);
+		auto native_batch = YyjsonObjectGet(root, "native_batch_support");
+		if (!native_batch) {
+			native_batch = YyjsonObjectGet(root, "native_batch_jobs");
+		}
+		if (native_batch) {
+			if (!duckdb_yyjson::yyjson_is_bool(native_batch)) {
+				throw InvalidInputException("External model native_batch_support must be a boolean");
+			}
+			capabilities.native_batch_jobs = duckdb_yyjson::yyjson_get_bool(native_batch);
+		}
+	}
+	return capabilities;
+}
+
+void ApplyModelProfileOptions(CompletionOptions &options) {
+	if (options.model_options.empty()) {
+		return;
+	}
+	std::string error;
+	auto document = ReadYyjsonDocument(options.model_options, error);
+	auto root = document ? duckdb_yyjson::yyjson_doc_get_root(document.get()) : nullptr;
+	if (!root || !duckdb_yyjson::yyjson_is_obj(root)) {
+		throw InvalidInputException("External model options must be a JSON object: %s", error);
+	}
+	auto apply_price = [&](const char *name, bool &has_value, double &target) {
+		double value;
+		if (!YyjsonDirectDouble(root, name, value)) {
+			return;
+		}
+		if (!std::isfinite(value) || value < 0) {
+			throw InvalidInputException("External model option \"%s\" must be a finite non-negative number", name);
+		}
+		if (!has_value) {
+			has_value = true;
+			target = value;
+		}
+	};
+	apply_price("input_token_price_per_million", options.has_input_token_price_per_million,
+	            options.input_token_price_per_million);
+	apply_price("output_token_price_per_million", options.has_output_token_price_per_million,
+	            options.output_token_price_per_million);
+}
+
 int64_t EstimateTokenCount(const std::string &input) {
 	if (input.empty()) {
 		return 0;
@@ -4439,25 +4704,26 @@ CompletionResult Complete(const std::string &prompt, const CompletionOptions &op
 	if (prompt.empty()) {
 		throw InvalidInputException("ai_complete prompt must not be empty");
 	}
-	auto config = ResolveProvider(options);
+	auto request_options = RequestOperationOptions(options);
+	auto config = ResolveProvider(request_options);
 	auto endpoint = RequestEndpoint(config);
-	auto payload = RequestPayload(config, prompt, options);
-	EnforceAllowedHost(endpoint, options);
+	auto payload = RequestPayload(config, prompt, request_options);
+	EnforceAllowedHost(endpoint, request_options);
 	HttpResponse response;
 	std::string cache_key;
 	try {
-		response = FetchProviderResponse("completion", config, endpoint, payload, options,
-		                                 EstimatedCompletionTokens(prompt, options), cache_key);
+		response = FetchProviderResponse("completion", config, endpoint, payload, request_options,
+		                                 EstimatedCompletionTokens(prompt, request_options), cache_key);
 	} catch (InterruptException &) {
 		// Query cancellation is not a provider failure; keep it out of usage error events.
 		throw;
 	} catch (std::exception &ex) {
-		RecordFailedUsageEvent(config, prompt, options, 0, ex.what(), 0);
+		RecordFailedUsageEvent(config, prompt, request_options, 0, ex.what(), 0);
 		throw;
 	}
 	if (response.status < 200 || response.status >= 300) {
 		auto error = ProviderErrorDetail(config, response);
-		RecordFailedUsageEvent(config, prompt, options, response.status, error, response.retries);
+		RecordFailedUsageEvent(config, prompt, request_options, response.status, error, response.retries);
 		throw IOException("%s", error);
 	}
 	CompletionResult result;
@@ -4467,13 +4733,13 @@ CompletionResult Complete(const std::string &prompt, const CompletionOptions &op
 		if (!cache_key.empty()) {
 			// Do not keep responses that cannot be parsed (for example truncated output); a
 			// poisoned entry would fail every later cache hit until ai_clear_cache().
-			RemoveCachedResponse(RuntimeState(options), cache_key);
+			RemoveCachedResponse(RuntimeState(request_options), cache_key);
 		}
-		RecordFailedUsageEvent(config, prompt, options, response.status, ex.what(), response.retries);
+		RecordFailedUsageEvent(config, prompt, request_options, response.status, ex.what(), response.retries);
 		throw;
 	}
-	RecordUsageEvent(config, prompt, result, options);
-	MaybePostUsageLog(config, prompt, result, options);
+	RecordUsageEvent(config, prompt, result, request_options);
+	MaybePostUsageLog(config, prompt, result, request_options);
 	return result;
 }
 
@@ -4481,28 +4747,29 @@ CompletionResult Redact(const std::string &text, const CompletionOptions &option
 	if (text.empty()) {
 		throw InvalidInputException("ai_redact text must not be empty");
 	}
-	auto config = ResolveProvider(options);
+	auto request_options = RequestOperationOptions(options);
+	auto config = ResolveProvider(request_options);
 	if (config.protocol != "privacy_filter") {
 		throw InvalidInputException("AI provider \"%s\" does not support dedicated Privacy Filter redaction.",
 		                            config.provider);
 	}
 	auto endpoint = RequestEndpoint(config);
-	auto payload = RequestPayload(config, text, options);
-	EnforceAllowedHost(endpoint, options);
+	auto payload = RequestPayload(config, text, request_options);
+	EnforceAllowedHost(endpoint, request_options);
 	HttpResponse response;
 	std::string cache_key;
 	try {
-		response =
-		    FetchProviderResponse("redaction", config, endpoint, payload, options, EstimateTokenCount(text), cache_key);
+		response = FetchProviderResponse("redaction", config, endpoint, payload, request_options,
+		                                 EstimateTokenCount(text), cache_key);
 	} catch (InterruptException &) {
 		throw;
 	} catch (std::exception &ex) {
-		RecordFailedUsageEvent(config, text, options, 0, ex.what(), 0);
+		RecordFailedUsageEvent(config, text, request_options, 0, ex.what(), 0);
 		throw;
 	}
 	if (response.status < 200 || response.status >= 300) {
 		auto error = ProviderErrorDetail(config, response);
-		RecordFailedUsageEvent(config, text, options, response.status, error, response.retries);
+		RecordFailedUsageEvent(config, text, request_options, response.status, error, response.retries);
 		throw IOException("%s", error);
 	}
 	CompletionResult result;
@@ -4510,13 +4777,13 @@ CompletionResult Redact(const std::string &text, const CompletionOptions &option
 		result = ParseCompletionResult(config, response);
 	} catch (std::exception &ex) {
 		if (!cache_key.empty()) {
-			RemoveCachedResponse(RuntimeState(options), cache_key);
+			RemoveCachedResponse(RuntimeState(request_options), cache_key);
 		}
-		RecordFailedUsageEvent(config, text, options, response.status, ex.what(), response.retries);
+		RecordFailedUsageEvent(config, text, request_options, response.status, ex.what(), response.retries);
 		throw;
 	}
-	RecordUsageEvent(config, text, result, options);
-	MaybePostUsageLog(config, text, result, options);
+	RecordUsageEvent(config, text, result, request_options);
+	MaybePostUsageLog(config, text, result, request_options);
 	return result;
 }
 
@@ -4543,24 +4810,32 @@ EmbeddingResult Embed(const std::string &input, const CompletionOptions &options
 	if (input.empty()) {
 		throw InvalidInputException("ai_embed input must not be empty");
 	}
-	auto config = ResolveEmbeddingProviderConfig(options, true);
+	auto request_options = RequestOperationOptions(options);
+	auto config = ResolveEmbeddingProviderConfig(request_options, true);
+	auto capabilities = GetProviderCapabilities(request_options);
+	try {
+		ValidateEmbeddingInputLimits(input, capabilities);
+	} catch (std::exception &ex) {
+		RecordFailedEmbeddingUsageEvent(config, input, request_options, 0, ex.what(), 0);
+		throw;
+	}
 	auto endpoint = EmbeddingEndpoint(config);
 	auto payload = EmbeddingPayload(config, input);
-	EnforceAllowedHost(endpoint, options);
+	EnforceAllowedHost(endpoint, request_options);
 	HttpResponse response;
 	std::string cache_key;
 	try {
-		response = FetchProviderResponse("embedding", config, endpoint, payload, options, EstimateTokenCount(input),
-		                                 cache_key);
+		response = FetchProviderResponse("embedding", config, endpoint, payload, request_options,
+		                                 EstimateTokenCount(input), cache_key);
 	} catch (InterruptException &) {
 		throw;
 	} catch (std::exception &ex) {
-		RecordFailedEmbeddingUsageEvent(config, input, options, 0, ex.what(), 0);
+		RecordFailedEmbeddingUsageEvent(config, input, request_options, 0, ex.what(), 0);
 		throw;
 	}
 	if (response.status < 200 || response.status >= 300) {
 		auto error = ProviderErrorDetail(config, response);
-		RecordFailedEmbeddingUsageEvent(config, input, options, response.status, error, response.retries);
+		RecordFailedEmbeddingUsageEvent(config, input, request_options, response.status, error, response.retries);
 		throw IOException("%s", error);
 	}
 	EmbeddingResult result;
@@ -4568,13 +4843,22 @@ EmbeddingResult Embed(const std::string &input, const CompletionOptions &options
 		result = ParseEmbeddingResult(config, response);
 	} catch (std::exception &ex) {
 		if (!cache_key.empty()) {
-			RemoveCachedResponse(RuntimeState(options), cache_key);
+			RemoveCachedResponse(RuntimeState(request_options), cache_key);
 		}
-		RecordFailedEmbeddingUsageEvent(config, input, options, response.status, ex.what(), response.retries);
+		RecordFailedEmbeddingUsageEvent(config, input, request_options, response.status, ex.what(), response.retries);
 		throw;
 	}
-	RecordEmbeddingUsageEvent(config, input, result, options);
-	MaybePostEmbeddingLog(config, input, result, options);
+	auto dimension_error = EmbeddingDimensionError(result, capabilities);
+	if (!dimension_error.empty()) {
+		if (!cache_key.empty()) {
+			RemoveCachedResponse(RuntimeState(request_options), cache_key);
+		}
+		RecordFailedEmbeddingUsageEvent(config, input, request_options, response.status, dimension_error,
+		                                response.retries);
+		throw InvalidInputException("%s", dimension_error);
+	}
+	RecordEmbeddingUsageEvent(config, input, result, request_options);
+	MaybePostEmbeddingLog(config, input, result, request_options);
 	return result;
 }
 
@@ -4593,6 +4877,15 @@ std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, c
 	auto config = ResolveEmbeddingProviderConfig(options, true);
 	auto endpoint = EmbeddingEndpoint(config);
 	EnforceAllowedHost(endpoint, options);
+	auto capabilities = GetProviderCapabilities(options);
+	for (auto &input : inputs) {
+		try {
+			ValidateEmbeddingInputLimits(input, capabilities);
+		} catch (std::exception &ex) {
+			RecordFailedEmbeddingUsageEvent(config, input, options, 0, ex.what(), 0);
+			throw;
+		}
+	}
 
 	std::vector<EmbeddingResult> results(inputs.size());
 	std::vector<idx_t> miss_rows;
@@ -4608,12 +4901,22 @@ std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, c
 			if (TryGetCachedResponse(runtime_state, cache_key, options, cached_response)) {
 				try {
 					results[i] = ParseEmbeddingResult(config, cached_response);
-				} catch (...) {
+				} catch (std::exception &ex) {
 					RemoveCachedResponse(runtime_state, cache_key);
+					RecordFailedEmbeddingUsageEvent(config, inputs[i], options, cached_response.status, ex.what(),
+					                                cached_response.retries);
 					throw;
 				}
-				RecordEmbeddingUsageEvent(config, inputs[i], results[i], options);
-				MaybePostEmbeddingLog(config, inputs[i], results[i], options);
+				auto dimension_error = EmbeddingDimensionError(results[i], capabilities);
+				if (!dimension_error.empty()) {
+					RemoveCachedResponse(runtime_state, cache_key);
+					RecordFailedEmbeddingUsageEvent(config, inputs[i], options, cached_response.status, dimension_error,
+					                                cached_response.retries);
+					throw InvalidInputException("%s", dimension_error);
+				}
+				auto cache_options = ChildOperationOptions(options);
+				RecordEmbeddingUsageEvent(config, inputs[i], results[i], cache_options);
+				MaybePostEmbeddingLog(config, inputs[i], results[i], cache_options);
 				continue;
 			}
 			miss_rows.push_back(i);
@@ -4624,15 +4927,67 @@ std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, c
 		}
 	}
 
-	for (idx_t batch_start = 0; batch_start < miss_rows.size(); batch_start += MAX_EMBED_BATCH_INPUTS) {
-		auto batch_end = std::min<idx_t>(batch_start + MAX_EMBED_BATCH_INPUTS, miss_rows.size());
+	std::vector<std::pair<idx_t, idx_t>> batches;
+	idx_t batch_start = 0;
+	while (batch_start < miss_rows.size()) {
+		auto batch_end = batch_start;
+		int64_t batch_tokens = 0;
+		int64_t batch_bytes = 64;
+		while (batch_end < miss_rows.size()) {
+			auto &input = inputs[miss_rows[batch_end]];
+			auto input_tokens = EstimateTokenCount(input);
+			auto input_bytes = NumericCast<int64_t>(input.size()) + 16;
+			auto input_count = NumericCast<int64_t>(batch_end - batch_start + 1);
+			if (batch_end > batch_start && (input_count > capabilities.max_batch_inputs ||
+			                                batch_tokens + input_tokens > capabilities.max_batch_tokens ||
+			                                batch_bytes + input_bytes > capabilities.max_request_bytes)) {
+				break;
+			}
+			batch_tokens += input_tokens;
+			batch_bytes += input_bytes;
+			batch_end++;
+		}
+		batches.emplace_back(batch_start, batch_end);
+		batch_start = batch_end;
+	}
+
+	std::function<std::vector<EmbeddingResult>(const std::vector<std::string> &)> execute_batch;
+	execute_batch = [&](const std::vector<std::string> &batch_inputs) -> std::vector<EmbeddingResult> {
+		auto batch_options = ChildOperationOptions(options);
+		if (batch_inputs.size() == 1) {
+			return {Embed(batch_inputs[0], batch_options)};
+		}
+		try {
+			return EmbedBatchRequest(config, endpoint, batch_inputs, batch_options);
+		} catch (IOException &ex) {
+			auto message = LowerAscii(ex.what());
+			auto payload_too_large = message.find("413") != std::string::npos ||
+			                         message.find("payload too large") != std::string::npos ||
+			                         message.find("request too large") != std::string::npos ||
+			                         message.find("maximum context") != std::string::npos;
+			if (!payload_too_large || batch_inputs.size() <= 1) {
+				throw;
+			}
+			auto split = batch_inputs.size() / 2;
+			std::vector<std::string> left(batch_inputs.begin(), batch_inputs.begin() + split);
+			std::vector<std::string> right(batch_inputs.begin() + split, batch_inputs.end());
+			auto left_results = execute_batch(left);
+			auto right_results = execute_batch(right);
+			left_results.insert(left_results.end(), std::make_move_iterator(right_results.begin()),
+			                    std::make_move_iterator(right_results.end()));
+			return left_results;
+		}
+	};
+
+	for (auto &batch : batches) {
+		batch_start = batch.first;
+		auto batch_end = batch.second;
 		std::vector<std::string> batch_inputs;
 		batch_inputs.reserve(batch_end - batch_start);
 		for (idx_t i = batch_start; i < batch_end; i++) {
 			batch_inputs.push_back(inputs[miss_rows[i]]);
 		}
-		auto batch_results = batch_inputs.size() == 1 ? std::vector<EmbeddingResult> {Embed(batch_inputs[0], options)}
-		                                              : EmbedBatchRequest(config, endpoint, batch_inputs, options);
+		auto batch_results = execute_batch(batch_inputs);
 		for (idx_t i = 0; i < batch_results.size(); i++) {
 			auto input_row = miss_rows[batch_start + i];
 			if (cache_enabled && batch_inputs.size() > 1) {
@@ -4646,6 +5001,50 @@ std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, c
 		}
 	}
 	return results;
+}
+
+void RecordEmbeddingCacheHit(const std::string &input, int64_t dimensions, const CompletionOptions &options) {
+	auto config = ResolveEmbeddingProviderConfig(options, false);
+	EmbeddingResult result;
+	result.http_status = 200;
+	result.prompt_tokens = 0;
+	result.total_tokens = 0;
+	result.elapsed_ms = 0;
+	result.retries = 0;
+	result.cache_hit = true;
+	auto cache_options = options;
+	cache_options.operation_id.clear();
+	if (cache_options.parent_operation_id.empty()) {
+		cache_options.parent_operation_id = cache_options.query_id;
+	}
+	RecordEmbeddingUsageEvent(config, input, result, cache_options, MaxValue<int64_t>(0, dimensions));
+}
+
+std::string ControlPlaneRequest(const std::string &path, const std::string &payload, const CompletionOptions &options) {
+	auto base_url = TrimTrailingSlash(GetEnv("DUCKDB_AI_CONTROL_PLANE_URL"));
+	if (base_url.empty()) {
+		throw InvalidInputException("DUCKDB_AI_CONTROL_PLANE_URL is required for this operation");
+	}
+	if (path.empty() || path.front() != '/') {
+		throw InvalidInputException("AI control-plane request path must start with /");
+	}
+	auto endpoint = base_url + path;
+	EnforceAllowedHost(endpoint, options);
+	std::vector<std::string> headers {"Content-Type: application/json"};
+	auto token = GetEnv("DUCKDB_AI_CONTROL_PLANE_TOKEN");
+	if (!token.empty()) {
+		headers.push_back("Authorization: Bearer " + token);
+	}
+	auto response = HttpPost(endpoint, payload, headers, TimeoutSeconds(options), false, RetryCount(options),
+	                         RetryBackoffMs(options), options.client_context);
+	if (response.status < 200 || response.status >= 300) {
+		throw IOException("AI control plane returned HTTP %ld: %s", response.status, RedactValue(response.body, token));
+	}
+	std::string error;
+	if (!ValidateJsonDocumentInternal(response.body, error)) {
+		throw IOException("AI control plane returned invalid JSON: %s", error);
+	}
+	return response.body;
 }
 
 void InitializeProviderRuntime() {
@@ -4672,15 +5071,34 @@ std::vector<UsageEvent> UsageEvents(ClientContext &context) {
 	return state.usage_events;
 }
 
+UsageBufferStats UsageStats() {
+	std::unique_lock<std::mutex> usage_lock(fallback_runtime_state.usage_mutex, std::defer_lock);
+	std::unique_lock<std::mutex> log_lock(fallback_runtime_state.usage_log_mutex, std::defer_lock);
+	std::lock(usage_lock, log_lock);
+	return {fallback_runtime_state.usage_events.size(), fallback_runtime_state.dropped_usage_events,
+	        fallback_runtime_state.usage_log_queue.size(), fallback_runtime_state.dropped_usage_log_events};
+}
+
+UsageBufferStats UsageStats(ClientContext &context) {
+	auto &state = RuntimeState(context);
+	std::unique_lock<std::mutex> usage_lock(state.usage_mutex, std::defer_lock);
+	std::unique_lock<std::mutex> log_lock(state.usage_log_mutex, std::defer_lock);
+	std::lock(usage_lock, log_lock);
+	return {state.usage_events.size(), state.dropped_usage_events, state.usage_log_queue.size(),
+	        state.dropped_usage_log_events};
+}
+
 void ClearUsageEvents() {
 	std::lock_guard<std::mutex> lock(fallback_runtime_state.usage_mutex);
 	fallback_runtime_state.usage_events.clear();
+	fallback_runtime_state.dropped_usage_events = 0;
 }
 
 void ClearUsageEvents(ClientContext &context) {
 	auto &state = RuntimeState(context);
 	std::lock_guard<std::mutex> lock(state.usage_mutex);
 	state.usage_events.clear();
+	state.dropped_usage_events = 0;
 }
 
 void ClearResponseCache() {
@@ -4707,6 +5125,8 @@ void RecordLocalUsageEvent(ClientContext *context, const std::string &event_name
 	event.event = event_name;
 	event.function_name = event_name;
 	event.query_id = "";
+	event.operation_id = "local:op:" + std::to_string(next_operation_id.fetch_add(1));
+	event.parent_operation_id = "";
 	event.provider = "local";
 	event.protocol = "duckdb";
 	event.model = "";

--- a/src/include/duckdb_ai_provider.hpp
+++ b/src/include/duckdb_ai_provider.hpp
@@ -21,11 +21,26 @@ struct ProviderConfig {
 	bool requires_api_key;
 };
 
+//! Conservative provider limits used to plan embedding batches and expose runtime capabilities.
+struct ProviderCapabilities {
+	std::string provider;
+	std::string protocol;
+	int64_t max_batch_inputs;
+	int64_t max_batch_tokens;
+	int64_t max_request_bytes;
+	int64_t context_tokens;
+	int64_t embedding_dimensions;
+	bool native_batch_jobs;
+};
+
 //! Per-call completion, embedding, retry, rate-limit, logging, and cost-estimation options.
 struct CompletionOptions {
 	std::string model;
 	std::string provider;
 	std::string secret_name;
+	bool explicit_model = false;
+	bool explicit_provider = false;
+	bool explicit_base_url = false;
 	std::string system_prompt;
 	std::string base_url;
 	std::string api_key;
@@ -77,6 +92,9 @@ struct CompletionOptions {
 	std::string response_schema;
 	std::string function_name;
 	std::string query_id;
+	std::string operation_id;
+	std::string parent_operation_id;
+	std::string model_options;
 	ClientContext *client_context = nullptr;
 	void *runtime_state = nullptr;
 };
@@ -116,6 +134,8 @@ struct UsageEvent {
 	std::string event;
 	std::string function_name;
 	std::string query_id;
+	std::string operation_id;
+	std::string parent_operation_id;
 	std::string provider;
 	std::string protocol;
 	std::string model;
@@ -135,6 +155,14 @@ struct UsageEvent {
 	std::string status;
 	std::string error;
 	double estimated_cost_usd;
+};
+
+//! Bounded-buffer statistics exposed through ai_usage_summary().
+struct UsageBufferStats {
+	uint64_t retained_events;
+	uint64_t dropped_events;
+	uint64_t queued_log_events;
+	uint64_t dropped_log_events;
 };
 
 //! Built-in model pricing row exposed through ai_model_prices().
@@ -187,6 +215,10 @@ std::string NormalizeProviderName(const std::string &provider);
 std::string ProviderBaseUrl(const std::string &provider);
 //! Return the provider protocol used for request/response shaping.
 std::string ProviderProtocol(const std::string &provider);
+//! Return conservative execution limits for the resolved provider/model.
+ProviderCapabilities GetProviderCapabilities(const CompletionOptions &options);
+//! Apply safe pricing metadata stored in an external model's JSON options.
+void ApplyModelProfileOptions(CompletionOptions &options);
 //! Return a local approximate token count used by ai_count_tokens() and token-aware pacing.
 int64_t EstimateTokenCount(const std::string &input);
 //! Build a completion request payload without making a network call.
@@ -209,6 +241,10 @@ EmbeddingResult Embed(const std::string &input, const std::string &model, const 
 EmbeddingResult Embed(const std::string &input, const CompletionOptions &options);
 //! Execute a batched embedding request from a full option set.
 std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, const CompletionOptions &options);
+//! Record an embedding served by the query-local similarity cache.
+void RecordEmbeddingCacheHit(const std::string &input, int64_t dimensions, const CompletionOptions &options);
+//! POST a JSON control-plane request to DUCKDB_AI_CONTROL_PLANE_URL.
+std::string ControlPlaneRequest(const std::string &path, const std::string &payload, const CompletionOptions &options);
 //! Return the effective max_concurrent_requests value from options or env.
 int64_t EffectiveMaxConcurrentRequests(const CompletionOptions &options);
 //! Initialize provider runtime dependencies such as libcurl.
@@ -219,6 +255,10 @@ void AttachProviderRuntimeState(CompletionOptions &options, ClientContext &conte
 std::vector<UsageEvent> UsageEvents();
 //! Return a snapshot of the bounded per-database usage buffer.
 std::vector<UsageEvent> UsageEvents(ClientContext &context);
+//! Return bounded usage/log buffer statistics.
+UsageBufferStats UsageStats();
+//! Return per-database bounded usage/log buffer statistics.
+UsageBufferStats UsageStats(ClientContext &context);
 //! Clear the in-process usage buffer.
 void ClearUsageEvents();
 //! Clear the per-database usage buffer.

--- a/test/benchmarks/ai_runtime_benchmark.py
+++ b/test/benchmarks/ai_runtime_benchmark.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Deterministic 1k/10k benchmarks for packed embeddings and similarity deduplication."""
+
+import argparse
+import csv
+import io
+import json
+import os
+import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+class BenchmarkProviderHandler(BaseHTTPRequestHandler):
+    lock = threading.Lock()
+    request_input_counts = []
+
+    @classmethod
+    def reset(cls):
+        with cls.lock:
+            cls.request_input_counts.clear()
+
+    @classmethod
+    def snapshot(cls):
+        with cls.lock:
+            return list(cls.request_input_counts)
+
+    def do_POST(self):
+        if self.path != "/embeddings":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get("content-length", "0"))
+        request = json.loads(self.rfile.read(length).decode("utf-8"))
+        inputs = request.get("input")
+        values = inputs if isinstance(inputs, list) else [inputs]
+        with self.lock:
+            self.request_input_counts.append(len(values))
+
+        # Keep requests observable long enough for thread/RSS sampling while remaining fast.
+        time.sleep(0.002)
+        payload = {
+            "data": [
+                {"embedding": [1.0, 0.0, 0.0] if sum(value.encode("utf-8")) % 2 else [0.0, 1.0, 0.0]}
+                for value in values
+            ],
+            "usage": {"prompt_tokens": 2 * len(values), "total_tokens": 2 * len(values)},
+        }
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, fmt, *args):
+        return
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def process_metrics(pid: int):
+    status_path = Path(f"/proc/{pid}/status")
+    if status_path.exists():
+        rss_kb = 0
+        thread_count = 0
+        for line in status_path.read_text().splitlines():
+            if line.startswith("VmRSS:"):
+                rss_kb = int(line.split()[1])
+            elif line.startswith("Threads:"):
+                thread_count = int(line.split()[1])
+        return rss_kb, thread_count
+
+    rss = subprocess.run(
+        ["ps", "-o", "rss=", "-p", str(pid)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).stdout.strip()
+    threads = subprocess.run(
+        ["ps", "-M", "-p", str(pid)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).stdout.splitlines()
+    return int(rss or 0), max(0, len(threads) - 1)
+
+
+def benchmark_sql(rows: int, workload: str, base_url: str) -> str:
+    if workload == "unique_embed":
+        query = f"""
+            SELECT sum(ai_embed(
+                'benchmark-value-' || i,
+                input_token_price_per_million := 1.0
+            )[1])
+            FROM range({rows}) AS input(i);
+        """
+    else:
+        query = f"""
+            SELECT sum(ai_similarity(
+                'query-' || (i % 10),
+                'candidate-' || (i % 10),
+                input_token_price_per_million := 1.0
+            ))
+            FROM range({rows}) AS input(i);
+        """
+    return f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_model = 'benchmark-model';
+        SET duckdb_ai_embedding_model = 'benchmark-embedding-model';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_timeout_seconds = 30;
+        {query}
+        SELECT 'BENCH', coalesce(sum(calls), 0), coalesce(sum(batch_count), 0),
+               coalesce(sum(total_tokens), 0), coalesce(sum(estimated_cost_usd), 0),
+               coalesce(max(retained_events), 0), coalesce(max(dropped_events), 0)
+        FROM ai_usage_summary();
+    """
+
+
+def run_case(duckdb_path: Path, base_url: str, workload: str, rows: int):
+    BenchmarkProviderHandler.reset()
+    process = subprocess.Popen(
+        [str(duckdb_path), "-csv", "-noheader", "-c", benchmark_sql(rows, workload, base_url)],
+        cwd=repo_root(),
+        env={**os.environ, "OPENAI_API_KEY": "benchmark-key"},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    started = time.perf_counter()
+    peak_rss_kb = 0
+    peak_threads = 0
+    while process.poll() is None:
+        rss_kb, thread_count = process_metrics(process.pid)
+        peak_rss_kb = max(peak_rss_kb, rss_kb)
+        peak_threads = max(peak_threads, thread_count)
+        time.sleep(0.005)
+    output = process.stdout.read() if process.stdout else ""
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    if process.returncode != 0:
+        raise RuntimeError(f"benchmark failed for {workload}/{rows}:\n{output}")
+
+    summary = None
+    for row in csv.reader(io.StringIO(output)):
+        if row and row[0] == "BENCH":
+            summary = row
+    if summary is None:
+        raise RuntimeError(f"benchmark summary missing for {workload}/{rows}:\n{output}")
+
+    request_sizes = BenchmarkProviderHandler.snapshot()
+    return {
+        "workload": workload,
+        "rows": rows,
+        "distinct_inputs": rows if workload == "unique_embed" else 20,
+        "http_requests": len(request_sizes),
+        "largest_batch": max(request_sizes, default=0),
+        "wall_ms": round(elapsed_ms, 1),
+        "peak_threads": peak_threads,
+        "peak_rss_mb": round(peak_rss_kb / 1024, 1),
+        "usage_calls": int(summary[1]),
+        "usage_batches": int(summary[2]),
+        "total_tokens": int(summary[3]),
+        "usage_estimated_cost_usd": float(summary[4]),
+        "provider_cost_estimate_usd": round(sum(request_sizes) * 2 / 1_000_000, 8),
+        "retained_events": int(summary[5]),
+        "dropped_events": int(summary[6]),
+    }
+
+
+def print_markdown(results):
+    columns = [
+        "workload",
+        "rows",
+        "distinct_inputs",
+        "http_requests",
+        "largest_batch",
+        "wall_ms",
+        "peak_threads",
+        "peak_rss_mb",
+        "provider_cost_estimate_usd",
+        "dropped_events",
+    ]
+    print("| " + " | ".join(columns) + " |")
+    print("| " + " | ".join("---" for _ in columns) + " |")
+    for result in results:
+        print("| " + " | ".join(str(result[column]) for column in columns) + " |")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--duckdb",
+        type=Path,
+        default=repo_root() / "build" / "release" / "duckdb",
+        help="Path to the built DuckDB shell with duckdb_ai linked",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    args = parser.parse_args()
+    if not args.duckdb.exists():
+        raise SystemExit(f"{args.duckdb} does not exist; run `GEN=ninja make release` first")
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), BenchmarkProviderHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        results = [
+            run_case(args.duckdb, base_url, workload, rows)
+            for workload in ("unique_embed", "similarity_dedup")
+            for rows in (1000, 10000)
+        ]
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        print_markdown(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -16,6 +16,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
     ollama_requests = []
     claude_requests = []
     log_requests = []
+    control_plane_requests = []
+    control_plane_authorization_headers = []
     authorization_headers = []
     openrouter_referer_headers = []
     openrouter_title_headers = []
@@ -32,6 +34,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
         cls.ollama_requests.clear()
         cls.claude_requests.clear()
         cls.log_requests.clear()
+        cls.control_plane_requests.clear()
+        cls.control_plane_authorization_headers.clear()
         cls.authorization_headers.clear()
         cls.openrouter_referer_headers.clear()
         cls.openrouter_title_headers.clear()
@@ -88,6 +92,10 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 content = "mock retry completion"
             elif prompt == "cache dogpile":
                 content = "mock dogpile completion"
+            elif prompt == "oversized response":
+                content = "x" * 2048
+            elif "EMPTY_INTERMEDIATE" in prompt and "larger SQL aggregate" in prompt:
+                content = ""
             elif "return invalid schema JSON" in prompt:
                 content = '{"summary":123}'
             elif "return constrained schema JSON" in prompt:
@@ -108,6 +116,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 content = '{"tags":["duck","duck"]}'
             elif "return oneOf violation JSON" in prompt:
                 content = '{"a":1,"b":2}'
+            elif "Score how well the input satisfies the supplied criteria" in full_prompt:
+                content = '{"score":0.91}'
             elif request.get("response_format") or "Return only valid JSON" in full_prompt:
                 content = '{"summary":"mock structured"}'
             elif "Explain the DuckDB SQL query" in full_prompt:
@@ -122,6 +132,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 content = "```sql\nSELECT 42\n```"
             elif "Return only a JSON array of chosen labels" in full_prompt:
                 content = '["billing, overdue","performance"]'
+            elif "class_a" in full_prompt and "class_b" in full_prompt:
+                content = "class_a" if "alpha" in prompt else "class_b"
             elif "Score candidate relevance to the search query" in full_prompt:
                 content = "0.82"
             payload = {
@@ -141,8 +153,22 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             self.embedding_requests.append(request)
             inputs = request.get("input")
             input_count = len(inputs) if isinstance(inputs, list) else 1
+            if isinstance(inputs, list) and len(inputs) > 2 and any("split batch" in value for value in inputs):
+                self._send_json({"error": {"message": "payload too large"}}, status=413)
+                return
+
+            def embedding(value):
+                if "alpha" in value:
+                    return [1.0, 0.0, 0.0]
+                if "beta" in value:
+                    return [0.0, 1.0, 0.0]
+                if "ambiguous" in value:
+                    return [1.0, 1.0, 0.0]
+                return [0.25, -0.5, 1.25]
+
+            input_values = inputs if isinstance(inputs, list) else [inputs]
             payload = {
-                "data": [{"embedding": [0.25, -0.5, 1.25]} for _ in range(input_count)],
+                "data": [{"embedding": embedding(value)} for value in input_values],
                 "usage": {
                     "prompt_tokens": 2 * input_count,
                     "total_tokens": 2 * input_count,
@@ -185,6 +211,56 @@ class MockProviderHandler(BaseHTTPRequestHandler):
         if self.path == "/log":
             self.log_requests.append(json.loads(body))
             self._send_json({"ok": True})
+            return
+
+        if self.path.startswith("/v1/endpoints/"):
+            request = json.loads(body)
+            self.control_plane_requests.append((self.path, request))
+            self.control_plane_authorization_headers.append(self.headers.get("authorization"))
+            if self.path == "/v1/endpoints/provision":
+                self._send_json(
+                    {
+                        "operation_id": "provision-op",
+                        "status": "submitted",
+                        "estimated_hourly_cost_usd": 1.25,
+                    }
+                )
+            elif self.path == "/v1/endpoints/status":
+                self._send_json(
+                    {
+                        "operation_id": request["operation_id"],
+                        "status": "ready",
+                        "endpoint_url": "https://endpoint.example/v1",
+                    }
+                )
+            else:
+                self._send_json({"operation_id": "deprovision-op", "status": "submitted"})
+            return
+
+        if self.path == "/v1/documents/parse":
+            request = json.loads(body)
+            self.control_plane_requests.append((self.path, request))
+            self.control_plane_authorization_headers.append(self.headers.get("authorization"))
+            if request.get("parser_profile") == "malformed":
+                self._send_json({"document_id": "document-malformed", "unexpected": []})
+                return
+            self._send_json(
+                {
+                    "document_id": "document-1",
+                    "elements": [
+                        {
+                            "page": 1,
+                            "element_index": 0,
+                            "element_type": "paragraph",
+                            "text": "DuckDB document",
+                            "markdown": "DuckDB document",
+                            "bbox": [0, 0, 10, 10],
+                            "confidence": 0.99,
+                            "metadata": {"language": "en"},
+                        }
+                    ],
+                }
+            )
             return
 
         self.send_response(404)
@@ -680,6 +756,91 @@ def run_duckdb_invalid_env_log_sample_rate(duckdb_path: Path) -> str:
     return result.stdout
 
 
+def run_duckdb_invalid_url_scheme(duckdb_path: Path) -> str:
+    sql = """
+        SELECT ai_complete(
+            'invalid scheme',
+            provider := 'openai',
+            model := 'mock-model',
+            base_url := 'ftp://127.0.0.1'
+        );
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"duckdb invalid URL scheme unexpectedly succeeded\n{result.stdout}")
+    return result.stdout
+
+
+def run_duckdb_invalid_header(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT ai_complete(
+            'invalid header',
+            provider := 'openrouter',
+            model := 'openai/gpt-4o-mini',
+            base_url := '{base_url}'
+        );
+    """
+    env = os.environ.copy()
+    env.update(
+        {
+            "OPENROUTER_API_KEY": "openrouter-test-key",
+            "OPENROUTER_X_TITLE": "safe title\r\nX-Injected: true",
+        }
+    )
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"duckdb invalid HTTP header unexpectedly succeeded\n{result.stdout}")
+    return result.stdout
+
+
+def run_duckdb_oversized_response(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT ai_complete(
+            'oversized response',
+            provider := 'openai',
+            model := 'mock-model',
+            base_url := '{base_url}'
+        );
+    """
+    env = os.environ.copy()
+    env.update(
+        {
+            "OPENAI_API_KEY": "test-key",
+            "DUCKDB_AI_MAX_RESPONSE_BYTES": "1024",
+        }
+    )
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"duckdb oversized HTTP response unexpectedly succeeded\n{result.stdout}")
+    return result.stdout
+
+
 def run_duckdb_openrouter_headers(duckdb_path: Path, base_url: str) -> str:
     sql = f"""
         SELECT ai_complete(
@@ -836,6 +997,33 @@ def assert_invalid_env_log_sample_rate(output: str):
         )
 
 
+def assert_invalid_url_scheme(output: str):
+    if "AI provider URL scheme must be http or https" not in output:
+        raise AssertionError(f"invalid URL scheme error missing expected message\n{output}")
+    if MockProviderHandler.completion_requests:
+        raise AssertionError(
+            f"invalid URL scheme should fail before provider request: {MockProviderHandler.completion_requests}"
+        )
+
+
+def assert_invalid_header(output: str):
+    if "AI HTTP header value contains prohibited control characters" not in output:
+        raise AssertionError(f"invalid HTTP header error missing expected message\n{output}")
+    if MockProviderHandler.completion_requests:
+        raise AssertionError(
+            f"invalid HTTP header should fail before provider request: {MockProviderHandler.completion_requests}"
+        )
+
+
+def assert_oversized_response(output: str):
+    if "AI HTTP response exceeded DUCKDB_AI_MAX_RESPONSE_BYTES (1024 bytes)" not in output:
+        raise AssertionError(f"oversized HTTP response error missing expected message\n{output}")
+    if len(MockProviderHandler.completion_requests) != 1:
+        raise AssertionError(
+            f"oversized response should make one provider request: {MockProviderHandler.completion_requests}"
+        )
+
+
 def run_duckdb_provider_metadata(duckdb_path: Path) -> str:
     sql = """
         SELECT ai_provider_base_url('aws_bedrock') AS bedrock_url;
@@ -973,8 +1161,8 @@ def assert_smoke_result(output: str):
 
     if len(MockProviderHandler.completion_requests) != 34:
         raise AssertionError(f"expected 34 completion requests, got {len(MockProviderHandler.completion_requests)}")
-    if len(MockProviderHandler.authorization_headers) != 44:
-        raise AssertionError(f"expected 44 auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if len(MockProviderHandler.authorization_headers) != 40:
+        raise AssertionError(f"expected 40 auth headers, got {len(MockProviderHandler.authorization_headers)}")
     for header in MockProviderHandler.authorization_headers:
         if header != "Bearer test-key":
             raise AssertionError(f"unexpected authorization header: {header}")
@@ -1206,8 +1394,8 @@ def assert_smoke_result(output: str):
     if MockProviderHandler.claude_versions != ["2023-06-01"]:
         raise AssertionError(f"unexpected Claude version headers: {MockProviderHandler.claude_versions}")
 
-    if len(MockProviderHandler.embedding_requests) != 9:
-        raise AssertionError(f"expected 9 embedding requests, got {len(MockProviderHandler.embedding_requests)}")
+    if len(MockProviderHandler.embedding_requests) != 5:
+        raise AssertionError(f"expected 5 embedding requests, got {len(MockProviderHandler.embedding_requests)}")
     embedding_request = MockProviderHandler.embedding_requests[0]
     if embedding_request["model"] != "mock-embedding-default":
         raise AssertionError(f"unexpected embedding model: {embedding_request}")
@@ -1219,17 +1407,16 @@ def assert_smoke_result(output: str):
     batched_embedding_request = MockProviderHandler.embedding_requests[2]
     if batched_embedding_request["input"] != ["embed batch one", "embed batch two", "embed batch three"]:
         raise AssertionError(f"unexpected batched embedding input: {batched_embedding_request}")
-    similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[3:5]]
-    if similarity_inputs != ["same left", "same right"]:
-        raise AssertionError(f"unexpected similarity embedding inputs: {similarity_inputs}")
-    similarity_models = [request["model"] for request in MockProviderHandler.embedding_requests[3:5]]
-    if similarity_models != ["mock-embedding-default", "mock-embedding-default"]:
-        raise AssertionError(f"unexpected similarity embedding models: {similarity_models}")
-    constant_similarity_inputs = [request["input"] for request in MockProviderHandler.embedding_requests[5:]]
+    similarity_request = MockProviderHandler.embedding_requests[3]
+    if similarity_request["input"] != ["same left", "same right"]:
+        raise AssertionError(f"unexpected packed similarity inputs: {similarity_request}")
+    if similarity_request["model"] != "mock-embedding-default":
+        raise AssertionError(f"unexpected similarity embedding model: {similarity_request}")
+    constant_similarity_inputs = MockProviderHandler.embedding_requests[4]["input"]
     if constant_similarity_inputs.count("constant query") != 1:
         raise AssertionError(f"expected one constant-side embedding, got {constant_similarity_inputs}")
     if set(constant_similarity_inputs) != {"constant query", "candidate one", "candidate two", "candidate three"}:
-        raise AssertionError(f"unexpected constant similarity embedding inputs: {constant_similarity_inputs}")
+        raise AssertionError(f"unexpected packed constant similarity inputs: {constant_similarity_inputs}")
 
     log_deadline = time.time() + 5
     while len(MockProviderHandler.log_requests) < 47 and time.time() < log_deadline:
@@ -1363,6 +1550,375 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"expected controlled embedding cache miss and hit, got {controlled_embedding_logs}")
 
 
+def run_duckdb_adaptive_batches(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT * FROM ai_clear_usage();
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_embedding_model = 'mock-embedding';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_timeout_seconds = 5;
+        SELECT sum(ai_embed('split batch ' || i::VARCHAR)[1]) AS split_embedding_sum
+        FROM range(8) t(i);
+        CREATE EXTERNAL MODEL capped_embedding WITH (
+            provider = 'openai',
+            model = 'mock-embedding',
+            location = '{base_url}',
+            model_type = 'embedding',
+            options = '{{"max_batch_inputs":3,"max_batch_tokens":100,"max_request_bytes":4096,"embedding_dimensions":3}}'
+        );
+        SELECT sum(ai_embed('capped input ' || i::VARCHAR, profile := 'capped_embedding')[1]) AS capped_embedding_sum
+        FROM range(8) t(i);
+        CREATE EXTERNAL MODEL tiny_embedding_request WITH (
+            provider = 'openai',
+            model = 'mock-embedding',
+            location = '{base_url}',
+            model_type = 'embedding',
+            options = '{{"max_batch_tokens":1}}'
+        );
+        SELECT ai_embed(
+            'too many tokens for one request',
+            profile := 'tiny_embedding_request',
+            fail_on_error := false
+        ) IS NULL AS token_limit_rejected;
+        CREATE EXTERNAL MODEL cached_embedding_dimensions WITH (
+            provider = 'openai',
+            model = 'mock-embedding',
+            location = '{base_url}',
+            model_type = 'embedding',
+            options = '{{"embedding_dimensions":3}}'
+        );
+        SELECT count(ai_embed('cached dimension ' || i::VARCHAR,
+                              profile := 'cached_embedding_dimensions', cache := true)) AS cached_dimensions_seeded
+        FROM range(2) t(i);
+        CREATE OR REPLACE EXTERNAL MODEL cached_embedding_dimensions WITH (
+            provider = 'openai',
+            model = 'mock-embedding',
+            location = '{base_url}',
+            model_type = 'embedding',
+            options = '{{"embedding_dimensions":4}}'
+        );
+        SELECT count(ai_embed('cached dimension ' || i::VARCHAR,
+                              profile := 'cached_embedding_dimensions', cache := true,
+                              fail_on_error := false)) = 0 AS stale_dimensions_rejected
+        FROM range(2) t(i);
+        SELECT round(sum(ai_similarity(left_text, right_text)), 6) AS deduplicated_similarity_sum
+        FROM (VALUES
+            ('same left', 'same right'),
+            ('same left', 'same right'),
+            ('same left', 'other right'),
+            ('same left', 'other right')
+        ) input(left_text, right_text);
+        SELECT sum(batch_count) AS request_batches, sum(failures) AS failed_input_events
+        FROM ai_usage_summary();
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb adaptive batch smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_adaptive_batches(output: str):
+    for expected in (
+        "split_embedding_sum",
+        "2.0",
+        "token_limit_rejected",
+        "true",
+        "cached_dimensions_seeded",
+        "stale_dimensions_rejected",
+        "deduplicated_similarity_sum",
+        "4.0",
+        "request_batches",
+    ):
+        if expected not in output:
+            raise AssertionError(f"adaptive batch output missing {expected!r}\n{output}")
+    if len(MockProviderHandler.embedding_requests) != 12:
+        raise AssertionError(f"expected 12 adaptive embedding requests, got {MockProviderHandler.embedding_requests}")
+    split_sizes = [len(request["input"]) for request in MockProviderHandler.embedding_requests[:7]]
+    if split_sizes != [8, 4, 2, 2, 4, 2, 2]:
+        raise AssertionError(f"unexpected recursive split request sizes: {split_sizes}")
+    capped_sizes = [len(request["input"]) for request in MockProviderHandler.embedding_requests[7:10]]
+    if capped_sizes != [3, 3, 2]:
+        raise AssertionError(f"external model batch capabilities were not applied: {capped_sizes}")
+    cached_dimension_inputs = MockProviderHandler.embedding_requests[10]["input"]
+    if cached_dimension_inputs != ["cached dimension 0", "cached dimension 1"]:
+        raise AssertionError(f"unexpected cache dimension seed inputs: {cached_dimension_inputs}")
+    deduplicated_inputs = MockProviderHandler.embedding_requests[11]["input"]
+    if deduplicated_inputs != ["same left", "same right", "other right"]:
+        raise AssertionError(f"similarity inputs were not packed and deduplicated: {deduplicated_inputs}")
+
+
+def run_duckdb_hierarchical_aggregate(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT * FROM ai_clear_usage();
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_aggregate_model = 'mock-aggregate';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_timeout_seconds = 5;
+        SELECT ai_agg(value, 'Summarize all values', max_context_chars := 40) AS hierarchical_result
+        FROM (
+            SELECT repeat(chr(65 + (i % 26)::INTEGER), 18) || i::VARCHAR AS value
+            FROM range(20) t(i)
+        );
+        SELECT count(DISTINCT operation_id) AS operations,
+               count(DISTINCT parent_operation_id) AS parents,
+               bool_and(parent_operation_id IS NOT NULL) AS all_children_linked
+        FROM ai_usage()
+        WHERE function_name LIKE 'ai_agg%';
+        SELECT ai_agg(value, 'Summarize all values', max_context_chars := 40,
+                      fail_on_error := false) IS NULL AS empty_intermediate_rejected
+        FROM (
+            SELECT repeat('EMPTY_INTERMEDIATE', 4) || i::VARCHAR AS value
+            FROM range(4) t(i)
+        );
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb hierarchical aggregate smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_hierarchical_aggregate(output: str):
+    for expected in (
+        "hierarchical_result",
+        "mock completion",
+        "operations",
+        "parents",
+        "empty_intermediate_rejected",
+        "true",
+    ):
+        if expected not in output:
+            raise AssertionError(f"hierarchical aggregate output missing {expected!r}\n{output}")
+    if len(MockProviderHandler.completion_requests) < 5:
+        raise AssertionError(
+            f"expected a multi-level aggregate request tree, got {len(MockProviderHandler.completion_requests)} requests"
+        )
+    prompts = [request["messages"][-1]["content"] for request in MockProviderHandler.completion_requests]
+    if sum("mock completion" in prompt for prompt in prompts) < 2:
+        raise AssertionError(f"aggregate did not perform recursive map/reduce: {prompts}")
+
+
+def run_duckdb_optimized_classifier(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_task_model = 'mock-task';
+        SET duckdb_ai_embedding_model = 'mock-embedding';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_timeout_seconds = 5;
+        CREATE TEMP TABLE training AS
+        SELECT CASE WHEN i % 2 = 0 THEN 'alpha example ' ELSE 'beta example ' END || i::VARCHAR AS text
+        FROM range(20) t(i);
+        CREATE TEMP TABLE classifier AS
+        SELECT ai_build_classifier(
+            text,
+            ['class_a', 'class_b'],
+            optimization := 'minimize_cost',
+            sample_size := 20,
+            quality_threshold := 0.75,
+            confidence_margin := 0.05
+        ) AS artifact
+        FROM training;
+        SELECT contains(artifact, '"optimization":"minimize_cost"') AS optimization,
+               contains(artifact, '"usable":true') AS usable,
+               contains(artifact, '"validation_count":') AS validation_count
+        FROM classifier;
+        SELECT result.value AS local_value, result.used_fallback AS local_fallback,
+               contains(result.metadata, '"path":"local"') AS local_metadata
+        FROM (SELECT ai_classify_optimized('alpha new', artifact) AS result FROM classifier);
+        SELECT result.value AS fallback_value, result.used_fallback AS used_fallback,
+               contains(result.metadata, '"path":"fallback"') AS fallback_metadata,
+               result.error IS NULL AS fallback_ok
+        FROM (SELECT ai_classify_optimized('ambiguous example', artifact) AS result FROM classifier);
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb optimized classifier smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_optimized_classifier(output: str):
+    for expected in (
+        "optimization",
+        "usable",
+        "validation_count",
+        "local_value",
+        "class_a",
+        "local_fallback",
+        "fallback_value",
+        "class_b",
+        "used_fallback",
+        "fallback_ok",
+    ):
+        if expected not in output:
+            raise AssertionError(f"optimized classifier output missing {expected!r}\n{output}")
+    if len(MockProviderHandler.completion_requests) != 21:
+        raise AssertionError(
+            f"expected 20 sampled labels and one fallback, got {len(MockProviderHandler.completion_requests)}"
+        )
+    if len(MockProviderHandler.embedding_requests) != 3:
+        raise AssertionError(
+            f"expected three packed/local embedding requests, got {MockProviderHandler.embedding_requests}"
+        )
+    training_inputs = MockProviderHandler.embedding_requests[0]["input"]
+    if not isinstance(training_inputs, list) or len(training_inputs) != 20:
+        raise AssertionError(f"classifier training embeddings were not batched: {training_inputs}")
+
+
+def run_duckdb_new_task_functions(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_task_model = 'mock-task';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_timeout_seconds = 5;
+        SELECT ai_score('DuckDB runs in process', 'describes an embedded database') AS score;
+        SELECT ai_classify(
+            'alpha example', ['class_a', 'class_b'],
+            label_descriptions := '{{"class_a":"alpha text","class_b":"beta text"}}',
+            instructions := 'Prefer explicit terms.',
+            examples := '[{{"input":"alpha","label":"class_a"}}]'
+        ) AS rich_classification;
+        SELECT result.value, result.error IS NULL, contains(result.metadata, '"multi_label":true')
+        FROM (
+            SELECT ai_classify_result(
+                'invoice overdue and slow app', ['billing, overdue', 'performance', 'support']
+            ) AS result
+        );
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb new task function smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_new_task_functions(output: str):
+    for expected in ("score", "0.91", "rich_classification", "class_a", "billing, overdue", "performance"):
+        if expected not in output:
+            raise AssertionError(f"new task function output missing {expected!r}\n{output}")
+    score_format = MockProviderHandler.completion_requests[0].get("response_format", {})
+    score_schema = score_format.get("json_schema", {}).get("schema", {})
+    if score_format.get("type") != "json_schema" or "score" not in score_schema.get("properties", {}):
+        raise AssertionError(f"ai_score did not send its constrained score schema: {score_format}")
+    rich_request = MockProviderHandler.completion_requests[1]
+    system_prompt = rich_request["messages"][0]["content"]
+    for expected in ("Label descriptions", "Prefer explicit terms.", "Examples"):
+        if expected not in system_prompt:
+            raise AssertionError(f"rich classification prompt missing {expected!r}: {system_prompt}")
+
+
+def run_duckdb_control_plane(duckdb_path: Path, base_url: str) -> str:
+    sql = """
+        CREATE EXTERNAL MODEL provisioned_model WITH (
+            provider = 'azure',
+            model = 'gpt-test',
+            location = 'https://safe-metadata.example/v1',
+            capabilities = 'completion,json_schema'
+        );
+        SELECT operation_id, status, estimated_hourly_cost_usd
+        FROM ai_provision_endpoint(
+            'provisioned_model', dry_run := false, max_hourly_cost_usd := 2.0
+        );
+        SELECT operation_id, status, endpoint_url FROM ai_endpoint_status('provision-op');
+        SELECT operation_id, status FROM ai_deprovision_endpoint('provisioned_model');
+        SELECT document_id, page, element_index, element_type, text, markdown,
+               bbox, confidence, metadata, error IS NULL
+        FROM ai_parse_document('abc'::BLOB, 'text/plain', 'documents');
+        SELECT error
+        FROM ai_parse_document('abc'::BLOB, 'text/plain', 'malformed', fail_on_error := false);
+    """
+    env = os.environ.copy()
+    env.update(
+        {
+            "DUCKDB_AI_CONTROL_PLANE_URL": base_url,
+            "DUCKDB_AI_CONTROL_PLANE_TOKEN": "control-token",
+        }
+    )
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb control-plane smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_control_plane(output: str):
+    for expected in (
+        "provision-op",
+        "submitted",
+        "1.25",
+        "ready",
+        "https://endpoint.example/v1",
+        "deprovision-op",
+        "document-1",
+        "paragraph",
+        "DuckDB document",
+        "0.99",
+        "AI document parser response must contain an elements array",
+    ):
+        if expected not in output:
+            raise AssertionError(f"control-plane output missing {expected!r}\n{output}")
+    paths = [path for path, _ in MockProviderHandler.control_plane_requests]
+    if paths != [
+        "/v1/endpoints/provision",
+        "/v1/endpoints/status",
+        "/v1/endpoints/deprovision",
+        "/v1/documents/parse",
+        "/v1/documents/parse",
+    ]:
+        raise AssertionError(f"unexpected control-plane requests: {MockProviderHandler.control_plane_requests}")
+    if MockProviderHandler.control_plane_authorization_headers != ["Bearer control-token"] * 5:
+        raise AssertionError(
+            f"unexpected control-plane authorization: {MockProviderHandler.control_plane_authorization_headers}"
+        )
+    document_request = MockProviderHandler.control_plane_requests[3][1]
+    if document_request.get("content_base64") != "YWJj" or document_request.get("mime_type") != "text/plain":
+        raise AssertionError(f"unexpected normalized document request: {document_request}")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -1384,6 +1940,21 @@ def main():
         assert_provider_metadata(provider_metadata_output)
         output = run_duckdb(args.duckdb, f"http://127.0.0.1:{port}")
         assert_smoke_result(output)
+        MockProviderHandler.reset()
+        adaptive_batch_output = run_duckdb_adaptive_batches(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_adaptive_batches(adaptive_batch_output)
+        MockProviderHandler.reset()
+        hierarchical_output = run_duckdb_hierarchical_aggregate(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_hierarchical_aggregate(hierarchical_output)
+        MockProviderHandler.reset()
+        optimized_classifier_output = run_duckdb_optimized_classifier(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_optimized_classifier(optimized_classifier_output)
+        MockProviderHandler.reset()
+        new_task_output = run_duckdb_new_task_functions(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_new_task_functions(new_task_output)
+        MockProviderHandler.reset()
+        control_plane_output = run_duckdb_control_plane(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_control_plane(control_plane_output)
         MockProviderHandler.reset()
         self_correction_output = run_duckdb_self_correction(args.duckdb, f"http://127.0.0.1:{port}")
         assert_self_correction_result(self_correction_output)
@@ -1408,6 +1979,15 @@ def main():
         MockProviderHandler.reset()
         invalid_env_log_sample_rate_output = run_duckdb_invalid_env_log_sample_rate(args.duckdb)
         assert_invalid_env_log_sample_rate(invalid_env_log_sample_rate_output)
+        MockProviderHandler.reset()
+        invalid_url_scheme_output = run_duckdb_invalid_url_scheme(args.duckdb)
+        assert_invalid_url_scheme(invalid_url_scheme_output)
+        MockProviderHandler.reset()
+        invalid_header_output = run_duckdb_invalid_header(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_invalid_header(invalid_header_output)
+        MockProviderHandler.reset()
+        oversized_response_output = run_duckdb_oversized_response(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_oversized_response(oversized_response_output)
     finally:
         server.shutdown()
         thread.join(timeout=5)

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -943,6 +943,218 @@ SELECT ai_provider_base_url('not-a-provider');
 ----
 Invalid Input Error: Unsupported AI provider "not-a-provider".
 
+# Deterministic Unicode-aware chunking uses code-point offsets and exclusive ends.
+query IIIII
+SELECT chunk_index, start_offset, end_offset, chunk_length, chunk
+FROM ai_generate_chunks('é🙂abc', chunk_size := 2, overlap_percent := 0, strategy := 'fixed')
+ORDER BY chunk_index;
+----
+0	0	2	2	é🙂
+1	2	4	2	ab
+2	4	5	1	c
+
+query IIII
+SELECT chunk_index, start_offset, end_offset, chunk
+FROM ai_generate_chunks('abcdef', chunk_size := 4, overlap_percent := 50, strategy := 'fixed')
+ORDER BY chunk_index;
+----
+0	0	4	abcd
+1	2	6	cdef
+
+query II
+SELECT (SELECT count(*) FROM ai_generate_chunks('')),
+       (SELECT count(*) FROM ai_generate_chunks(NULL));
+----
+0	0
+
+query I
+WITH first AS (
+  SELECT chunk_index, chunk_id FROM ai_generate_chunks('deterministic chunks', chunk_size := 5)
+), second AS (
+  SELECT chunk_index, chunk_id FROM ai_generate_chunks('deterministic chunks', chunk_size := 5)
+)
+SELECT bool_and(first.chunk_id = second.chunk_id)
+FROM first JOIN second USING (chunk_index);
+----
+true
+
+query I
+SELECT
+  (SELECT chunk_id FROM ai_generate_chunks('first revision', source_id := 'document-1') LIMIT 1) <>
+  (SELECT chunk_id FROM ai_generate_chunks('second revision', source_id := 'document-1') LIMIT 1);
+----
+true
+
+statement error
+SELECT * FROM ai_generate_chunks('invalid overlap', overlap_percent := 51);
+----
+Binder Error: overlap_percent must be between 0 and 50
+
+# Local RAG preparation preserves headings, page metadata, table rows, metadata, and row-level error shape.
+query IIII
+WITH chunks AS (
+  SELECT * FROM ai_prep_search(
+    '# Guide' || chr(10) || 'alpha beta gamma' || chr(12) || '# Page 2' || chr(10) || 'delta',
+    source_id := 'guide', title := 'Manual', metadata := '{"kind":"guide"}',
+    chunk_size := 14, overlap_percent := 0
+  )
+)
+SELECT min(page), max(page), bool_and(heading IS NOT NULL),
+       bool_and(metadata::VARCHAR = '{"kind":"guide"}' AND error IS NULL)
+FROM chunks;
+----
+1	2	true	true
+
+query I
+WITH chunks AS (
+  SELECT * FROM ai_prep_search(
+    '# T' || chr(10) || '| a | b |' || chr(10) || '|---|---|' || chr(10) || '| 1 | 2 |',
+    chunk_size := 12, overlap_percent := 0
+  )
+)
+SELECT string_agg(chunk_to_retrieve, '' ORDER BY chunk_index) =
+       '# T' || chr(10) || '| a | b |' || chr(10) || '|---|---|' || chr(10) || '| 1 | 2 |'
+FROM chunks;
+----
+true
+
+# Rich classification options bind without changing the existing return type.
+query I
+SELECT ai_classify('great', ['positive', 'negative'],
+                   label_descriptions := '{"positive":"favorable"}',
+                   instructions := 'Prefer explicit sentiment.',
+                   examples := '[{"input":"excellent","label":"positive"}]',
+                   provider := 'not-a-provider', fail_on_error := false) IS NULL;
+----
+true
+
+query II
+SELECT result.value IS NULL, contains(result.error, 'Unsupported AI provider')
+FROM (SELECT ai_classify_result('great', ['positive', 'negative'], provider := 'not-a-provider') AS result);
+----
+true	true
+
+query I
+SELECT ai_score('DuckDB runs in process', 'describes an embedded database',
+                provider := 'not-a-provider', fail_on_error := false) IS NULL;
+----
+true
+
+# Aggregate overflow is explicit and the experimental optimizer preserves diagnostics.
+statement error
+SELECT ai_agg(x, 'summarize', max_context_chars := 4, overflow_policy := 'error')
+FROM (VALUES ('abcdef')) t(x);
+----
+Invalid Input Error: AI aggregate input has
+
+statement error
+SELECT ai_summarize_agg(x, overflow_policy := 'truncate') FROM (VALUES ('duck')) t(x);
+----
+Binder Error: AI aggregate option "overflow_policy" must be hierarchical or error
+
+query I
+SELECT ai_build_classifier('x' || i::VARCHAR, ['a', 'b'], optimization := 'minimize_cost',
+                           sample_size := 8, provider := 'not-a-provider', fail_on_error := false) IS NULL
+FROM range(8) t(i);
+----
+true
+
+query II
+SELECT result.error IS NOT NULL, contains(result.metadata, 'invalid classifier artifact')
+FROM (SELECT ai_classify_optimized('x', '{}') AS result);
+----
+true	true
+
+query I
+SELECT contains(result.error, 'embedding provider and model are required')
+FROM (
+  SELECT ai_classify_optimized(
+    'x',
+    '{"version":1,"optimization":"minimize_cost","usable":true,"accuracy":0.9,"confidence_margin":0.1,"labels":["a","b"],"centroids":[[1,0],[0,1]],"embedding":{}}'
+  ) AS result
+);
+----
+true
+
+# External model profiles store only safe metadata and provisioning defaults to a local dry run.
+statement error
+CREATE EXTERNAL MODEL duplicate_ai_test_model WITH (
+  provider = 'openai',
+  provider = 'azure',
+  model = 'gpt-profile'
+);
+----
+Duplicate external model option: provider
+
+statement ok
+CREATE EXTERNAL MODEL ai_test_model WITH (
+  provider = 'openai',
+  model = 'gpt-profile',
+  location = 'https://api.openai.com/v1',
+  model_type = 'completion',
+  capabilities = 'completion,json_schema',
+  options = '{"max_input_tokens":128000,"input_token_price_per_million":0.5,"output_token_price_per_million":1.0}'
+);
+
+query IIIIII
+SELECT name, provider, model, location, capabilities, options
+FROM ai_models() WHERE name = 'ai_test_model';
+----
+ai_test_model	openai	gpt-profile	https://api.openai.com/v1	completion,json_schema	{"max_input_tokens":128000,"input_token_price_per_million":0.5,"output_token_price_per_million":1.0}
+
+query IIIIII
+SELECT max_batch_inputs = 512, context_tokens = 128000,
+       input_token_price_per_million = 0.5, output_token_price_per_million = 1.0,
+       native_batch_jobs = false, validation_status = 'valid'
+FROM ai_models() WHERE name = 'ai_test_model';
+----
+true	true	true	true	true	true
+
+query I
+SELECT contains(ai_completion_request_json('hello', profile := 'ai_test_model'), '"model":"gpt-profile"');
+----
+true
+
+statement ok
+SET duckdb_ai_completion_model = 'settings-model';
+
+query II
+SELECT contains(ai_completion_request_json('hello', profile := 'ai_test_model'), '"model":"gpt-profile"'),
+       contains(ai_completion_request_json('hello', profile := 'ai_test_model', model := 'explicit-model'), '"model":"explicit-model"');
+----
+true	true
+
+statement ok
+RESET duckdb_ai_completion_model;
+
+query II
+SELECT status, action_required FROM ai_provision_endpoint('ai_test_model');
+----
+planned	rerun with dry_run := false and an explicit max_hourly_cost_usd ceiling
+
+statement error
+SELECT * FROM ai_provision_endpoint('ai_test_model', dry_run := false);
+----
+Binder Error: ai_provision_endpoint requires max_hourly_cost_usd > 0 when dry_run is false
+
+query I
+SELECT error IS NOT NULL
+FROM ai_parse_document('plain text'::BLOB, 'text/plain', 'documents', fail_on_error := false);
+----
+true
+
+query III
+SELECT bool_and(batch_count <= calls), sum(retries) >= 0,
+       max(dropped_events) = 0 AND max(dropped_log_events) = 0
+FROM ai_usage_summary();
+----
+true	true	true
+
+query I
+SELECT count(*) > 0 FROM ai_usage() WHERE operation_id IS NOT NULL;
+----
+true
+
 # Every ai_* function exposes catalog documentation for duckdb_functions().
 query I
 SELECT count(*)


### PR DESCRIPTION
This expands duckdb_ai from scalar AI helpers into a scalable AI SQL runtime with context-safe aggregation, RAG preparation, reusable model profiles, normalized document parsing, and an experimental cost-minimized classifier workflow. It also fixes execution and observability issues found during review so large relation workloads remain bounded, diagnosable, and deterministic.

### Codex description

- add provider capability metadata, adaptive embedding packing, recursive 413 splitting, persistent bounded workers, similarity deduplication, and query-level usage summaries
- replace aggregate truncation with hierarchical map/reduce and explicit overflow behavior
- add deterministic Unicode chunking, RAG search preparation, constrained scoring, richer classification diagnostics, and experimental centroid classification
- add safe `CREATE EXTERNAL MODEL` profiles, model introspection, guarded control-plane operations, and normalized remote document parsing
- fix stale cached embeddings bypassing profile limits, empty aggregate reductions, malformed parser responses, ambiguous model options, mixed concurrency caps, and control-plane token redaction
- scope `make test` to the extension SQLLogic suite and add deterministic mock-provider regressions plus 1k/10k runtime benchmarks
- validate formatting, release build, 320 SQLLogic assertions, mock provider smoke, benchmarks, website typecheck/build, and diff hygiene