### PR TITLE
Fix StepFun defaults and refresh docs dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 - Corrected the Amazon Bedrock Mantle default model ID for OpenAI-compatible
   Chat Completions requests.
+- Restored StepFun's direct API default to the documented `step-3.5-flash`
+  model and canonical `https://api.stepfun.com/v1` endpoint.
 - Refreshed the documentation lockfile to resolve the `body-parser` size-limit
   advisory without changing direct package ranges.
+- Updated the documentation lockfile to React 19.2.8 and patched `fast-uri`
+  3.1.4, resolving its URI validation denial-of-service advisory.
 
 ## 0.4.14 - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ End-to-end setup examples for each provider are in
 | `sambanova` | SambaNova Cloud hosted open-weight models | `https://api.sambanova.ai/v1`; `SAMBANOVA_API_KEY` |
 | `siliconflow` | SiliconFlow hosted open-weight models | `https://api.siliconflow.com/v1`; `SILICONFLOW_API_KEY` |
 | `snowflake` | Snowflake Cortex REST Chat Completions API | Set `BASE_URL`, `SNOWFLAKE_ACCOUNT_URL`, or `SNOWFLAKE_ACCOUNT`; `SNOWFLAKE_PAT` |
-| `stepfun` / `step` | StepFun OpenAI-compatible models | `https://api.stepfun.ai/v1`; `STEPFUN_API_KEY` or `STEP_API_KEY` |
+| `stepfun` / `step` | StepFun OpenAI-compatible models | `https://api.stepfun.com/v1`; `STEPFUN_API_KEY` or `STEP_API_KEY` |
 | `together` | Together AI hosted open-weight chat and embedding models | `https://api.together.xyz/v1`; `TOGETHER_API_KEY` |
 | `vercel` / `vercel_ai_gateway` | Vercel AI Gateway multi-provider routing | `https://ai-gateway.vercel.sh/v1`; `AI_GATEWAY_API_KEY` |
 | `vertex` / `google_vertex` | Google Vertex AI OpenAI-compatible endpoints | Set `BASE_URL` or `GOOGLE_CLOUD_PROJECT`; `VERTEX_AI_ACCESS_TOKEN` or `GOOGLE_CLOUD_ACCESS_TOKEN` |

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1167,7 +1167,7 @@ Supported provider names and aliases are:
 | `sambanova` | `sambanova_ai`, `samba_nova`, `sambacloud` | Yes | No | `Meta-Llama-3.3-70B-Instruct` |
 | `siliconflow` | `silicon_flow` | Yes | No | `Qwen/Qwen2.5-72B-Instruct` |
 | `snowflake` | none | Yes | No | `claude-sonnet-4-5` |
-| `stepfun` | `step`, `step_fun` | Yes | No | `step-3.7-flash` |
+| `stepfun` | `step`, `step_fun` | Yes | No | `step-3.5-flash` |
 | `together` | `together_ai` | Yes | Yes | `meta-llama/Llama-3.3-70B-Instruct-Turbo` |
 | `vercel` | `vercel_ai_gateway`, `vercel_gateway`, `ai_gateway` | Yes | Yes | `openai/gpt-4o-mini` |
 | `vertex` | `google_vertex`, `vertex_ai`, `gcp_vertex` | Yes | No | `google/gemini-2.5-flash` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -65,7 +65,7 @@ LIMIT 1;
 | `sambanova` | OpenAI-compatible chat | `Meta-Llama-3.3-70B-Instruct` | `SAMBANOVA_API_KEY` | Defaults to `https://api.sambanova.ai/v1`. |
 | `siliconflow` | OpenAI-compatible chat | `Qwen/Qwen2.5-72B-Instruct` | `SILICONFLOW_API_KEY` | Defaults to `https://api.siliconflow.com/v1`. |
 | `together` | OpenAI-compatible chat and embeddings | `meta-llama/Llama-3.3-70B-Instruct-Turbo`; embeddings use `BAAI/bge-base-en-v1.5` | `TOGETHER_API_KEY` | Defaults to `https://api.together.xyz/v1`. |
-| `stepfun` / `step` | OpenAI-compatible chat | `step-3.7-flash` | `STEPFUN_API_KEY` or `STEP_API_KEY` | Defaults to `https://api.stepfun.ai/v1`. |
+| `stepfun` / `step` | OpenAI-compatible chat | `step-3.5-flash` | `STEPFUN_API_KEY` or `STEP_API_KEY` | Defaults to `https://api.stepfun.com/v1`. |
 | `vercel` / `vercel_ai_gateway` | OpenAI-compatible chat and embeddings | `openai/gpt-4o-mini`; embeddings use `openai/text-embedding-3-small` | `AI_GATEWAY_API_KEY`, `VERCEL_AI_GATEWAY_API_KEY`, or `VERCEL_OIDC_TOKEN` | Defaults to `https://ai-gateway.vercel.sh/v1`. |
 | `vertex` / `google_vertex` | OpenAI-compatible chat | `google/gemini-2.5-flash` | `VERTEX_AI_ACCESS_TOKEN`, `GOOGLE_CLOUD_ACCESS_TOKEN`, or `VERTEX_API_KEY` | Derives the endpoint from `GOOGLE_CLOUD_PROJECT`, or accepts `VERTEX_AI_BASE_URL`, `GOOGLE_VERTEX_BASE_URL`, or secret `BASE_URL`. |
 | `volcengine` / `doubao` | OpenAI-compatible chat | `doubao-seed-2-1-pro-260628` | `VOLCENGINE_API_KEY`, `ARK_API_KEY`, or `DOUBAO_API_KEY` | Defaults to `https://ark.cn-beijing.volces.com/api/v3`. |
@@ -806,7 +806,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET stepfun_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'step',
-    MODEL 'step-3.7-flash'
+    MODEL 'step-3.5-flash'
 );
 
 SELECT ai_complete(

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -2901,7 +2901,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	    {"siliconflow", "openai_chat", "Qwen/Qwen2.5-72B-Instruct", "", "https://api.siliconflow.com/v1",
 	     "SILICONFLOW_API_KEY", true},
 	    {"snowflake", "openai_chat", "claude-sonnet-4-5", "", "", "SNOWFLAKE_PAT", true},
-	    {"stepfun", "openai_chat", "step-3.7-flash", "", "https://api.stepfun.ai/v1", "STEPFUN_API_KEY", true},
+	    {"stepfun", "openai_chat", "step-3.5-flash", "", "https://api.stepfun.com/v1", "STEPFUN_API_KEY", true},
 	    {"together", "openai_chat", "meta-llama/Llama-3.3-70B-Instruct-Turbo", "BAAI/bge-base-en-v1.5",
 	     "https://api.together.xyz/v1", "TOGETHER_API_KEY", true},
 	    {"vercel", "openai_chat", "openai/gpt-4o-mini", "openai/text-embedding-3-small",

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1233,6 +1233,7 @@ def run_duckdb_provider_metadata(duckdb_path: Path) -> str:
         SELECT ai_completion_request_json('hello qwen', provider := 'qwen') AS dashscope_request;
         SELECT ai_completion_request_json('hello kimi', provider := 'kimi') AS moonshot_request;
         SELECT ai_completion_request_json('hello ark', provider := 'ark') AS volcengine_request;
+        SELECT ai_completion_request_json('hello stepfun', provider := 'step') AS stepfun_request;
         SELECT ai_embedding_request_json('hello cloudflare', provider := 'workers_ai') AS cloudflare_embedding_request;
         SELECT ai_completion_request_json('hello nvidia', provider := 'nvidia_nim') AS nvidia_request;
     """
@@ -1268,7 +1269,7 @@ def assert_provider_metadata(output: str):
         "https://api.moonshot.ai/v1",
         "https://qianfan.baidubce.com/v2",
         "https://tokenhub.tencentmaas.com/v1",
-        "https://api.stepfun.ai/v1",
+        "https://api.stepfun.com/v1",
         "https://ai-gateway.vercel.sh/v1",
         "https://ark.cn-beijing.volces.com/api/v3",
         "github_protocol",
@@ -1283,6 +1284,7 @@ def assert_provider_metadata(output: str):
         '"model":"qwen-plus"',
         '"model":"kimi-k2.7-code"',
         '"model":"doubao-seed-2-1-pro-260628"',
+        '"model":"step-3.5-flash"',
         '"model":"@cf/baai/bge-base-en-v1.5"',
         '"model":"meta/llama-3.3-70b-instruct"',
     ]

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -175,7 +175,7 @@ openai_chat@https://api.moonshot.ai/v1|openai_chat@https://qianfan.baidubce.com/
 query I
 SELECT ai_provider_protocol('step') || '@' || ai_provider_base_url('step') || '|' || ai_provider_protocol('mini_max') || '@' || ai_provider_base_url('mini_max') || '|' || ai_provider_protocol('poe') || '@' || ai_provider_base_url('poe') || '|' || ai_provider_protocol('doubao') || '@' || ai_provider_base_url('doubao');
 ----
-openai_chat@https://api.stepfun.ai/v1|openai_chat@https://api.minimax.io/v1|openai_chat@https://api.poe.com/v1|openai_chat@https://ark.cn-beijing.volces.com/api/v3
+openai_chat@https://api.stepfun.com/v1|openai_chat@https://api.minimax.io/v1|openai_chat@https://api.poe.com/v1|openai_chat@https://ark.cn-beijing.volces.com/api/v3
 
 query IIII
 SELECT contains(ai_embedding_request_json('duck', provider := 'cohere'), '"model":"embed-v4.0"'), contains(ai_embedding_request_json('duck', provider := 'together'), '"model":"BAAI/bge-base-en-v1.5"'), contains(ai_embedding_request_json('duck', provider := 'deepinfra'), '"model":"BAAI/bge-large-en-v1.5"'), contains(ai_embedding_request_json('duck', provider := 'fireworks'), '"model":"nomic-ai/nomic-embed-text-v1.5"');
@@ -203,7 +203,7 @@ SELECT contains(ai_completion_request_json('hello', provider := 'workers_ai'), '
 true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'kimi'), '"model":"kimi-k2.7-code"') AND contains(ai_completion_request_json('hello', provider := 'baidu'), '"model":"ernie-4.5-turbo-128k"') AND contains(ai_completion_request_json('hello', provider := 'hunyuan'), '"model":"hy3"') AND contains(ai_completion_request_json('hello', provider := 'step_fun'), '"model":"step-3.7-flash"') AND contains(ai_completion_request_json('hello', provider := 'minimax'), '"model":"MiniMax-M2.7"') AND contains(ai_completion_request_json('hello', provider := 'poe'), '"model":"GPT-5.4"') AND contains(ai_completion_request_json('hello', provider := 'ark'), '"model":"doubao-seed-2-1-pro-260628"');
+SELECT contains(ai_completion_request_json('hello', provider := 'kimi'), '"model":"kimi-k2.7-code"') AND contains(ai_completion_request_json('hello', provider := 'baidu'), '"model":"ernie-4.5-turbo-128k"') AND contains(ai_completion_request_json('hello', provider := 'hunyuan'), '"model":"hy3"') AND contains(ai_completion_request_json('hello', provider := 'step_fun'), '"model":"step-3.5-flash"') AND contains(ai_completion_request_json('hello', provider := 'minimax'), '"model":"MiniMax-M2.7"') AND contains(ai_completion_request_json('hello', provider := 'poe'), '"model":"GPT-5.4"') AND contains(ai_completion_request_json('hello', provider := 'ark'), '"model":"doubao-seed-2-1-pro-260628"');
 ----
 true
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9428,9 +9428,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -16503,24 +16503,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-fast-compare": {


### PR DESCRIPTION
## Summary

- align StepFun with its documented direct API default (`step-3.5-flash` at `https://api.stepfun.com/v1`)
- cover the StepFun endpoint and request model in SQLLogic and real DuckDB smoke validation
- refresh the documentation lockfile to React 19.2.8 and patched `fast-uri` 3.1.4

## Why

StepFun documents `step-3.5-flash` and the `.com` base URL for its direct OpenAI-compatible API. The previous `step-3.7-flash` default is available through other gateways but is not in the current direct API catalog. The lockfile also resolved `fast-uri` 3.1.3, which is affected by a URI validation denial-of-service advisory.

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release`
- `GEN=ninja make test` (355 assertions)
- `python3 test/smoke/mock_provider_smoke.py`
- built DuckDB PoC for `ai_provider_base_url` and `ai_completion_request_json`
- `npm audit --omit=dev`
- `npm run typecheck`
- `npm run build`

## Release

Release intentionally skipped; these fixes remain in `Unreleased`. No DuckDB community publication PR was opened or updated.
