### PR TITLE
fix(schema): filter tables before sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.12 - 2026-07-17
+
+### Fixed
+
+- Applied schema include/exclude filters before collecting table metadata and
+  sample rows, avoiding unnecessary scans of tables omitted from AI prompts.
+
 ## 0.4.11 - 2026-07-15
 
 ### Fixed

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.11
+    EXTENSION_VERSION 0.4.12
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_extension.cpp
+++ b/src/duckdb_ai_extension.cpp
@@ -4220,16 +4220,17 @@ std::string BuildPromptSchemaContext(ClientContext &context, const PromptSchemaO
 			info.catalog = table.catalog.GetName();
 			info.schema = table.schema.name;
 			info.table = table.name;
+			auto included = include_specs.empty() || MatchesAnyTableSpec(info, include_specs);
+			auto excluded = MatchesAnyTableSpec(info, exclude_specs);
+			if (!included || excluded) {
+				return;
+			}
 			info.comment = ValueToOptionalString(table.comment);
 			info.sql = TableCreateSql(table);
 			info.estimated_rows = EstimatedRows(context, table);
 			info.columns = ExtractSchemaColumns(table);
 			TryCollectSampleRows(context, table, info, options.sample_rows, allow_actual_samples);
-			auto included = include_specs.empty() || MatchesAnyTableSpec(info, include_specs);
-			auto excluded = MatchesAnyTableSpec(info, exclude_specs);
-			if (included && !excluded) {
-				tables.push_back(std::move(info));
-			}
+			tables.push_back(std::move(info));
 		});
 	}
 


### PR DESCRIPTION
## Summary
- apply schema include/exclude filters before metadata extraction
- avoid sampling rows from tables omitted from AI prompts
- prepare the v0.4.12 patch release

## Validation
- format check
- release build and 351 SQLLogic assertions
- deterministic mock-provider smoke test
- community docs snapshot check
- npm clean install, audit, typecheck, and production build
- large excluded-table PoC reduced peak RSS from about 237 MB to 27 MB