### PR TITLE
Complete the v0.4.9 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 - Used brace initialization for the provider executor's worker lock so MSVC
   does not parse the declaration as a function and fail Windows builds.
+- Hardened AI SQL execution with bounded caches and concurrency, encoded
+  request-limit enforcement, aggregate convergence checks, accurate recursive
+  embedding-split accounting, and stricter model, classification, and result
+  validation.
 - Replaced Databricks' retired Llama 4 Maverick default with its documented
   OpenAI GPT OSS 120B replacement endpoint.
 - Emitted llama.cpp's direct JSON Schema response-format shape instead of the


### PR DESCRIPTION
## Summary

- add the merged AI SQL runtime hardening from PR #45 to the 0.4.9 changelog
- make the changelog cover the complete release range from v0.4.8

## Why

The runtime hardening merged after v0.4.8 but was omitted from the initial 0.4.9 changelog section. This release-only documentation patch keeps the published changelog complete before the tag is created.

## Validation

- reviewed `git log v0.4.8..main` against PRs #44, #45, and #46
- `git diff --check`

## Release

This PR does not change runtime code or the version number. After merge, the final main commit will be tagged as v0.4.9 and the full distribution workflow will be verified. No DuckDB community publication PR is included.