### PR TITLE
fix(providers): align Bedrock Mantle model id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Fixed
+
+- Corrected the Amazon Bedrock Mantle default model ID for OpenAI-compatible
+  Chat Completions requests.
+- Refreshed the documentation lockfile to resolve the `body-parser` size-limit
+  advisory without changing direct package ranges.
+
 ## 0.4.14 - 2026-07-21
 
 ### Fixed

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1141,7 +1141,7 @@ Supported provider names and aliases are:
 | `openai` | none | Yes | Yes | `gpt-4o-mini` |
 | `azure` | `azure_openai`, `azure-openai` | Yes | Yes | `gpt-4o` |
 | `anthropic` | `claude` | Yes | No | `claude-haiku-4-5` |
-| `bedrock` | `aws_bedrock`, `amazon_bedrock`, `bedrock_mantle` | Yes | No | `openai.gpt-oss-120b-1:0` |
+| `bedrock` | `aws_bedrock`, `amazon_bedrock`, `bedrock_mantle` | Yes | No | `openai.gpt-oss-120b` |
 | `cerebras` | `cerebras_cloud` | Yes | No | `gpt-oss-120b` |
 | `cloudflare` | `workers_ai`, `cloudflare_workers_ai`, `cloudflare_ai` | Yes | Yes | `@cf/zai-org/glm-4.7-flash` |
 | `cohere` | `cohere_ai` | Yes | Yes | `command-a-plus-05-2026` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -37,7 +37,7 @@ LIMIT 1;
 | `openai` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | `OPENAI_API_KEY` | Defaults to `https://api.openai.com/v1`. |
 | `azure` | OpenAI-compatible chat and embeddings | `gpt-4o`; embeddings use `text-embedding-3-small` | `AZURE_OPENAI_API_KEY` | Appends `/openai/v1` to `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, or secret `BASE_URL` when needed. |
 | `anthropic` / `claude` | Anthropic Messages | `claude-haiku-4-5` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | Defaults to `https://api.anthropic.com/v1`. |
-| `bedrock` | OpenAI-compatible chat | `openai.gpt-oss-120b-1:0` | `AWS_BEDROCK_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, or `BEDROCK_API_KEY` | Set `AWS_REGION`, `AWS_BEDROCK_REGION`, `AWS_BEDROCK_BASE_URL`, or secret `BASE_URL`. |
+| `bedrock` | OpenAI-compatible chat | `openai.gpt-oss-120b` | `AWS_BEDROCK_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, or `BEDROCK_API_KEY` | Set `AWS_REGION`, `AWS_BEDROCK_REGION`, `AWS_BEDROCK_BASE_URL`, or secret `BASE_URL`. |
 | `cerebras` | OpenAI-compatible chat | `gpt-oss-120b` | `CEREBRAS_API_KEY` | Defaults to `https://api.cerebras.ai/v1`. |
 | `cloudflare` / `workers_ai` | OpenAI-compatible chat and embeddings | `@cf/zai-org/glm-4.7-flash`; embeddings use `@cf/baai/bge-base-en-v1.5` | `CLOUDFLARE_API_KEY`, `CLOUDFLARE_API_TOKEN`, or `CLOUDFLARE_AUTH_TOKEN` | Derives the endpoint from `CLOUDFLARE_ACCOUNT_ID`, or accepts `CLOUDFLARE_WORKERS_AI_BASE_URL`, `CLOUDFLARE_AI_BASE_URL`, or secret `BASE_URL`. |
 | `cohere` | OpenAI-compatible chat and embeddings | `command-a-plus-05-2026`; embeddings use `embed-v4.0` | `COHERE_API_KEY` | Defaults to `https://api.cohere.ai/compatibility/v1`. |
@@ -1037,7 +1037,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET bedrock_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'bedrock',
-    MODEL 'openai.gpt-oss-120b-1:0'
+    MODEL 'openai.gpt-oss-120b'
 );
 
 SELECT ai_complete(

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -2856,7 +2856,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	    {"azure", "openai_chat", "gpt-4o", "text-embedding-3-small", "", "AZURE_OPENAI_API_KEY", true},
 	    {"anthropic", "anthropic_messages", "claude-haiku-4-5", "", "https://api.anthropic.com/v1", "ANTHROPIC_API_KEY",
 	     true},
-	    {"bedrock", "openai_chat", "openai.gpt-oss-120b-1:0", "", "", "AWS_BEDROCK_API_KEY", true},
+	    {"bedrock", "openai_chat", "openai.gpt-oss-120b", "", "", "AWS_BEDROCK_API_KEY", true},
 	    {"cerebras", "openai_chat", "gpt-oss-120b", "", "https://api.cerebras.ai/v1", "CEREBRAS_API_KEY", true},
 	    {"cloudflare", "openai_chat", "@cf/zai-org/glm-4.7-flash", "@cf/baai/bge-base-en-v1.5", "",
 	     "CLOUDFLARE_API_KEY", true},

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1229,6 +1229,7 @@ def run_duckdb_provider_metadata(duckdb_path: Path) -> str:
         SELECT ai_provider_protocol('sambanova_ai') AS sambanova_protocol;
         SELECT ai_provider_protocol('silicon_flow') AS siliconflow_protocol;
         SELECT ai_provider_protocol('x.ai') AS xai_protocol;
+        SELECT ai_completion_request_json('hello bedrock', provider := 'aws_bedrock') AS bedrock_request;
         SELECT ai_completion_request_json('hello qwen', provider := 'qwen') AS dashscope_request;
         SELECT ai_completion_request_json('hello kimi', provider := 'kimi') AS moonshot_request;
         SELECT ai_completion_request_json('hello ark', provider := 'ark') AS volcengine_request;
@@ -1278,6 +1279,7 @@ def assert_provider_metadata(output: str):
         "siliconflow_protocol",
         "xai_protocol",
         "openai_chat",
+        '"model":"openai.gpt-oss-120b"',
         '"model":"qwen-plus"',
         '"model":"kimi-k2.7-code"',
         '"model":"doubao-seed-2-1-pro-260628"',

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -188,7 +188,7 @@ SELECT contains(ai_embedding_request_json('duck', provider := 'workers_ai'), '"m
 true	true	true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'groq'), '"model":"openai/gpt-oss-20b"') AND contains(ai_completion_request_json('hello', provider := 'github'), '"model":"openai/gpt-4o"') AND contains(ai_completion_request_json('hello', provider := 'bedrock'), '"model":"openai.gpt-oss-120b-1:0"') AND contains(ai_completion_request_json('hello', provider := 'vertex'), '"model":"google/gemini-2.5-flash"');
+SELECT contains(ai_completion_request_json('hello', provider := 'groq'), '"model":"openai/gpt-oss-20b"') AND contains(ai_completion_request_json('hello', provider := 'github'), '"model":"openai/gpt-4o"') AND contains(ai_completion_request_json('hello', provider := 'bedrock'), '"model":"openai.gpt-oss-120b"') AND contains(ai_completion_request_json('hello', provider := 'vertex'), '"model":"google/gemini-2.5-flash"');
 ----
 true
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7087,9 +7087,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",


### PR DESCRIPTION
## What changed

- use Amazon Bedrock Mantle's OpenAI-compatible model ID, openai.gpt-oss-120b, as the Bedrock default
- keep the provider catalog, generated-request coverage, smoke metadata, and public docs synchronized
- refresh the docs lockfile from body-parser 1.20.5 to 1.20.6 within the existing dependency range

## Why

The extension derives the Bedrock Mantle /v1 endpoint for OpenAI-compatible Chat Completions. AWS documents openai.gpt-oss-120b for that endpoint; the previous openai.gpt-oss-120b-1:0 value is the Bedrock Runtime model ID and produces an inconsistent endpoint/model pair.

The lockfile refresh resolves the current body-parser size-limit advisory without changing direct package versions.

AWS reference: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html

## Validation

- PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
- GEN=ninja make release
- GEN=ninja make test (355 assertions)
- python3 test/smoke/mock_provider_smoke.py
- real DuckDB request-shape PoC for the derived Bedrock Mantle URL and model
- website npm ci, npm run typecheck, npm run build, and npm audit --omit=dev
- scripts/preview_community_docs.sh --check
- git diff --check

## Release

Release intentionally skipped; this PR leaves the fix in Unreleased. No DuckDB community publication PR was opened.
