### PR TITLE
Fix provider executor queue lookup on MSVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.10 - 2026-07-14
+
+### Fixed
+
+- Qualified provider executor queue accesses so MSVC resolves the member
+  instead of DuckDB's `queue` template inside the worker lambda.
+
 ## 0.4.9 - 2026-07-14
 
 ### Fixed

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.9
+    EXTENSION_VERSION 0.4.10
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -1741,12 +1741,12 @@ struct ProviderExecutorState : public ObjectCacheEntry {
 					std::function<void()> task;
 					{
 						std::unique_lock<std::mutex> lock {mutex};
-						cv.wait(lock, [&]() { return shutdown || !queue.empty(); });
-						if (shutdown && queue.empty()) {
+						cv.wait(lock, [&]() { return shutdown || !this->queue.empty(); });
+						if (shutdown && this->queue.empty()) {
 							return;
 						}
-						task = std::move(queue.front());
-						queue.pop_front();
+						task = std::move(this->queue.front());
+						this->queue.pop_front();
 					}
 					task();
 				}


### PR DESCRIPTION
## What changed
- qualify provider executor queue accesses through `this` inside the worker lambda
- bump the extension patch version to 0.4.10 and document the fix

## Why
The v0.4.9 full distribution run exposed an MSVC name-lookup failure: the compiler resolved the later-declared member as DuckDB's `queue` template at `queue.pop_front()`. Explicit member qualification removes the ambiguity without changing runtime behavior.

## Validation
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release`
- `GEN=ninja make test` (340 assertions)
- `python3 test/smoke/mock_provider_smoke.py`
- `git diff --check`

## Release
This is a patch release fix for the failed v0.4.9 Windows distribution. v0.4.10 will supersede v0.4.9 after the full distribution matrix passes. No DuckDB community publication PR is being opened.