### PR TITLE
fix(runtime): harden ai sql execution paths

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -368,7 +368,9 @@ Description: Classifies text into exactly one label from `labels`. `labels` can
 be a comma-separated `VARCHAR` or a `VARCHAR[]`; use `VARCHAR[]` when labels may
 contain commas. Use constant `label_descriptions :=`, `instructions :=`, and
 `examples :=` strings to add label semantics, global rules, and few-shot
-examples without changing the return type.
+examples without changing the return type. Configured labels must be non-empty
+and unique. The returned value is validated against the configured set and
+canonicalized to its original spelling.
 
 Example:
 
@@ -392,7 +394,8 @@ Result: `VARCHAR`
 
 Description: Classifies text into zero or more labels from `labels`. `labels`
 can be a comma-separated `VARCHAR` or a `VARCHAR[]`; use `VARCHAR[]` when labels
-may contain commas. The model must return a JSON array of label strings.
+may contain commas. The model must return a JSON array containing only unique
+members of the configured label set.
 
 Example:
 
@@ -409,7 +412,8 @@ Result: `VARCHAR[]`
 
 Description: Multi-label classification with pipeline-safe diagnostics. It
 always captures provider and parsing failures instead of failing the full
-vector, and returns metadata describing the selected provider and model.
+vector, preserves metadata for failed rows, and returns metadata describing the
+selected provider and model when resolution succeeds.
 
 Example:
 
@@ -994,6 +998,8 @@ Embedding profiles can set `max_batch_inputs`, `max_inputs`,
 `embedding_dimensions`, and `native_batch_support` in `options`. Packing uses
 these limits before sending requests and recursively splits provider HTTP 413
 responses. Declared embedding dimensions are validated against provider output.
+Completion profiles enforce declared input-token and request-byte limits before
+issuing an HTTP request. `model_type` must be `completion` or `embedding`.
 Profiles can also set non-negative `input_token_price_per_million` and
 `output_token_price_per_million`; an explicit per-call or session price takes
 precedence.

--- a/docs/runtime-behavior.md
+++ b/docs/runtime-behavior.md
@@ -92,8 +92,11 @@ caches; `ai_clear_cache()` clears it explicitly. Query-cache hits appear in
 
 When a provider rejects a multi-input embedding request with HTTP 413 or a
 recognized payload/context-size error, the extension recursively bisects that
-request. A single input that exceeds an external model's declared context or
-byte limit fails explicitly.
+request. Recoverable splits do not count as terminal failures in usage
+summaries. Input packing measures the encoded JSON payload, so quotes, control
+characters, and other escaped content are included in the byte limit. A single
+input that exceeds an external model's declared context or byte limit fails
+explicitly.
 
 ## Context-safe aggregate reduction
 
@@ -102,7 +105,9 @@ byte limit fails explicitly.
 boundaries, mapped concurrently into compact evidence, packed, and recursively
 reduced until one final request fits. Every child uses the parent query's
 operation tree for usage attribution. Set `overflow_policy := 'error'` to reject
-an oversized group before any provider call.
+an oversized group before any provider call. Hierarchical reduction also stops
+immediately with an explicit error when a provider's intermediate responses do
+not reduce either the chunk count or total byte size.
 
 ## Cancellation and retries
 
@@ -171,7 +176,8 @@ as `0` because no provider HTTP request was made.
 The maximum number of cached entries defaults to `1024`. Set
 `cache_max_entries := ...`, `duckdb_ai_cache_max_entries`, or
 `DUCKDB_AI_CACHE_MAX_ENTRIES` to change the bound. Use `0` to disable
-response-cache storage.
+response-cache storage. Cached response bodies and keys also have a hard 64 MiB
+per-database bound; an individual response larger than that is not cached.
 
 `ai_query_data()` also keeps a small in-memory generated-SQL cache for successful
 binds. `ai_clear_cache()` clears the response, generated-SQL, and similarity

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -49,6 +49,7 @@
 #include <initializer_list>
 #include <limits>
 #include <mutex>
+#include <numeric>
 #include <set>
 #include <sstream>
 #include <thread>
@@ -1770,8 +1771,18 @@ struct ProviderExecutorState : public ObjectCacheEntry {
 
 struct SimilarityOptionCache {
 	duckdb_ai::CompletionOptions options;
+	size_t credential_fingerprint = 0;
 	std::unordered_map<std::string, std::vector<double>> embeddings;
 };
+
+bool SimilarityCacheOptionsEqual(const SimilarityOptionCache &cached, const duckdb_ai::CompletionOptions &options) {
+	if (cached.credential_fingerprint != std::hash<std::string> {}(options.api_key)) {
+		return false;
+	}
+	auto sanitized = options;
+	sanitized.api_key.clear();
+	return CompletionOptionsEqual(cached.options, sanitized);
+}
 
 struct SimilarityQueryCache {
 	std::mutex mutex;
@@ -1915,12 +1926,17 @@ void RunProviderJobs(std::vector<JOB> &jobs, CALLBACK callback) {
 		idx_t remaining = 0;
 	};
 	auto wait_state = std::make_shared<BatchWaitState>();
-	wait_state->remaining = jobs.size();
+	wait_state->remaining = worker_count;
+	auto next_job = std::make_shared<std::atomic<idx_t>>(0);
 	auto &executor = ProviderExecutor(jobs[0].options);
 	executor.EnsureWorkers(worker_count);
-	for (idx_t job_index = 0; job_index < jobs.size(); job_index++) {
-		executor.Submit([&, job_index, wait_state]() {
-			if (!stop.load()) {
+	for (idx_t worker = 0; worker < worker_count; worker++) {
+		executor.Submit([&, next_job, wait_state]() {
+			while (!stop.load()) {
+				auto job_index = next_job->fetch_add(1);
+				if (job_index >= jobs.size()) {
+					break;
+				}
 				run_one(jobs[job_index]);
 			}
 			{
@@ -2933,7 +2949,7 @@ void PrecomputeSimilarityEmbeddings(ClientContext &context, std::vector<Provider
 			std::unique_lock<std::mutex> cache_lock(query_cache->mutex);
 			SimilarityOptionCache *option_cache = nullptr;
 			for (auto &candidate : query_cache->option_groups) {
-				if (CompletionOptionsEqual(candidate.options, jobs[group_start].options)) {
+				if (SimilarityCacheOptionsEqual(candidate, jobs[group_start].options)) {
 					option_cache = &candidate;
 					break;
 				}
@@ -2941,6 +2957,8 @@ void PrecomputeSimilarityEmbeddings(ClientContext &context, std::vector<Provider
 			if (!option_cache) {
 				SimilarityOptionCache candidate;
 				candidate.options = jobs[group_start].options;
+				candidate.credential_fingerprint = std::hash<std::string> {}(candidate.options.api_key);
+				candidate.options.api_key.clear();
 				query_cache->option_groups.push_back(std::move(candidate));
 				option_cache = &query_cache->option_groups.back();
 			}
@@ -3601,6 +3619,10 @@ std::string RunHierarchicalAggregate(const AiAggregateBindData &bind_data, const
 		if (level >= 32) {
 			throw InvalidInputException("AI aggregate hierarchical reduction did not converge after 32 levels");
 		}
+		auto previous_chunk_count = chunks.size();
+		auto previous_bytes =
+		    std::accumulate(chunks.begin(), chunks.end(), idx_t(0),
+		                    [](idx_t total, const std::string &chunk) { return total + chunk.size(); });
 		std::vector<ProviderStringJob> jobs;
 		jobs.reserve(chunks.size());
 		for (idx_t i = 0; i < chunks.size(); i++) {
@@ -3629,10 +3651,17 @@ std::string RunHierarchicalAggregate(const AiAggregateBindData &bind_data, const
 			}
 			partials.push_back(std::move(job.output));
 		}
-		chunks = PackAggregateValues(partials, bind_data.separator, bind_data.max_context_chars);
-		if (chunks.empty()) {
+		auto next_chunks = PackAggregateValues(partials, bind_data.separator, bind_data.max_context_chars);
+		if (next_chunks.empty()) {
 			throw InvalidInputException("AI aggregate hierarchical reduction produced no intermediate results");
 		}
+		auto next_bytes = std::accumulate(next_chunks.begin(), next_chunks.end(), idx_t(0),
+		                                  [](idx_t total, const std::string &chunk) { return total + chunk.size(); });
+		if (next_chunks.size() >= previous_chunk_count && next_bytes >= previous_bytes) {
+			throw InvalidInputException("AI aggregate hierarchical reduction made no progress at level %llu",
+			                            static_cast<unsigned long long>(level));
+		}
+		chunks = std::move(next_chunks);
 	}
 	auto options = bind_data.options;
 	options.parent_operation_id = root_operation_id;
@@ -3781,6 +3810,93 @@ std::string TrimAscii(const std::string &input) {
 		end--;
 	}
 	return input.substr(start, end - start);
+}
+
+std::vector<std::string> ClassificationLabelsFromParameter(const std::string &parameter) {
+	std::vector<std::string> labels;
+	std::string error;
+	if (duckdb_ai::ExtractJsonStringArray("[" + parameter + "]", labels, error) ||
+	    duckdb_ai::ExtractJsonStringArray(parameter, labels, error)) {
+		return labels;
+	}
+	for (idx_t start = 0; start <= parameter.size();) {
+		auto separator = parameter.find(',', start);
+		auto label =
+		    TrimAscii(parameter.substr(start, separator == std::string::npos ? std::string::npos : separator - start));
+		if (!label.empty()) {
+			labels.push_back(std::move(label));
+		}
+		if (separator == std::string::npos) {
+			break;
+		}
+		start = separator + 1;
+	}
+	return labels;
+}
+
+bool ValidateClassificationLabelSet(const std::vector<std::string> &labels, std::string &error) {
+	if (labels.empty()) {
+		error = "classification labels must not be empty";
+		return false;
+	}
+	std::set<std::string> seen;
+	for (auto &label : labels) {
+		auto trimmed = TrimAscii(label);
+		if (trimmed.empty()) {
+			error = "classification labels must not contain empty values";
+			return false;
+		}
+		if (!seen.insert(LowerAscii(trimmed)).second) {
+			error = "classification labels must be unique";
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CanonicalClassificationLabel(const std::string &parameter, const std::string &candidate, std::string &canonical,
+                                  std::string &error) {
+	auto labels = ClassificationLabelsFromParameter(parameter);
+	if (!ValidateClassificationLabelSet(labels, error)) {
+		return false;
+	}
+	auto normalized = TrimAscii(StripMarkdownJsonFence(candidate));
+	std::vector<std::string> parsed_candidate;
+	std::string parse_error;
+	if (duckdb_ai::ExtractJsonStringArray("[" + normalized + "]", parsed_candidate, parse_error) &&
+	    parsed_candidate.size() == 1) {
+		normalized = parsed_candidate[0];
+	}
+	for (auto &label : labels) {
+		if (LowerAscii(label) == LowerAscii(normalized)) {
+			canonical = label;
+			return true;
+		}
+	}
+	error = "model returned a label outside the allowed label set: " + normalized;
+	return false;
+}
+
+bool ValidateMultiClassificationLabels(const std::string &parameter, std::vector<std::string> &outputs,
+                                       std::string &error) {
+	auto labels = ClassificationLabelsFromParameter(parameter);
+	if (!ValidateClassificationLabelSet(labels, error)) {
+		return false;
+	}
+	std::set<std::string> seen;
+	for (auto &output : outputs) {
+		std::string canonical;
+		if (!CanonicalClassificationLabel(parameter, output, canonical, error)) {
+			return false;
+		}
+		auto normalized = LowerAscii(canonical);
+		if (!seen.insert(normalized).second) {
+			error = "model returned a duplicate classification label: " + canonical;
+			return false;
+		}
+		output = std::move(canonical);
+	}
+	return true;
 }
 
 std::string StripMarkdownJsonFence(const std::string &text) {
@@ -4268,6 +4384,14 @@ void AiTaskFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 		AppendSystemPrompt(job.options, system_prompt);
 		auto prompt = BuildTaskUserPrompt(bind_data.task, job.input, job.parameter);
 		job.output = duckdb_ai::Complete(prompt, job.options).text;
+		if (bind_data.task == AiTaskKind::CLASSIFY) {
+			std::string canonical;
+			std::string error;
+			if (!CanonicalClassificationLabel(job.parameter, job.output, canonical, error)) {
+				throw InvalidInputException("ai_classify %s", error);
+			}
+			job.output = std::move(canonical);
+		}
 	});
 
 	for (auto &job : jobs) {
@@ -4351,6 +4475,9 @@ void AiClassifyLabelsFunction(DataChunk &args, ExpressionState &state, Vector &r
 		if (!duckdb_ai::ExtractJsonStringArray(output, job.output, error)) {
 			throw InvalidInputException("ai_classify_labels expected a JSON array of strings: %s", error);
 		}
+		if (!ValidateMultiClassificationLabels(job.parameter, job.output, error)) {
+			throw InvalidInputException("ai_classify_labels %s", error);
+		}
 	});
 
 	for (auto &job : jobs) {
@@ -4433,7 +4560,7 @@ Value AiClassifyResultValue(const LogicalType &result_type, const std::vector<st
 	} else {
 		children.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
 		children.emplace_back(error);
-		children.emplace_back(LogicalType::VARCHAR);
+		children.push_back(metadata.empty() ? Value(LogicalType::VARCHAR) : Value(metadata));
 	}
 	return Value::STRUCT(result_type, std::move(children));
 }
@@ -4479,7 +4606,9 @@ void AiClassifyResultFunction(DataChunk &args, ExpressionState &state, Vector &r
 			job.parameter = std::move(labels);
 			jobs.push_back(std::move(job));
 		} catch (std::exception &ex) {
-			result.SetValue(row, AiClassifyResultValue(result_type, {}, ex.what(), ""));
+			result.SetValue(row,
+			                AiClassifyResultValue(result_type, {}, ex.what(),
+			                                      R"({"stage":"configuration","multi_label":true,"status":"error"})"));
 		}
 	}
 	RunProviderJobs(jobs, [&](ProviderStringListJob &job) {
@@ -4491,15 +4620,25 @@ void AiClassifyResultFunction(DataChunk &args, ExpressionState &state, Vector &r
 		if (!duckdb_ai::ExtractJsonStringArray(output, job.output, error)) {
 			throw InvalidInputException("ai_classify_result expected a JSON array of strings: %s", error);
 		}
+		if (!ValidateMultiClassificationLabels(job.parameter, job.output, error)) {
+			throw InvalidInputException("ai_classify_result %s", error);
+		}
 	});
 	for (auto &job : jobs) {
+		std::string metadata;
+		try {
+			auto config = duckdb_ai::ResolveProvider(job.options);
+			metadata = "{\"provider\":\"" + JsonEscapeSqlText(config.provider) + "\",\"model\":\"" +
+			           JsonEscapeSqlText(config.model) + "\",\"multi_label\":true";
+		} catch (...) {
+			metadata = R"({"stage":"configuration","multi_label":true)";
+		}
 		if (job.exception) {
-			result.SetValue(job.row, AiClassifyResultValue(result_type, {}, job.error_message, ""));
+			metadata += ",\"status\":\"error\"}";
+			result.SetValue(job.row, AiClassifyResultValue(result_type, {}, job.error_message, metadata));
 			continue;
 		}
-		auto config = duckdb_ai::ResolveProvider(job.options);
-		auto metadata = "{\"provider\":\"" + JsonEscapeSqlText(config.provider) + "\",\"model\":\"" +
-		                JsonEscapeSqlText(config.model) + "\",\"multi_label\":true}";
+		metadata += ",\"status\":\"ok\"}";
 		result.SetValue(job.row, AiClassifyResultValue(result_type, job.output, "", metadata));
 	}
 }
@@ -6042,6 +6181,22 @@ void AiSecretsFunction(ClientContext &, TableFunctionInput &data_p, DataChunk &o
 	output.SetCardinality(count);
 }
 
+bool ExternalModelHasCapability(const std::string &capabilities, const std::string &expected) {
+	for (idx_t start = 0; start <= capabilities.size();) {
+		auto separator = capabilities.find(',', start);
+		auto capability = TrimAscii(
+		    capabilities.substr(start, separator == std::string::npos ? std::string::npos : separator - start));
+		if (LowerAscii(capability) == expected) {
+			return true;
+		}
+		if (separator == std::string::npos) {
+			break;
+		}
+		start = separator + 1;
+	}
+	return false;
+}
+
 unique_ptr<FunctionData> AiModelsBind(ClientContext &, TableFunctionBindInput &, vector<LogicalType> &return_types,
                                       vector<string> &names) {
 	AddTableColumns(return_types, names,
@@ -6112,13 +6267,22 @@ void AiModelsFunction(ClientContext &context, TableFunctionInput &data_p, DataCh
 			inspected_options.base_url = location;
 			inspected_options.model_options = options;
 			duckdb_ai::ApplyModelProfileOptions(inspected_options);
-			runtime_capabilities = duckdb_ai::GetProviderCapabilities(inspected_options);
+			auto embedding_model = model_type == "embedding" || ExternalModelHasCapability(capabilities, "embedding");
+			runtime_capabilities = duckdb_ai::GetProviderCapabilities(inspected_options, embedding_model);
 			has_runtime_capabilities = true;
 			if (!credential.empty()) {
 				auto credential_entry = secret_manager.GetSecretByName(transaction, credential);
 				if (!credential_entry || !credential_entry->secret ||
 				    credential_entry->secret->GetType() != "duckdb_ai") {
 					validation_status = "missing_credential";
+				} else if (auto credential_secret =
+				               dynamic_cast<const KeyValueSecret *>(credential_entry->secret.get())) {
+					std::string credential_provider;
+					TryReadSecretString(*credential_secret, "provider", credential_provider);
+					if (!credential_provider.empty() && duckdb_ai::NormalizeProviderName(credential_provider) !=
+					                                        duckdb_ai::NormalizeProviderName(provider)) {
+						validation_status = "credential_provider_mismatch";
+					}
 				}
 			}
 		} catch (std::exception &ex) {
@@ -6133,10 +6297,9 @@ void AiModelsFunction(ClientContext &context, TableFunctionInput &data_p, DataCh
 			output_price = inspected_options.output_token_price_per_million;
 		}
 		if (input_price < 0 || output_price < 0) {
-			auto operation =
-			    model_type == "embedding" || LowerAscii(capabilities).find("embedding") != std::string::npos
-			        ? std::string("embedding")
-			        : std::string("completion");
+			auto operation = model_type == "embedding" || ExternalModelHasCapability(capabilities, "embedding")
+			                     ? std::string("embedding")
+			                     : std::string("completion");
 			for (auto &price : duckdb_ai::ModelPrices()) {
 				if (duckdb_ai::NormalizeProviderName(price.provider) == duckdb_ai::NormalizeProviderName(provider) &&
 				    LowerAscii(price.model) == LowerAscii(model) && price.operation == operation) {
@@ -6216,6 +6379,10 @@ unique_ptr<FunctionData> ExternalModelBind(ClientContext &, TableFunctionBindInp
 	bind_data->replace = BooleanValue::Get(replace_value);
 	if (bind_data->name.empty() || bind_data->provider.empty() || bind_data->model.empty()) {
 		throw BinderException("CREATE EXTERNAL MODEL requires a name, provider, and model");
+	}
+	if (!bind_data->model_type.empty() && bind_data->model_type != "completion" &&
+	    bind_data->model_type != "embedding") {
+		throw BinderException("CREATE EXTERNAL MODEL model_type must be completion or embedding");
 	}
 	if (!bind_data->options.empty()) {
 		std::string error;
@@ -6315,6 +6482,9 @@ unique_ptr<FunctionData> ControlPlaneBind(ClientContext &context, TableFunctionB
 	}
 	auto bind_data = make_uniq<ControlPlaneBindData>(operation);
 	bind_data->argument = ExternalModelInputString(input.inputs[0]);
+	if (bind_data->argument.empty()) {
+		throw BinderException("AI control-plane profile or operation id must not be empty");
+	}
 	ApplySettings(context, bind_data->options);
 	duckdb_ai::AttachProviderRuntimeState(bind_data->options, context);
 	if (operation == ControlPlaneOperation::PROVISION) {
@@ -6332,8 +6502,11 @@ unique_ptr<FunctionData> ControlPlaneBind(ClientContext &context, TableFunctionB
 				throw BinderException("Unsupported ai_provision_endpoint option \"%s\"", name);
 			}
 		}
-		if (!bind_data->dry_run && (!bind_data->has_max_hourly_cost || !std::isfinite(bind_data->max_hourly_cost_usd) ||
-		                            bind_data->max_hourly_cost_usd <= 0)) {
+		if (bind_data->has_max_hourly_cost &&
+		    (!std::isfinite(bind_data->max_hourly_cost_usd) || bind_data->max_hourly_cost_usd <= 0)) {
+			throw BinderException("ai_provision_endpoint max_hourly_cost_usd must be finite and greater than 0");
+		}
+		if (!bind_data->dry_run && !bind_data->has_max_hourly_cost) {
 			throw BinderException("ai_provision_endpoint requires max_hourly_cost_usd > 0 when dry_run is false");
 		}
 	}
@@ -6564,9 +6737,17 @@ void LoadDocumentElements(const DocumentParseBindData &bind_data, DocumentParseS
 		auto doc = ParseSqlJson(response);
 		auto root = doc ? duckdb_yyjson::yyjson_doc_get_root(doc.get()) : nullptr;
 		auto document_id = SqlJsonString(root, "document_id");
+		auto root_error = SqlJsonString(root, "error");
 		auto elements =
 		    root && duckdb_yyjson::yyjson_is_obj(root) ? duckdb_yyjson::yyjson_obj_get(root, "elements") : nullptr;
 		if (!elements || !duckdb_yyjson::yyjson_is_arr(elements)) {
+			if (!root_error.empty()) {
+				DocumentElement result;
+				result.document_id = document_id;
+				result.error = root_error;
+				state.elements.push_back(std::move(result));
+				return;
+			}
 			throw IOException("AI document parser response must contain an elements array");
 		}
 		if (elements && duckdb_yyjson::yyjson_is_arr(elements)) {
@@ -6594,10 +6775,9 @@ void LoadDocumentElements(const DocumentParseBindData &bind_data, DocumentParseS
 			}
 		}
 		if (state.elements.empty()) {
-			auto error = SqlJsonString(root, "error");
 			DocumentElement result;
 			result.document_id = document_id;
-			result.error = error.empty() ? "AI document parser returned no elements" : error;
+			result.error = root_error.empty() ? "AI document parser returned no elements" : root_error;
 			state.elements.push_back(std::move(result));
 		}
 	} catch (std::exception &ex) {
@@ -6695,6 +6875,12 @@ ParsedClassifierArtifact ParseClassifierArtifact(ClientContext &context, const s
 			throw InvalidInputException("classifier artifact labels must contain only strings");
 		}
 		result.labels.emplace_back(duckdb_yyjson::yyjson_get_str(entry), duckdb_yyjson::yyjson_get_len(entry));
+	}
+	std::set<std::string> unique_labels;
+	for (auto &label : result.labels) {
+		if (label.empty() || !unique_labels.insert(LowerAscii(label)).second) {
+			throw InvalidInputException("classifier artifact labels must be non-empty and unique");
+		}
 	}
 	auto centroids = duckdb_yyjson::yyjson_obj_get(root, "centroids");
 	if (!centroids || !duckdb_yyjson::yyjson_is_arr(centroids)) {

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -103,6 +103,7 @@ constexpr int64_t DEFAULT_COMPLETION_OUTPUT_TOKEN_ESTIMATE = 512;
 std::once_flag curl_global_init_once;
 std::atomic<uint64_t> next_operation_id {1};
 const size_t DEFAULT_MAX_RESPONSE_CACHE_ENTRIES = 1024;
+constexpr size_t DEFAULT_MAX_RESPONSE_CACHE_BYTES = 64ULL * 1024ULL * 1024ULL;
 
 struct ProviderRuntimeState : public ObjectCacheEntry {
 	~ProviderRuntimeState();
@@ -134,6 +135,7 @@ struct ProviderRuntimeState : public ObjectCacheEntry {
 
 	std::mutex response_cache_mutex;
 	std::unordered_map<std::string, CachedHttpResponse> response_cache;
+	size_t response_cache_bytes = 0;
 	//! Least-recently-used cache keys first; entries hold their own iterator for O(1) reordering.
 	std::list<std::string> response_cache_order;
 	std::unordered_map<std::string, std::shared_ptr<PendingHttpResponse>> response_cache_pending;
@@ -1079,6 +1081,9 @@ void RemoveCachedResponse(ProviderRuntimeState &state, const std::string &cache_
 	if (entry == state.response_cache.end()) {
 		return;
 	}
+	auto entry_bytes = cache_key.size() + entry->second.response.body.size();
+	state.response_cache_bytes =
+	    state.response_cache_bytes >= entry_bytes ? state.response_cache_bytes - entry_bytes : 0;
 	state.response_cache_order.erase(entry->second.order_entry);
 	state.response_cache.erase(entry);
 }
@@ -1091,6 +1096,9 @@ bool TryGetCachedResponse(ProviderRuntimeState &state, const std::string &cache_
 		return false;
 	}
 	if (ResponseCacheEntryExpired(entry->second, options)) {
+		auto entry_bytes = cache_key.size() + entry->second.response.body.size();
+		state.response_cache_bytes =
+		    state.response_cache_bytes >= entry_bytes ? state.response_cache_bytes - entry_bytes : 0;
 		state.response_cache_order.erase(entry->second.order_entry);
 		state.response_cache.erase(entry);
 		return false;
@@ -1106,28 +1114,42 @@ bool TryGetCachedResponse(ProviderRuntimeState &state, const std::string &cache_
 void StoreCachedResponse(ProviderRuntimeState &state, const std::string &cache_key, const HttpResponse &response,
                          const CompletionOptions &options) {
 	auto max_entries = MaxResponseCacheEntries(options);
-	if (max_entries == 0) {
+	auto response_bytes = cache_key.size() + response.body.size();
+	if (max_entries == 0 || response_bytes > DEFAULT_MAX_RESPONSE_CACHE_BYTES) {
 		return;
 	}
 	std::lock_guard<std::mutex> lock(state.response_cache_mutex);
 	auto entry = state.response_cache.find(cache_key);
 	if (entry != state.response_cache.end()) {
+		auto previous_bytes = cache_key.size() + entry->second.response.body.size();
+		state.response_cache_bytes =
+		    state.response_cache_bytes >= previous_bytes ? state.response_cache_bytes - previous_bytes : 0;
 		entry->second.response = response;
 		entry->second.response.cache_hit = false;
 		entry->second.created_at = std::chrono::steady_clock::now();
+		state.response_cache_bytes += response_bytes;
 		TouchResponseCacheEntry(state, entry->second, cache_key);
-		return;
+	} else {
+		CachedHttpResponse cached;
+		cached.response = response;
+		cached.response.cache_hit = false;
+		cached.created_at = std::chrono::steady_clock::now();
+		cached.order_entry = state.response_cache_order.insert(state.response_cache_order.end(), cache_key);
+		state.response_cache.emplace(cache_key, std::move(cached));
+		state.response_cache_bytes += response_bytes;
 	}
-	CachedHttpResponse cached;
-	cached.response = response;
-	cached.response.cache_hit = false;
-	cached.created_at = std::chrono::steady_clock::now();
-	cached.order_entry = state.response_cache_order.insert(state.response_cache_order.end(), cache_key);
-	state.response_cache.emplace(cache_key, std::move(cached));
-	while (state.response_cache.size() > max_entries && !state.response_cache_order.empty()) {
+	while (
+	    (state.response_cache.size() > max_entries || state.response_cache_bytes > DEFAULT_MAX_RESPONSE_CACHE_BYTES) &&
+	    !state.response_cache_order.empty()) {
 		auto oldest = std::move(state.response_cache_order.front());
 		state.response_cache_order.pop_front();
-		state.response_cache.erase(oldest);
+		auto oldest_entry = state.response_cache.find(oldest);
+		if (oldest_entry != state.response_cache.end()) {
+			auto oldest_bytes = oldest.size() + oldest_entry->second.response.body.size();
+			state.response_cache_bytes =
+			    state.response_cache_bytes >= oldest_bytes ? state.response_cache_bytes - oldest_bytes : 0;
+			state.response_cache.erase(oldest_entry);
+		}
 	}
 }
 
@@ -3787,26 +3809,25 @@ std::vector<EmbeddingResult> ParseEmbeddingResults(const ProviderConfig &config,
 	auto total_tokens = FindJsonIntegerValue(response.body, "total_tokens");
 	std::vector<EmbeddingResult> results;
 	results.reserve(values.size());
+	auto distribute_tokens = [&](int64_t tokens, idx_t index) {
+		if (tokens < 0) {
+			return int64_t(-1);
+		}
+		auto count = NumericCast<int64_t>(std::max<idx_t>(1, values.size()));
+		return tokens / count + (NumericCast<int64_t>(index) < tokens % count ? 1 : 0);
+	};
 	for (idx_t i = 0; i < values.size(); i++) {
 		EmbeddingResult result;
 		result.values = std::move(values[i]);
-		result.raw_response = response.body;
+		if (i == 0) {
+			result.raw_response = response.body;
+		}
 		result.http_status = response.status;
 		result.elapsed_ms = response.elapsed_ms;
 		result.retries = response.retries;
 		result.cache_hit = response.cache_hit;
-		if (prompt_tokens >= 0) {
-			result.prompt_tokens = static_cast<int64_t>(
-			    std::ceil(static_cast<double>(prompt_tokens) / static_cast<double>(std::max<idx_t>(1, values.size()))));
-		} else {
-			result.prompt_tokens = -1;
-		}
-		if (total_tokens >= 0) {
-			result.total_tokens = static_cast<int64_t>(
-			    std::ceil(static_cast<double>(total_tokens) / static_cast<double>(std::max<idx_t>(1, values.size()))));
-		} else {
-			result.total_tokens = -1;
-		}
+		result.prompt_tokens = distribute_tokens(prompt_tokens, i);
+		result.total_tokens = distribute_tokens(total_tokens, i);
 		results.push_back(std::move(result));
 	}
 	return results;
@@ -4451,7 +4472,8 @@ std::string SerializeEmbeddingCacheBody(const ProviderConfig &config, const Embe
 	return body;
 }
 
-void ValidateEmbeddingInputLimits(const std::string &input, const ProviderCapabilities &capabilities) {
+void ValidateEmbeddingInputLimits(const std::string &input, idx_t request_bytes,
+                                  const ProviderCapabilities &capabilities) {
 	auto input_tokens = EstimateTokenCount(input);
 	if (input_tokens > capabilities.max_batch_tokens) {
 		throw InvalidInputException(
@@ -4463,8 +4485,10 @@ void ValidateEmbeddingInputLimits(const std::string &input, const ProviderCapabi
 		    "AI embedding input has %lld estimated tokens; external model context limit is %lld",
 		    static_cast<long long>(input_tokens), static_cast<long long>(capabilities.context_tokens));
 	}
-	if (NumericCast<int64_t>(input.size()) + 64 > capabilities.max_request_bytes) {
-		throw InvalidInputException("AI embedding input exceeds external model max_request_bytes");
+	if (NumericCast<int64_t>(request_bytes) > capabilities.max_request_bytes) {
+		throw InvalidInputException("AI embedding request has %llu bytes; external model request limit is %lld",
+		                            static_cast<unsigned long long>(request_bytes),
+		                            static_cast<long long>(capabilities.max_request_bytes));
 	}
 }
 
@@ -4476,6 +4500,22 @@ std::string EmbeddingDimensionError(const EmbeddingResult &result, const Provide
 	return StringUtil::Format("AI embedding provider returned %llu dimensions; external model expects %lld",
 	                          static_cast<unsigned long long>(result.values.size()),
 	                          static_cast<long long>(capabilities.embedding_dimensions));
+}
+
+void ValidateCompletionRequestLimits(const std::string &prompt, const std::string &payload,
+                                     const CompletionOptions &options) {
+	auto capabilities = GetProviderCapabilities(options, false);
+	auto input_tokens = EstimateTokenCount(prompt) + EstimateTokenCount(options.system_prompt);
+	if (capabilities.context_tokens > 0 && input_tokens > capabilities.context_tokens) {
+		throw InvalidInputException(
+		    "AI completion input has %lld estimated tokens; external model context limit is %lld",
+		    static_cast<long long>(input_tokens), static_cast<long long>(capabilities.context_tokens));
+	}
+	if (NumericCast<int64_t>(payload.size()) > capabilities.max_request_bytes) {
+		throw InvalidInputException("AI completion request has %llu bytes; external model request limit is %lld",
+		                            static_cast<unsigned long long>(payload.size()),
+		                            static_cast<long long>(capabilities.max_request_bytes));
+	}
 }
 
 //! Fetch a provider response, going through the response cache and in-flight request coalescing
@@ -4518,6 +4558,22 @@ HttpResponse FetchProviderResponse(const std::string &operation, const ProviderC
 }
 
 //! Issue one batched embedding request and record per-input usage events.
+class EmbeddingBatchTooLargeException : public std::runtime_error {
+public:
+	explicit EmbeddingBatchTooLargeException(const std::string &message) : std::runtime_error(message) {
+	}
+};
+
+bool IsEmbeddingBatchTooLarge(long status, const std::string &error) {
+	if (status == 413) {
+		return true;
+	}
+	auto message = LowerAscii(error);
+	return message.find("payload too large") != std::string::npos ||
+	       message.find("request too large") != std::string::npos ||
+	       message.find("maximum context") != std::string::npos;
+}
+
 std::vector<EmbeddingResult> EmbedBatchRequest(const ProviderConfig &config, const std::string &endpoint,
                                                const std::vector<std::string> &inputs,
                                                const CompletionOptions &options) {
@@ -4539,6 +4595,9 @@ std::vector<EmbeddingResult> EmbedBatchRequest(const ProviderConfig &config, con
 	}
 	if (response.status < 200 || response.status >= 300) {
 		auto error = ProviderErrorDetail(config, response);
+		if (inputs.size() > 1 && IsEmbeddingBatchTooLarge(response.status, error)) {
+			throw EmbeddingBatchTooLargeException(error);
+		}
 		for (auto &input : inputs) {
 			RecordFailedEmbeddingUsageEvent(config, input, options, response.status, error, response.retries);
 		}
@@ -4553,7 +4612,7 @@ std::vector<EmbeddingResult> EmbedBatchRequest(const ProviderConfig &config, con
 		}
 		throw;
 	}
-	auto capabilities = GetProviderCapabilities(options);
+	auto capabilities = GetProviderCapabilities(options, true);
 	if (capabilities.embedding_dimensions > 0) {
 		for (auto &result : results) {
 			auto error = EmbeddingDimensionError(result, capabilities);
@@ -4601,8 +4660,11 @@ std::string ProviderProtocol(const std::string &provider) {
 	return ProviderDefaults(provider).protocol;
 }
 
-ProviderCapabilities GetProviderCapabilities(const CompletionOptions &options) {
-	auto config = ResolveProviderConfig(options, false);
+ProviderCapabilities GetProviderCapabilities(const CompletionOptions &options, bool embedding) {
+	auto config = embedding ? ResolveEmbeddingProviderConfig(options, false) : ResolveProviderConfig(options, false);
+	if (!config.base_url.empty()) {
+		UrlHost(config.base_url);
+	}
 	ProviderCapabilities capabilities;
 	capabilities.provider = config.provider;
 	capabilities.protocol = config.protocol;
@@ -4708,7 +4770,9 @@ std::string BuildRequestJson(const std::string &prompt, const std::string &model
 
 std::string BuildRequestJson(const std::string &prompt, const CompletionOptions &options) {
 	auto config = ResolveProviderConfig(options, false);
-	return RequestPayload(config, prompt, options);
+	auto payload = RequestPayload(config, prompt, options);
+	ValidateCompletionRequestLimits(prompt, payload, options);
+	return payload;
 }
 
 CompletionResult Complete(const std::string &prompt, const std::string &model, const std::string &provider) {
@@ -4725,8 +4789,15 @@ CompletionResult Complete(const std::string &prompt, const CompletionOptions &op
 	auto request_options = RequestOperationOptions(options);
 	auto config = ResolveProvider(request_options);
 	auto endpoint = RequestEndpoint(config);
-	auto payload = RequestPayload(config, prompt, request_options);
-	EnforceAllowedHost(endpoint, request_options);
+	std::string payload;
+	try {
+		payload = RequestPayload(config, prompt, request_options);
+		ValidateCompletionRequestLimits(prompt, payload, request_options);
+		EnforceAllowedHost(endpoint, request_options);
+	} catch (std::exception &ex) {
+		RecordFailedUsageEvent(config, prompt, request_options, 0, ex.what(), 0);
+		throw;
+	}
 	HttpResponse response;
 	std::string cache_key;
 	try {
@@ -4772,8 +4843,15 @@ CompletionResult Redact(const std::string &text, const CompletionOptions &option
 		                            config.provider);
 	}
 	auto endpoint = RequestEndpoint(config);
-	auto payload = RequestPayload(config, text, request_options);
-	EnforceAllowedHost(endpoint, request_options);
+	std::string payload;
+	try {
+		payload = RequestPayload(config, text, request_options);
+		ValidateCompletionRequestLimits(text, payload, request_options);
+		EnforceAllowedHost(endpoint, request_options);
+	} catch (std::exception &ex) {
+		RecordFailedUsageEvent(config, text, request_options, 0, ex.what(), 0);
+		throw;
+	}
 	HttpResponse response;
 	std::string cache_key;
 	try {
@@ -4814,7 +4892,9 @@ std::string BuildEmbeddingRequestJson(const std::string &input, const std::strin
 
 std::string BuildEmbeddingRequestJson(const std::string &input, const CompletionOptions &options) {
 	auto config = ResolveEmbeddingProviderConfig(options, false);
-	return EmbeddingPayload(config, input);
+	auto payload = EmbeddingPayload(config, input);
+	ValidateEmbeddingInputLimits(input, payload.size(), GetProviderCapabilities(options, true));
+	return payload;
 }
 
 EmbeddingResult Embed(const std::string &input, const std::string &model, const std::string &provider) {
@@ -4830,15 +4910,15 @@ EmbeddingResult Embed(const std::string &input, const CompletionOptions &options
 	}
 	auto request_options = RequestOperationOptions(options);
 	auto config = ResolveEmbeddingProviderConfig(request_options, true);
-	auto capabilities = GetProviderCapabilities(request_options);
+	auto capabilities = GetProviderCapabilities(request_options, true);
+	auto payload = EmbeddingPayload(config, input);
 	try {
-		ValidateEmbeddingInputLimits(input, capabilities);
+		ValidateEmbeddingInputLimits(input, payload.size(), capabilities);
 	} catch (std::exception &ex) {
 		RecordFailedEmbeddingUsageEvent(config, input, request_options, 0, ex.what(), 0);
 		throw;
 	}
 	auto endpoint = EmbeddingEndpoint(config);
-	auto payload = EmbeddingPayload(config, input);
 	EnforceAllowedHost(endpoint, request_options);
 	HttpResponse response;
 	std::string cache_key;
@@ -4895,10 +4975,10 @@ std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, c
 	auto config = ResolveEmbeddingProviderConfig(options, true);
 	auto endpoint = EmbeddingEndpoint(config);
 	EnforceAllowedHost(endpoint, options);
-	auto capabilities = GetProviderCapabilities(options);
+	auto capabilities = GetProviderCapabilities(options, true);
 	for (auto &input : inputs) {
 		try {
-			ValidateEmbeddingInputLimits(input, capabilities);
+			ValidateEmbeddingInputLimits(input, EmbeddingPayload(config, input).size(), capabilities);
 		} catch (std::exception &ex) {
 			RecordFailedEmbeddingUsageEvent(config, input, options, 0, ex.what(), 0);
 			throw;
@@ -4950,11 +5030,11 @@ std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, c
 	while (batch_start < miss_rows.size()) {
 		auto batch_end = batch_start;
 		int64_t batch_tokens = 0;
-		int64_t batch_bytes = 64;
+		int64_t batch_bytes = NumericCast<int64_t>(EmbeddingPayload(config, std::vector<std::string> {}).size());
 		while (batch_end < miss_rows.size()) {
 			auto &input = inputs[miss_rows[batch_end]];
 			auto input_tokens = EstimateTokenCount(input);
-			auto input_bytes = NumericCast<int64_t>(input.size()) + 16;
+			auto input_bytes = NumericCast<int64_t>(JsonEscape(input).size()) + 2 + (batch_end > batch_start ? 1 : 0);
 			auto input_count = NumericCast<int64_t>(batch_end - batch_start + 1);
 			if (batch_end > batch_start && (input_count > capabilities.max_batch_inputs ||
 			                                batch_tokens + input_tokens > capabilities.max_batch_tokens ||
@@ -4977,15 +5057,7 @@ std::vector<EmbeddingResult> EmbedMany(const std::vector<std::string> &inputs, c
 		}
 		try {
 			return EmbedBatchRequest(config, endpoint, batch_inputs, batch_options);
-		} catch (IOException &ex) {
-			auto message = LowerAscii(ex.what());
-			auto payload_too_large = message.find("413") != std::string::npos ||
-			                         message.find("payload too large") != std::string::npos ||
-			                         message.find("request too large") != std::string::npos ||
-			                         message.find("maximum context") != std::string::npos;
-			if (!payload_too_large || batch_inputs.size() <= 1) {
-				throw;
-			}
+		} catch (EmbeddingBatchTooLargeException &) {
 			auto split = batch_inputs.size() / 2;
 			std::vector<std::string> left(batch_inputs.begin(), batch_inputs.begin() + split);
 			std::vector<std::string> right(batch_inputs.begin() + split, batch_inputs.end());
@@ -5123,6 +5195,7 @@ void ClearResponseCache() {
 	std::lock_guard<std::mutex> lock(fallback_runtime_state.response_cache_mutex);
 	fallback_runtime_state.response_cache.clear();
 	fallback_runtime_state.response_cache_order.clear();
+	fallback_runtime_state.response_cache_bytes = 0;
 }
 
 void ClearResponseCache(ClientContext &context) {
@@ -5130,6 +5203,7 @@ void ClearResponseCache(ClientContext &context) {
 	std::lock_guard<std::mutex> lock(state.response_cache_mutex);
 	state.response_cache.clear();
 	state.response_cache_order.clear();
+	state.response_cache_bytes = 0;
 }
 
 std::vector<ModelPrice> ModelPrices() {

--- a/src/include/duckdb_ai_provider.hpp
+++ b/src/include/duckdb_ai_provider.hpp
@@ -216,7 +216,7 @@ std::string ProviderBaseUrl(const std::string &provider);
 //! Return the provider protocol used for request/response shaping.
 std::string ProviderProtocol(const std::string &provider);
 //! Return conservative execution limits for the resolved provider/model.
-ProviderCapabilities GetProviderCapabilities(const CompletionOptions &options);
+ProviderCapabilities GetProviderCapabilities(const CompletionOptions &options, bool embedding = false);
 //! Apply safe pricing metadata stored in an external model's JSON options.
 void ApplyModelProfileOptions(CompletionOptions &options);
 //! Return a local approximate token count used by ai_count_tokens() and token-aware pacing.

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -5,11 +5,12 @@ import os
 import subprocess
 import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 
 
 class MockProviderHandler(BaseHTTPRequestHandler):
+    request_lock = threading.Lock()
     completion_requests = []
     embedding_requests = []
     privacy_filter_requests = []
@@ -25,6 +26,10 @@ class MockProviderHandler(BaseHTTPRequestHandler):
     claude_api_keys = []
     claude_versions = []
     retry_completion_attempts = 0
+    active_cap_one_requests = 0
+    max_cap_one_requests = 0
+    active_grow_pool_requests = 0
+    max_grow_pool_requests = 0
 
     @classmethod
     def reset(cls):
@@ -43,6 +48,10 @@ class MockProviderHandler(BaseHTTPRequestHandler):
         cls.claude_api_keys.clear()
         cls.claude_versions.clear()
         cls.retry_completion_attempts = 0
+        cls.active_cap_one_requests = 0
+        cls.max_cap_one_requests = 0
+        cls.active_grow_pool_requests = 0
+        cls.max_grow_pool_requests = 0
 
     def do_POST(self):
         length = int(self.headers.get("content-length", "0"))
@@ -59,6 +68,19 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             self.completion_requests.append(request)
             prompt = request["messages"][-1]["content"]
             full_prompt = "\n".join(message["content"] for message in request["messages"])
+            concurrency_group = None
+            if prompt.startswith("cap one "):
+                concurrency_group = "cap_one"
+            elif prompt.startswith("grow pool "):
+                concurrency_group = "grow_pool"
+            if concurrency_group:
+                with self.request_lock:
+                    active_name = f"active_{concurrency_group}_requests"
+                    max_name = f"max_{concurrency_group}_requests"
+                    active = getattr(MockProviderHandler, active_name) + 1
+                    setattr(MockProviderHandler, active_name, active)
+                    setattr(MockProviderHandler, max_name, max(getattr(MockProviderHandler, max_name), active))
+                time.sleep(0.05)
             if "force provider error" in prompt:
                 self._send_json(
                     {
@@ -96,6 +118,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 content = "x" * 2048
             elif "EMPTY_INTERMEDIATE" in prompt and "larger SQL aggregate" in prompt:
                 content = ""
+            elif "NON_CONVERGING" in prompt and "larger SQL aggregate" in prompt:
+                content = ("NON_CONVERGING" + "X" * 40)[:40]
             elif "return invalid schema JSON" in prompt:
                 content = '{"summary":123}'
             elif "return constrained schema JSON" in prompt:
@@ -131,9 +155,11 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             elif "Generate one DuckDB SQL SELECT statement" in full_prompt:
                 content = "```sql\nSELECT 42\n```"
             elif "Return only a JSON array of chosen labels" in full_prompt:
-                content = '["billing, overdue","performance"]'
+                content = '["outside"]' if "return unknown labels" in prompt else '["billing, overdue","performance"]'
             elif "class_a" in full_prompt and "class_b" in full_prompt:
                 content = "class_a" if "alpha" in prompt else "class_b"
+            elif "Classify the following text into exactly one" in full_prompt:
+                content = "outside" if "return unknown label" in prompt else "billing, overdue"
             elif "Score candidate relevance to the search query" in full_prompt:
                 content = "0.82"
             payload = {
@@ -144,6 +170,14 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                     "total_tokens": 10,
                 },
             }
+            if concurrency_group:
+                with self.request_lock:
+                    active_name = f"active_{concurrency_group}_requests"
+                    setattr(
+                        MockProviderHandler,
+                        active_name,
+                        getattr(MockProviderHandler, active_name) - 1,
+                    )
             self._send_json(payload)
             return
 
@@ -167,11 +201,12 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 return [0.25, -0.5, 1.25]
 
             input_values = inputs if isinstance(inputs, list) else [inputs]
+            usage_tokens = 5 if any("uneven usage" in value for value in input_values) else 2 * input_count
             payload = {
                 "data": [{"embedding": embedding(value)} for value in input_values],
                 "usage": {
-                    "prompt_tokens": 2 * input_count,
-                    "total_tokens": 2 * input_count,
+                    "prompt_tokens": usage_tokens,
+                    "total_tokens": usage_tokens,
                 },
             }
             self._send_json(payload)
@@ -243,6 +278,9 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             self.control_plane_authorization_headers.append(self.headers.get("authorization"))
             if request.get("parser_profile") == "malformed":
                 self._send_json({"document_id": "document-malformed", "unexpected": []})
+                return
+            if request.get("parser_profile") == "error-only":
+                self._send_json({"document_id": "document-error", "error": "remote parser failed"})
                 return
             self._send_json(
                 {
@@ -1422,7 +1460,11 @@ def assert_smoke_result(output: str):
     while len(MockProviderHandler.log_requests) < 47 and time.time() < log_deadline:
         time.sleep(0.05)
     if len(MockProviderHandler.log_requests) != 47:
-        raise AssertionError(f"expected 47 log requests, got {len(MockProviderHandler.log_requests)}")
+        event_counts = {}
+        for request in MockProviderHandler.log_requests:
+            event = "otlp" if "resourceLogs" in request else request.get("event", "unknown")
+            event_counts[event] = event_counts.get(event, 0) + 1
+        raise AssertionError(f"expected 47 log requests, got {len(MockProviderHandler.log_requests)}: {event_counts}")
     completion_logs = [
         request for request in MockProviderHandler.log_requests if request.get("event") == "ai_completion"
     ]
@@ -1580,6 +1622,24 @@ def run_duckdb_adaptive_batches(duckdb_path: Path, base_url: str) -> str:
             profile := 'tiny_embedding_request',
             fail_on_error := false
         ) IS NULL AS token_limit_rejected;
+        CREATE EXTERNAL MODEL escaped_embedding_request WITH (
+            provider = 'openai',
+            model = 'mock-embedding',
+            location = '{base_url}',
+            model_type = 'embedding',
+            options = '{{"max_request_bytes":200}}'
+        );
+        SELECT ai_embed(repeat('"', 100), profile := 'escaped_embedding_request',
+                        fail_on_error := false) IS NULL AS escaped_byte_limit_rejected;
+        CREATE EXTERNAL MODEL tiny_completion_context WITH (
+            provider = 'openai',
+            model = 'mock-completion',
+            location = '{base_url}',
+            model_type = 'completion',
+            options = '{{"max_input_tokens":1}}'
+        );
+        SELECT ai_complete('too many completion tokens', profile := 'tiny_completion_context',
+                           fail_on_error := false) IS NULL AS completion_context_rejected;
         CREATE EXTERNAL MODEL cached_embedding_dimensions WITH (
             provider = 'openai',
             model = 'mock-embedding',
@@ -1608,7 +1668,7 @@ def run_duckdb_adaptive_batches(duckdb_path: Path, base_url: str) -> str:
             ('same left', 'other right'),
             ('same left', 'other right')
         ) input(left_text, right_text);
-        SELECT sum(batch_count) AS request_batches, sum(failures) AS failed_input_events
+        SELECT sum(batch_count) AS request_batches, sum(failures) = 4 AS only_terminal_failures
         FROM ai_usage_summary();
     """
     env = os.environ.copy()
@@ -1632,12 +1692,15 @@ def assert_adaptive_batches(output: str):
         "split_embedding_sum",
         "2.0",
         "token_limit_rejected",
+        "escaped_byte_limit_rejected",
+        "completion_context_rejected",
         "true",
         "cached_dimensions_seeded",
         "stale_dimensions_rejected",
         "deduplicated_similarity_sum",
         "4.0",
         "request_batches",
+        "only_terminal_failures",
     ):
         if expected not in output:
             raise AssertionError(f"adaptive batch output missing {expected!r}\n{output}")
@@ -1655,6 +1718,82 @@ def assert_adaptive_batches(output: str):
     deduplicated_inputs = MockProviderHandler.embedding_requests[11]["input"]
     if deduplicated_inputs != ["same left", "same right", "other right"]:
         raise AssertionError(f"similarity inputs were not packed and deduplicated: {deduplicated_inputs}")
+    if MockProviderHandler.completion_requests:
+        raise AssertionError(
+            f"completion context preflight unexpectedly called the provider: {MockProviderHandler.completion_requests}"
+        )
+
+
+def run_duckdb_embedding_usage_distribution(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT * FROM ai_clear_usage();
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_embedding_model = 'mock-embedding';
+        SET duckdb_ai_base_url = '{base_url}';
+        SELECT sum(ai_embed('uneven usage ' || i::VARCHAR)[1]) FROM range(3) t(i);
+        SELECT sum(prompt_tokens) = 5 AS exact_prompt_tokens,
+               sum(total_tokens) = 5 AS exact_total_tokens
+        FROM ai_usage() WHERE event = 'ai_embedding';
+    """
+    env = {**os.environ, "OPENAI_API_KEY": "test-key"}
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb embedding usage distribution exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_embedding_usage_distribution(output: str):
+    for expected in ("exact_prompt_tokens", "exact_total_tokens", "true"):
+        if expected not in output:
+            raise AssertionError(f"embedding usage distribution output missing {expected!r}\n{output}")
+    if len(MockProviderHandler.embedding_requests) != 1:
+        raise AssertionError(f"expected one packed uneven-usage request: {MockProviderHandler.embedding_requests}")
+
+
+def run_duckdb_executor_concurrency(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_completion_model = 'mock-completion';
+        SET duckdb_ai_base_url = '{base_url}';
+        SET duckdb_ai_timeout_seconds = 5;
+        SELECT count(ai_complete('grow pool ' || i::VARCHAR, max_concurrent_requests := 8)) AS grown
+        FROM range(8) t(i);
+        SELECT count(ai_complete('cap one ' || i::VARCHAR, max_concurrent_requests := 1)) AS capped
+        FROM range(8) t(i);
+    """
+    env = {**os.environ, "OPENAI_API_KEY": "test-key"}
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb executor concurrency exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_executor_concurrency(output: str):
+    for expected in ("grown", "capped", "8"):
+        if expected not in output:
+            raise AssertionError(f"executor concurrency output missing {expected!r}\n{output}")
+    if MockProviderHandler.max_grow_pool_requests < 2:
+        raise AssertionError("executor did not exercise concurrent provider requests")
+    if MockProviderHandler.max_cap_one_requests != 1:
+        raise AssertionError(
+            f"max_concurrent_requests=1 allowed {MockProviderHandler.max_cap_one_requests} concurrent requests"
+        )
 
 
 def run_duckdb_hierarchical_aggregate(duckdb_path: Path, base_url: str) -> str:
@@ -1678,6 +1817,12 @@ def run_duckdb_hierarchical_aggregate(duckdb_path: Path, base_url: str) -> str:
                       fail_on_error := false) IS NULL AS empty_intermediate_rejected
         FROM (
             SELECT repeat('EMPTY_INTERMEDIATE', 4) || i::VARCHAR AS value
+            FROM range(4) t(i)
+        );
+        SELECT ai_agg(value, 'Summarize all values', max_context_chars := 40,
+                      fail_on_error := false) IS NULL AS non_converging_rejected
+        FROM (
+            SELECT repeat('NON_CONVERGING', 4) || i::VARCHAR AS value
             FROM range(4) t(i)
         );
     """
@@ -1704,6 +1849,7 @@ def assert_hierarchical_aggregate(output: str):
         "operations",
         "parents",
         "empty_intermediate_rejected",
+        "non_converging_rejected",
         "true",
     ):
         if expected not in output:
@@ -1715,6 +1861,9 @@ def assert_hierarchical_aggregate(output: str):
     prompts = [request["messages"][-1]["content"] for request in MockProviderHandler.completion_requests]
     if sum("mock completion" in prompt for prompt in prompts) < 2:
         raise AssertionError(f"aggregate did not perform recursive map/reduce: {prompts}")
+    non_converging_requests = sum("NON_CONVERGING" in prompt for prompt in prompts)
+    if non_converging_requests == 0 or non_converging_requests > 10:
+        raise AssertionError(f"non-converging aggregate was not stopped promptly: {non_converging_requests} requests")
 
 
 def run_duckdb_optimized_classifier(duckdb_path: Path, base_url: str) -> str:
@@ -1812,6 +1961,22 @@ def run_duckdb_new_task_functions(duckdb_path: Path, base_url: str) -> str:
                 'invoice overdue and slow app', ['billing, overdue', 'performance', 'support']
             ) AS result
         );
+        SELECT ai_classify('return unknown label', ['red', 'blue'],
+                           fail_on_error := false) IS NULL AS unknown_single_rejected;
+        SELECT ai_classify_labels('return unknown labels', ['red', 'blue'],
+                                  fail_on_error := false) IS NULL AS unknown_multi_rejected;
+        SELECT ai_classify('alpha example', ['class_a', 'CLASS_A'],
+                           fail_on_error := false) IS NULL AS duplicate_labels_rejected;
+        SELECT contains(result.error, 'outside the allowed label set') AS diagnostic_error,
+               contains(result.metadata, '"status":"error"') AS diagnostic_metadata
+        FROM (
+            SELECT ai_classify_result('return unknown labels', ['red', 'blue']) AS result
+        );
+        SELECT contains(result.error, 'labels must be unique') AS duplicate_diagnostic_error,
+               contains(result.metadata, '"status":"error"') AS duplicate_diagnostic_metadata
+        FROM (
+            SELECT ai_classify_result('invoice overdue', ['billing', 'BILLING']) AS result
+        );
     """
     env = os.environ.copy()
     env["OPENAI_API_KEY"] = "test-key"
@@ -1830,7 +1995,21 @@ def run_duckdb_new_task_functions(duckdb_path: Path, base_url: str) -> str:
 
 
 def assert_new_task_functions(output: str):
-    for expected in ("score", "0.91", "rich_classification", "class_a", "billing, overdue", "performance"):
+    for expected in (
+        "score",
+        "0.91",
+        "rich_classification",
+        "class_a",
+        "billing, overdue",
+        "performance",
+        "unknown_single_rejected",
+        "unknown_multi_rejected",
+        "duplicate_labels_rejected",
+        "diagnostic_error",
+        "diagnostic_metadata",
+        "duplicate_diagnostic_error",
+        "duplicate_diagnostic_metadata",
+    ):
         if expected not in output:
             raise AssertionError(f"new task function output missing {expected!r}\n{output}")
     score_format = MockProviderHandler.completion_requests[0].get("response_format", {})
@@ -1863,6 +2042,8 @@ def run_duckdb_control_plane(duckdb_path: Path, base_url: str) -> str:
         FROM ai_parse_document('abc'::BLOB, 'text/plain', 'documents');
         SELECT error
         FROM ai_parse_document('abc'::BLOB, 'text/plain', 'malformed', fail_on_error := false);
+        SELECT document_id, error
+        FROM ai_parse_document('abc'::BLOB, 'text/plain', 'error-only', fail_on_error := false);
     """
     env = os.environ.copy()
     env.update(
@@ -1898,6 +2079,8 @@ def assert_control_plane(output: str):
         "DuckDB document",
         "0.99",
         "AI document parser response must contain an elements array",
+        "document-error",
+        "remote parser failed",
     ):
         if expected not in output:
             raise AssertionError(f"control-plane output missing {expected!r}\n{output}")
@@ -1908,9 +2091,10 @@ def assert_control_plane(output: str):
         "/v1/endpoints/deprovision",
         "/v1/documents/parse",
         "/v1/documents/parse",
+        "/v1/documents/parse",
     ]:
         raise AssertionError(f"unexpected control-plane requests: {MockProviderHandler.control_plane_requests}")
-    if MockProviderHandler.control_plane_authorization_headers != ["Bearer control-token"] * 5:
+    if MockProviderHandler.control_plane_authorization_headers != ["Bearer control-token"] * 6:
         raise AssertionError(
             f"unexpected control-plane authorization: {MockProviderHandler.control_plane_authorization_headers}"
         )
@@ -1943,6 +2127,21 @@ def main():
         MockProviderHandler.reset()
         adaptive_batch_output = run_duckdb_adaptive_batches(args.duckdb, f"http://127.0.0.1:{port}")
         assert_adaptive_batches(adaptive_batch_output)
+        MockProviderHandler.reset()
+        usage_distribution_output = run_duckdb_embedding_usage_distribution(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_embedding_usage_distribution(usage_distribution_output)
+        MockProviderHandler.reset()
+        threaded_server = ThreadingHTTPServer(("127.0.0.1", 0), MockProviderHandler)
+        threaded_thread = threading.Thread(target=threaded_server.serve_forever, daemon=True)
+        threaded_thread.start()
+        try:
+            concurrency_output = run_duckdb_executor_concurrency(
+                args.duckdb, f"http://127.0.0.1:{threaded_server.server_address[1]}"
+            )
+            assert_executor_concurrency(concurrency_output)
+        finally:
+            threaded_server.shutdown()
+            threaded_thread.join(timeout=5)
         MockProviderHandler.reset()
         hierarchical_output = run_duckdb_hierarchical_aggregate(args.duckdb, f"http://127.0.0.1:{port}")
         assert_hierarchical_aggregate(hierarchical_output)

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -1038,11 +1038,12 @@ SELECT ai_classify('great', ['positive', 'negative'],
 ----
 true
 
-query II
-SELECT result.value IS NULL, contains(result.error, 'Unsupported AI provider')
+query III
+SELECT result.value IS NULL, contains(result.error, 'Unsupported AI provider'),
+       contains(result.metadata, '"stage":"configuration"')
 FROM (SELECT ai_classify_result('great', ['positive', 'negative'], provider := 'not-a-provider') AS result);
 ----
-true	true
+true	true	true
 
 query I
 SELECT ai_score('DuckDB runs in process', 'describes an embedded database',
@@ -1086,6 +1087,17 @@ FROM (
 ----
 true
 
+query I
+SELECT contains(result.error, 'labels must be non-empty and unique')
+FROM (
+  SELECT ai_classify_optimized(
+    'x',
+    '{"version":1,"optimization":"minimize_cost","usable":true,"accuracy":0.9,"confidence_margin":0.1,"labels":["a","A"],"centroids":[[1,0],[0,1]],"embedding":{"provider":"ollama","model":"embed"}}'
+  ) AS result
+);
+----
+true
+
 # External model profiles store only safe metadata and provisioning defaults to a local dry run.
 statement error
 CREATE EXTERNAL MODEL duplicate_ai_test_model WITH (
@@ -1095,6 +1107,13 @@ CREATE EXTERNAL MODEL duplicate_ai_test_model WITH (
 );
 ----
 Duplicate external model option: provider
+
+statement error
+CREATE EXTERNAL MODEL invalid_model_type WITH (
+  provider = 'openai', model = 'gpt-profile', model_type = 'reranker'
+);
+----
+Binder Error: CREATE EXTERNAL MODEL model_type must be completion or embedding
 
 statement ok
 CREATE EXTERNAL MODEL ai_test_model WITH (
@@ -1137,6 +1156,65 @@ true	true
 statement ok
 RESET duckdb_ai_completion_model;
 
+statement ok
+CREATE EXTERNAL MODEL limited_completion WITH (
+  provider = 'ollama', model = 'mock-completion', model_type = 'completion',
+  options = '{"max_input_tokens":1}'
+);
+
+statement error
+SELECT ai_completion_request_json('this prompt is too long', profile := 'limited_completion');
+----
+Invalid Input Error: AI completion input has
+
+statement ok
+CREATE EXTERNAL MODEL ollama_embedding_model WITH (
+  provider = 'ollama', model = 'mock-embedding', model_type = 'embedding'
+);
+
+query I
+SELECT max_batch_inputs = 128 FROM ai_models() WHERE name = 'ollama_embedding_model';
+----
+true
+
+statement ok
+CREATE EXTERNAL MODEL ollama_non_embedding_capability WITH (
+  provider = 'ollama', model = 'mock-completion', model_type = 'completion',
+  capabilities = 'nonembedding'
+);
+
+query I
+SELECT max_batch_inputs = 512 FROM ai_models() WHERE name = 'ollama_non_embedding_capability';
+----
+true
+
+statement ok
+CREATE EXTERNAL MODEL invalid_location_model WITH (
+  provider = 'openai', model = 'gpt-profile', location = 'not-a-url'
+);
+
+query I
+SELECT contains(validation_status, 'URL must include a scheme')
+FROM ai_models() WHERE name = 'invalid_location_model';
+----
+true
+
+statement ok
+CREATE SECRET mismatched_model_credential (
+  TYPE duckdb_ai, API_KEY 'test-key', AI_PROVIDER 'azure'
+);
+
+statement ok
+CREATE EXTERNAL MODEL mismatched_credential_model WITH (
+  provider = 'openai', model = 'gpt-profile', credential = 'mismatched_model_credential'
+);
+
+query I
+SELECT validation_status = 'credential_provider_mismatch'
+FROM ai_models() WHERE name = 'mismatched_credential_model';
+----
+true
+
 query II
 SELECT status, action_required FROM ai_provision_endpoint('ai_test_model');
 ----
@@ -1146,6 +1224,16 @@ statement error
 SELECT * FROM ai_provision_endpoint('ai_test_model', dry_run := false);
 ----
 Binder Error: ai_provision_endpoint requires max_hourly_cost_usd > 0 when dry_run is false
+
+statement error
+SELECT * FROM ai_provision_endpoint('ai_test_model', max_hourly_cost_usd := -1);
+----
+Binder Error: ai_provision_endpoint max_hourly_cost_usd must be finite and greater than 0
+
+statement error
+SELECT * FROM ai_endpoint_status('');
+----
+Binder Error: AI control-plane profile or operation id must not be empty
 
 query I
 SELECT error IS NOT NULL


### PR DESCRIPTION
AI SQL execution needs predictable batching, bounded memory, trustworthy diagnostics, and explicit failures under provider limits. This change hardens those paths while preserving the existing SQL surface and documenting the resulting runtime behavior.

### Codex description

- enforce provider concurrency, encoded request limits, cache bounds, and aggregate convergence
- correct embedding usage accounting, recursive split behavior, and similarity credential handling
- validate classification, external-model, control-plane, and document-parser results with deterministic coverage