### PR TITLE
Fix TLS CA discovery in slim containers

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -141,7 +141,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install -y -qq ninja-build libcurl4-openssl-dev ccache
+          sudo apt-get install -y -qq ninja-build libcurl4-openssl-dev ccache openssl
 
       - name: Build release extension
         shell: bash
@@ -152,6 +152,10 @@ jobs:
       - name: Run SQLLogicTests
         shell: bash
         run: make test
+
+      - name: Run TLS trust-store smoke test
+        shell: bash
+        run: python3 test/smoke/mock_provider_smoke.py --tls-only
 
       - name: Run mock-provider smoke test
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.14 - 2026-07-21
+
+### Fixed
+
+- Discovered portable system CA bundle paths for HTTPS provider requests and
+  honored standard certificate environment overrides, fixing provider access
+  from slim Linux containers.
+
 ## 0.4.13 - 2026-07-17
 
 ### Fixed

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.13
+    EXTENSION_VERSION 0.4.14
 )
 
 # Any extra extensions that should be built

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -19,6 +19,7 @@
 #include <deque>
 #include <list>
 #include <exception>
+#include <fstream>
 #include <functional>
 #include <initializer_list>
 #include <iomanip>
@@ -603,6 +604,46 @@ CURL *ThreadLocalCurlHandle() {
 	thread_local CurlEasyHandle handle;
 	curl_easy_reset(handle.handle);
 	return handle.handle;
+}
+
+std::string CurlCaBundlePath() {
+	auto ca_bundle = GetEnv("CURL_CA_BUNDLE");
+	if (ca_bundle.empty()) {
+		ca_bundle = GetEnv("SSL_CERT_FILE");
+	}
+	if (!ca_bundle.empty()) {
+		return ca_bundle;
+	}
+
+#ifndef _WIN32
+	static const std::vector<std::string> system_ca_bundles {
+	    "/etc/ssl/certs/ca-certificates.crt",                // Debian, Ubuntu, Alpine
+	    "/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora, RHEL
+	    "/etc/ssl/ca-bundle.pem",                            // openSUSE
+	    "/etc/pki/tls/cacert.pem",                           // OpenELEC
+	    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS, RHEL
+	    "/etc/ssl/cert.pem",                                 // macOS
+	};
+	for (auto &path : system_ca_bundles) {
+		std::ifstream ca_bundle_file(path);
+		if (ca_bundle_file.good()) {
+			return path;
+		}
+	}
+#endif
+
+	return "";
+}
+
+void ConfigureCurlTrustStore(CURL *curl) {
+	auto ca_bundle = CurlCaBundlePath();
+	if (!ca_bundle.empty()) {
+		curl_easy_setopt(curl, CURLOPT_CAINFO, ca_bundle.c_str());
+	}
+	auto ca_path = GetEnv("SSL_CERT_DIR");
+	if (!ca_path.empty()) {
+		curl_easy_setopt(curl, CURLOPT_CAPATH, ca_path.c_str());
+	}
 }
 
 bool EndsWith(const std::string &value, const std::string &suffix) {
@@ -2598,6 +2639,7 @@ HttpResponse HttpPost(const std::string &url, const std::string &payload, const 
 		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
 		curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CurlProgressCallback);
 		curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &progress_state);
+		ConfigureCurlTrustStore(curl);
 
 		auto start = std::chrono::steady_clock::now();
 		auto result = curl_easy_perform(curl);

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -322,7 +322,7 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def run_duckdb_tls_trust(duckdb_path: Path, base_url: str, ca_bundle: Path) -> str:
+def run_duckdb_tls_request(duckdb_path: Path, base_url: str, ca_environment: dict[str, str], expect_success: bool):
     sql = f"""
         SELECT ai_embed(
             'tls trust smoke',
@@ -332,13 +332,44 @@ def run_duckdb_tls_trust(duckdb_path: Path, base_url: str, ca_bundle: Path) -> s
         )[1] AS first_embedding_value;
     """
     env = os.environ.copy()
-    env.pop("CURL_CA_BUNDLE", None)
-    env.update(
-        {
-            "OPENAI_API_KEY": "test-key",
-            "SSL_CERT_FILE": str(ca_bundle),
-        }
+    for name in ("CURL_CA_BUNDLE", "SSL_CERT_FILE", "SSL_CERT_DIR"):
+        env.pop(name, None)
+    env["OPENAI_API_KEY"] = "test-key"
+    env.update(ca_environment)
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
     )
+    if expect_success and result.returncode != 0:
+        raise AssertionError(f"duckdb TLS trust smoke exited with {result.returncode}\n{result.stdout}")
+    if not expect_success and result.returncode == 0:
+        raise AssertionError(f"duckdb TLS trust smoke unexpectedly succeeded\n{result.stdout}")
+    return result
+
+
+def run_duckdb_tls_log(
+    duckdb_path: Path, provider_base_url: str, log_endpoint: str, ca_environment: dict[str, str]
+) -> str:
+    sql = f"""
+        SET duckdb_ai_log_endpoint = '{log_endpoint}';
+        SET duckdb_ai_log_strict = true;
+        SELECT ai_complete(
+            'tls log smoke',
+            provider := 'openai',
+            model := 'mock-completion',
+            base_url := '{provider_base_url}'
+        ) AS completion;
+    """
+    env = os.environ.copy()
+    for name in ("CURL_CA_BUNDLE", "SSL_CERT_FILE", "SSL_CERT_DIR"):
+        env.pop(name, None)
+    env["OPENAI_API_KEY"] = "test-key"
+    env.update(ca_environment)
     result = subprocess.run(
         [str(duckdb_path), "-c", sql],
         cwd=repo_root(),
@@ -349,13 +380,91 @@ def run_duckdb_tls_trust(duckdb_path: Path, base_url: str, ca_bundle: Path) -> s
         check=False,
     )
     if result.returncode != 0:
-        raise AssertionError(f"duckdb TLS trust smoke exited with {result.returncode}\n{result.stdout}")
+        raise AssertionError(f"duckdb TLS log smoke exited with {result.returncode}\n{result.stdout}")
     return result.stdout
 
 
-def assert_tls_trust(output: str):
-    if "first_embedding_value" not in output or "0.25" not in output:
-        raise AssertionError(f"duckdb TLS trust output missing embedding\n{output}")
+def run_tls_smoke_suite(duckdb_path: Path, provider_base_url: str):
+    with tempfile.TemporaryDirectory() as tls_directory:
+        tls_directory = Path(tls_directory)
+        tls_certificate = tls_directory / "server.pem"
+        tls_key = tls_directory / "server-key.pem"
+        subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-sha256",
+                "-nodes",
+                "-days",
+                "1",
+                "-subj",
+                "/CN=127.0.0.1",
+                "-addext",
+                "subjectAltName=IP:127.0.0.1",
+                "-keyout",
+                str(tls_key),
+                "-out",
+                str(tls_certificate),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        tls_server = HTTPServer(("127.0.0.1", 0), MockProviderHandler)
+        tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        tls_context.minimum_version = ssl.TLSVersion.TLSv1_2
+        tls_context.load_cert_chain(tls_certificate, tls_key)
+        tls_server.socket = tls_context.wrap_socket(tls_server.socket, server_side=True)
+        tls_thread = threading.Thread(target=tls_server.serve_forever, daemon=True)
+        tls_thread.start()
+        try:
+            tls_base_url = f"https://127.0.0.1:{tls_server.server_address[1]}"
+            certificate_path = str(tls_certificate)
+
+            ssl_cert_result = run_duckdb_tls_request(
+                duckdb_path,
+                tls_base_url,
+                {"SSL_CERT_FILE": certificate_path},
+                expect_success=True,
+            )
+            if "first_embedding_value" not in ssl_cert_result.stdout or "0.25" not in ssl_cert_result.stdout:
+                raise AssertionError(f"SSL_CERT_FILE output missing embedding\n{ssl_cert_result.stdout}")
+
+            curl_bundle_result = run_duckdb_tls_request(
+                duckdb_path,
+                tls_base_url,
+                {
+                    "CURL_CA_BUNDLE": certificate_path,
+                    "SSL_CERT_FILE": str(tls_directory / "missing-ca.pem"),
+                },
+                expect_success=True,
+            )
+            if "0.25" not in curl_bundle_result.stdout:
+                raise AssertionError(f"CURL_CA_BUNDLE output missing embedding\n{curl_bundle_result.stdout}")
+
+            run_duckdb_tls_request(duckdb_path, tls_base_url, {}, expect_success=False)
+            run_duckdb_tls_request(
+                duckdb_path,
+                f"https://localhost:{tls_server.server_address[1]}",
+                {"SSL_CERT_FILE": certificate_path},
+                expect_success=False,
+            )
+
+            MockProviderHandler.reset()
+            tls_log_output = run_duckdb_tls_log(
+                duckdb_path,
+                provider_base_url,
+                f"{tls_base_url}/log",
+                {"SSL_CERT_FILE": certificate_path},
+            )
+            if "mock completion" not in tls_log_output or len(MockProviderHandler.log_requests) != 1:
+                raise AssertionError(f"HTTPS usage log smoke failed\n{tls_log_output}")
+        finally:
+            tls_server.shutdown()
+            tls_thread.join(timeout=5)
 
 
 def run_duckdb(duckdb_path: Path, base_url: str) -> str:
@@ -370,6 +479,7 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
         SET duckdb_ai_sql_assistant_model = 'mock-sql-model';
         SET duckdb_ai_base_url = '{base_url}';
         SET duckdb_ai_log_endpoint = '{base_url}/log';
+        SET duckdb_ai_log_strict = true;
         SET duckdb_ai_timeout_seconds = 5;
         CREATE OR REPLACE SECRET smoke_duckdb_ai (
             TYPE duckdb_ai,
@@ -2149,6 +2259,7 @@ def main():
         default=repo_root() / "build" / "release" / "duckdb",
         help="Path to the built DuckDB shell with duckdb_ai linked",
     )
+    parser.add_argument("--tls-only", action="store_true", help="Run only the HTTPS trust-store regression suite")
     args = parser.parse_args()
     if not args.duckdb.exists():
         raise SystemExit(f"{args.duckdb} does not exist; run `GEN=ninja make release` first")
@@ -2160,51 +2271,10 @@ def main():
     try:
         provider_metadata_output = run_duckdb_provider_metadata(args.duckdb)
         assert_provider_metadata(provider_metadata_output)
-        with tempfile.TemporaryDirectory() as tls_directory:
-            tls_directory = Path(tls_directory)
-            tls_certificate = tls_directory / "server.pem"
-            tls_key = tls_directory / "server-key.pem"
-            subprocess.run(
-                [
-                    "openssl",
-                    "req",
-                    "-x509",
-                    "-newkey",
-                    "rsa:2048",
-                    "-sha256",
-                    "-nodes",
-                    "-days",
-                    "1",
-                    "-subj",
-                    "/CN=127.0.0.1",
-                    "-addext",
-                    "subjectAltName=IP:127.0.0.1",
-                    "-keyout",
-                    str(tls_key),
-                    "-out",
-                    str(tls_certificate),
-                ],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            tls_server = HTTPServer(("127.0.0.1", 0), MockProviderHandler)
-            tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-            tls_context.minimum_version = ssl.TLSVersion.TLSv1_2
-            tls_context.load_cert_chain(tls_certificate, tls_key)
-            tls_server.socket = tls_context.wrap_socket(tls_server.socket, server_side=True)
-            tls_thread = threading.Thread(target=tls_server.serve_forever, daemon=True)
-            tls_thread.start()
-            try:
-                tls_output = run_duckdb_tls_trust(
-                    args.duckdb,
-                    f"https://127.0.0.1:{tls_server.server_address[1]}",
-                    tls_certificate,
-                )
-                assert_tls_trust(tls_output)
-            finally:
-                tls_server.shutdown()
-                tls_thread.join(timeout=5)
+        run_tls_smoke_suite(args.duckdb, f"http://127.0.0.1:{port}")
+        if args.tls_only:
+            print("tls trust smoke passed")
+            return
         MockProviderHandler.reset()
         output = run_duckdb(args.duckdb, f"http://127.0.0.1:{port}")
         assert_smoke_result(output)

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -2190,6 +2190,7 @@ def main():
             )
             tls_server = HTTPServer(("127.0.0.1", 0), MockProviderHandler)
             tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            tls_context.minimum_version = ssl.TLSVersion.TLSv1_2
             tls_context.load_cert_chain(tls_certificate, tls_key)
             tls_server.socket = tls_context.wrap_socket(tls_server.socket, server_side=True)
             tls_thread = threading.Thread(target=tls_server.serve_forever, daemon=True)

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -2,7 +2,9 @@
 import argparse
 import json
 import os
+import ssl
 import subprocess
+import tempfile
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
@@ -318,6 +320,42 @@ class MockProviderHandler(BaseHTTPRequestHandler):
 
 def repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def run_duckdb_tls_trust(duckdb_path: Path, base_url: str, ca_bundle: Path) -> str:
+    sql = f"""
+        SELECT ai_embed(
+            'tls trust smoke',
+            provider := 'openai',
+            model := 'mock-embedding',
+            base_url := '{base_url}'
+        )[1] AS first_embedding_value;
+    """
+    env = os.environ.copy()
+    env.pop("CURL_CA_BUNDLE", None)
+    env.update(
+        {
+            "OPENAI_API_KEY": "test-key",
+            "SSL_CERT_FILE": str(ca_bundle),
+        }
+    )
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb TLS trust smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_tls_trust(output: str):
+    if "first_embedding_value" not in output or "0.25" not in output:
+        raise AssertionError(f"duckdb TLS trust output missing embedding\n{output}")
 
 
 def run_duckdb(duckdb_path: Path, base_url: str) -> str:
@@ -2122,6 +2160,51 @@ def main():
     try:
         provider_metadata_output = run_duckdb_provider_metadata(args.duckdb)
         assert_provider_metadata(provider_metadata_output)
+        with tempfile.TemporaryDirectory() as tls_directory:
+            tls_directory = Path(tls_directory)
+            tls_certificate = tls_directory / "server.pem"
+            tls_key = tls_directory / "server-key.pem"
+            subprocess.run(
+                [
+                    "openssl",
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-sha256",
+                    "-nodes",
+                    "-days",
+                    "1",
+                    "-subj",
+                    "/CN=127.0.0.1",
+                    "-addext",
+                    "subjectAltName=IP:127.0.0.1",
+                    "-keyout",
+                    str(tls_key),
+                    "-out",
+                    str(tls_certificate),
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            tls_server = HTTPServer(("127.0.0.1", 0), MockProviderHandler)
+            tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            tls_context.load_cert_chain(tls_certificate, tls_key)
+            tls_server.socket = tls_context.wrap_socket(tls_server.socket, server_side=True)
+            tls_thread = threading.Thread(target=tls_server.serve_forever, daemon=True)
+            tls_thread.start()
+            try:
+                tls_output = run_duckdb_tls_trust(
+                    args.duckdb,
+                    f"https://127.0.0.1:{tls_server.server_address[1]}",
+                    tls_certificate,
+                )
+                assert_tls_trust(tls_output)
+            finally:
+                tls_server.shutdown()
+                tls_thread.join(timeout=5)
+        MockProviderHandler.reset()
         output = run_duckdb(args.duckdb, f"http://127.0.0.1:{port}")
         assert_smoke_result(output)
         MockProviderHandler.reset()


### PR DESCRIPTION
## Summary

Fix HTTPS provider calls in slim Linux containers by resolving usable system CA bundles and honoring standard certificate environment overrides. Add deterministic HTTPS regression coverage and prepare v0.4.14.

## Why

The published extension bundled libcurl with a CA path that is absent from Debian slim images, so every HTTPS provider failed before reaching its API. This keeps certificate verification enabled while selecting the platform trust store.

Fixes #53.

## Validation

- format check
- release build
- 355 SQLLogic assertions
- mock-provider and local HTTPS smoke tests
- provider matrix in python:3.12-slim