### PR TITLE
Fix provider executor build on MSVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.9 - 2026-07-14
+
+### Fixed
+
+- Used brace initialization for the provider executor's worker lock so MSVC
+  does not parse the declaration as a function and fail Windows builds.
+
 ## 0.4.8 - 2026-07-14
 
 ### Fixed

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.8
+    EXTENSION_VERSION 0.4.9
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -1739,7 +1739,7 @@ struct ProviderExecutorState : public ObjectCacheEntry {
 				while (true) {
 					std::function<void()> task;
 					{
-						std::unique_lock<std::mutex> lock(mutex);
+						std::unique_lock<std::mutex> lock {mutex};
 						cv.wait(lock, [&]() { return shutdown || !queue.empty(); });
 						if (shutdown && queue.empty()) {
 							return;


### PR DESCRIPTION
## Summary

- brace-initialize the provider executor worker lock so MSVC cannot parse it as a function declaration
- prepare patch release 0.4.9 for the cross-platform build fix

## Why

The v0.4.8 full distribution run failed in Windows MSVC while compiling `src/duckdb_ai_extension.cpp`: `condition_variable::wait` received what MSVC parsed as a function declaration instead of a `unique_lock` variable. Linux and macOS compilers accepted the parenthesized form, so the normal hosted PR checks did not expose this portability issue.

Failed distribution evidence: https://github.com/leonardovida/duckdb-ai/actions/runs/29317754326/job/87036789729

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release` (reports extension 0.4.9)
- `GEN=ninja make test` (323 assertions)
- `python3 test/smoke/mock_provider_smoke.py`

## Release

This PR intentionally prepares patch release 0.4.9. After merge, the full Linux, macOS, Windows, and WASM distribution workflow will be rerun and must pass. No DuckDB community publication PR is included.
