### PR TITLE
Fix Databricks and llama.cpp provider drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 - Used brace initialization for the provider executor's worker lock so MSVC
   does not parse the declaration as a function and fail Windows builds.
+- Replaced Databricks' retired Llama 4 Maverick default with its documented
+  OpenAI GPT OSS 120B replacement endpoint.
+- Emitted llama.cpp's direct JSON Schema response-format shape instead of the
+  nested OpenAI envelope.
 
 ## 0.4.8 - 2026-07-14
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1146,7 +1146,7 @@ Supported provider names and aliases are:
 | `cloudflare` | `workers_ai`, `cloudflare_workers_ai`, `cloudflare_ai` | Yes | Yes | `@cf/zai-org/glm-4.7-flash` |
 | `cohere` | `cohere_ai` | Yes | Yes | `command-a-plus-05-2026` |
 | `dashscope` | `qwen`, `alibaba`, `alibaba_model_studio`, `model_studio` | Yes | Yes | `qwen-plus` |
-| `databricks` | `mosaic`, `mosaic_ai`, `databricks_ai` | Yes | No | `databricks-llama-4-maverick` |
+| `databricks` | `mosaic`, `mosaic_ai`, `databricks_ai` | Yes | No | `databricks-gpt-oss-120b` |
 | `deepinfra` | `deepinfra_ai` | Yes | Yes | `meta-llama/Meta-Llama-3.1-8B-Instruct` |
 | `deepseek` | none | Yes | No | `deepseek-v4-flash` |
 | `fireworks` | `fireworks_ai` | Yes | Yes | `accounts/fireworks/models/llama-v3p1-8b-instruct` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -57,7 +57,7 @@ LIMIT 1;
 | `zai` / `zhipu` | OpenAI-compatible chat and embeddings | `glm-4.7-flash`; embeddings use `embedding-3` | `ZAI_API_KEY` | Defaults to `https://api.z.ai/api/paas/v4`. |
 | `deepseek` | OpenAI-compatible chat | `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | Defaults to `https://api.deepseek.com`. |
 | `openrouter` | OpenAI-compatible chat and embeddings | `openai/gpt-4o-mini`; embeddings use `openai/text-embedding-3-small` | `OPENROUTER_API_KEY` | Defaults to `https://openrouter.ai/api/v1`. |
-| `databricks` | OpenAI-compatible chat | `databricks-llama-4-maverick` | `DATABRICKS_TOKEN` | Derives `/serving-endpoints` from `DATABRICKS_HOST`, or accepts full Model Serving, AI Gateway, or chat-completions URLs. |
+| `databricks` | OpenAI-compatible chat | `databricks-gpt-oss-120b` | `DATABRICKS_TOKEN` | Derives `/serving-endpoints` from `DATABRICKS_HOST`, or accepts full Model Serving, AI Gateway, or chat-completions URLs. |
 | `snowflake` | OpenAI-compatible chat | `claude-sonnet-4-5` | `SNOWFLAKE_PAT` or `SNOWFLAKE_TOKEN` | Derives `/api/v2/cortex/v1` from Snowflake account URL, host, or account id. |
 | `perplexity` | OpenAI-compatible chat | `sonar` | `PERPLEXITY_API_KEY` | Defaults to `https://api.perplexity.ai`. |
 | `poe` | OpenAI-compatible chat | `GPT-5.4` | `POE_API_KEY` | Defaults to `https://api.poe.com/v1`. |
@@ -1098,7 +1098,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET databricks_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'databricks',
-    MODEL 'databricks-llama-4-maverick'
+    MODEL 'databricks-gpt-oss-120b'
 );
 
 SELECT ai_complete(
@@ -1303,6 +1303,9 @@ answers with its loaded model, so no model configuration is needed either.
 Set `LLAMACPP_BASE_URL` for a non-default host or port, and `LLAMACPP_API_KEY`
 when the server runs with `--api-key`. Embedding calls require starting
 `llama-server` with `--embeddings`.
+
+`response_schema := ...` uses llama.cpp's direct `response_format.schema`
+request shape so `llama-server` can enforce the supplied JSON Schema.
 
 For throughput, start `llama-server` with parallel slots (for example
 `--parallel 4`) and match `max_concurrent_requests` so DuckDB keeps every slot

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -2813,7 +2813,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	     "COHERE_API_KEY", true},
 	    {"dashscope", "openai_chat", "qwen-plus", "text-embedding-v4",
 	     "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "DASHSCOPE_API_KEY", true},
-	    {"databricks", "openai_chat", "databricks-llama-4-maverick", "", "", "DATABRICKS_TOKEN", true},
+	    {"databricks", "openai_chat", "databricks-gpt-oss-120b", "", "", "DATABRICKS_TOKEN", true},
 	    {"deepinfra", "openai_chat", "meta-llama/Meta-Llama-3.1-8B-Instruct", "BAAI/bge-large-en-v1.5",
 	     "https://api.deepinfra.com/v1/openai", "DEEPINFRA_API_KEY", true},
 	    {"deepseek", "openai_chat", "deepseek-v4-flash", "", "https://api.deepseek.com", "DEEPSEEK_API_KEY", true},
@@ -3571,6 +3571,22 @@ std::string CohereResponseFormatJson(const CompletionOptions &options) {
 	return "\"response_format\":{\"type\":\"json_object\"}";
 }
 
+std::string LlamaCppResponseFormatJson(const CompletionOptions &options) {
+	ValidateResponseSchema(options);
+	if (!options.response_schema.empty()) {
+		return "\"response_format\":{\"type\":\"json_schema\",\"schema\":" + options.response_schema + "}";
+	}
+	auto format = NormalizeResponseFormat(options);
+	if (format.empty() || format == "text") {
+		return "";
+	}
+	if (format == "json_schema") {
+		throw InvalidInputException(
+		    "AI option \"response_schema\" must be provided when response_format is json_schema");
+	}
+	return "\"response_format\":{\"type\":\"json_object\"}";
+}
+
 std::string OllamaFormatJson(const CompletionOptions &options) {
 	ValidateResponseSchema(options);
 	if (!options.response_schema.empty()) {
@@ -3658,8 +3674,14 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 			payload += ",\"max_tokens\":" + std::to_string(options.max_tokens);
 		}
 	}
-	auto response_format =
-	    config.provider == "cohere" ? CohereResponseFormatJson(options) : OpenAIResponseFormatJson(options);
+	std::string response_format;
+	if (config.provider == "cohere") {
+		response_format = CohereResponseFormatJson(options);
+	} else if (config.provider == "llamacpp") {
+		response_format = LlamaCppResponseFormatJson(options);
+	} else {
+		response_format = OpenAIResponseFormatJson(options);
+	}
 	if (!response_format.empty()) {
 		payload += "," + response_format;
 	}

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -350,7 +350,7 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             API_KEY 'test-key',
             AI_PROVIDER 'databricks',
             BASE_URL '{base_url}',
-            MODEL 'databricks-llama-4-maverick'
+            MODEL 'databricks-gpt-oss-120b'
         );
         CREATE OR REPLACE SECRET smoke_snowflake_ai (
             TYPE duckdb_ai,
@@ -478,7 +478,7 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             'hello databricks',
             secret := 'smoke_databricks_ai',
             provider := 'databricks',
-            model := 'databricks-llama-4-maverick'
+            model := 'databricks-gpt-oss-120b'
         ) AS databricks_completion;
         SELECT ai_complete(
             'hello snowflake',
@@ -1177,7 +1177,7 @@ def assert_smoke_result(output: str):
         "privacy_filter",
         "databricks",
         "snowflake",
-        "databricks-llama-4-maverick",
+        "databricks-gpt-oss-120b",
         "claude-sonnet-4-5",
         "email [PRIVATE_EMAIL] token [SECRET]",
         "billing, overdue",
@@ -1362,7 +1362,7 @@ def assert_smoke_result(output: str):
     if builtin_price_request["messages"][-1]["content"] != "builtin pricing smoke":
         raise AssertionError(f"unexpected builtin pricing prompt: {builtin_price_request}")
     databricks_request = MockProviderHandler.completion_requests[29]
-    if databricks_request.get("model") != "databricks-llama-4-maverick":
+    if databricks_request.get("model") != "databricks-gpt-oss-120b":
         raise AssertionError(f"unexpected Databricks model: {databricks_request}")
     if databricks_request["messages"][-1]["content"] != "hello databricks":
         raise AssertionError(f"unexpected Databricks prompt: {databricks_request}")
@@ -1547,7 +1547,7 @@ def assert_smoke_result(output: str):
     if builtin_estimated_cost is None or abs(builtin_estimated_cost - 0.00001875) > 0.000000001:
         raise AssertionError(f"unexpected builtin pricing cost: {builtin_price_log}")
     databricks_log = next(
-        (request for request in completion_logs if request.get("model") == "databricks-llama-4-maverick"), None
+        (request for request in completion_logs if request.get("model") == "databricks-gpt-oss-120b"), None
     )
     if databricks_log is None or databricks_log.get("provider") != "databricks":
         raise AssertionError(f"missing Databricks completion log: {completion_logs}")

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -415,6 +415,11 @@ SELECT contains(request, '"response_format":{"type":"json_object","schema":{"typ
 true
 
 query I
+SELECT contains(request, '"response_format":{"type":"json_schema","schema":{"type":"object"') AND NOT contains(request, '"json_schema":') AND NOT contains(request, '"strict":') FROM (SELECT ai_completion_request_json('extract', provider := 'llamacpp', response_schema := '{"type":"object","properties":{"summary":{"type":"string"}}}') AS request);
+----
+true
+
+query I
 SELECT contains(ai_completion_request_json('json please', 'llama3', 'ollama', response_format := 'json_object'), '"format":"json"');
 ----
 true
@@ -427,7 +432,7 @@ SELECT ai_completion_request_json('redact email alice@example.com', provider := 
 query I
 SELECT ai_completion_request_json('hello databricks', provider := 'databricks');
 ----
-{"model":"databricks-llama-4-maverick","messages":[{"role":"user","content":"hello databricks"}],"temperature":0.1}
+{"model":"databricks-gpt-oss-120b","messages":[{"role":"user","content":"hello databricks"}],"temperature":0.1}
 
 query I
 SELECT ai_completion_request_json('hello snowflake', provider := 'snowflake');


### PR DESCRIPTION
## Summary

- replace the retired Databricks Llama 4 Maverick default with the documented `databricks-gpt-oss-120b` replacement endpoint
- emit llama.cpp JSON Schema requests through its direct `response_format.schema` shape instead of the nested OpenAI envelope
- update deterministic, mock-provider, and public documentation coverage

## Why

The built-in Databricks default reached end of support, so default calls could target an unavailable endpoint. llama.cpp documents a provider-specific JSON Schema envelope, while the extension previously sent the OpenAI nested envelope and could not reliably enforce schemas through `llama-server`.

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release` (reports extension 0.4.9)
- `GEN=ninja make test` (340 assertions)
- `python3 test/smoke/mock_provider_smoke.py`
- request-preview PoCs for the Databricks default and llama.cpp JSON Schema payload
- real local Ollama completion with Gemma returning `maintenance-ok`
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)
- `git diff --check`

## Release

This PR completes patch release 0.4.9 together with the already-merged MSVC portability fix. After merge, the full Linux, macOS, Windows, and WASM distribution workflow will be run and verified. No DuckDB community publication PR is included.