### PR TITLE
fix(providers): support Anthropic structured outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ### Fixed
 
+- Sent JSON Schema completion requests to Anthropic through the current
+  `output_config.format` structured-output shape instead of rejecting them.
 - Corrected the Amazon Bedrock Mantle default model ID for OpenAI-compatible
   Chat Completions requests.
 - Restored StepFun's direct API default to the documented `step-3.5-flash`

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1083,7 +1083,7 @@ not from direct API key arguments.
 | `on_error` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Error handling mode: `fail`, `null`, or `capture`. `capture` is used by `ai_try_complete`; scalar/table functions that cannot return an error field use `NULL` behavior. |
 | `fail_on_error` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Compatibility alias: `true` maps to `on_error := 'fail'`, `false` maps to `on_error := 'null'`. |
 | `response_format` | `VARCHAR` | Completion and SQL assistant | `text`, `json_object`, or `json_schema`. |
-| `response_schema`, `json_schema` | `VARCHAR` | Completion and SQL assistant | JSON Schema object for structured output hints and validation. |
+| `response_schema`, `json_schema` | `VARCHAR` | Completion and SQL assistant | JSON Schema object for provider-enforced structured output where supported, including OpenAI-compatible APIs, Anthropic, Cohere, llama.cpp, and Ollama, plus local response validation. |
 | `input_token_price_per_million` | `DOUBLE` | Completion, embedding, SQL assistant, aggregate | Manual input-token price for cost estimation. |
 | `output_token_price_per_million` | `DOUBLE` | Completion, SQL assistant, aggregate | Manual output-token price for cost estimation. |
 | `use_builtin_model_prices` | `BOOLEAN` | Completion, embedding, SQL assistant, aggregate | Enables lookup from `ai_model_prices()` when manual prices are not supplied. |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -216,10 +216,22 @@ SELECT ai_summarize(
     secret := 'claude_ai',
     max_tokens := 80
 ) AS summary;
+
+SELECT ai_complete_json(
+    'Extract DuckDB as a database profile.',
+    secret := 'claude_ai',
+    response_schema := '{
+      "type": "object",
+      "properties": {"name": {"type": "string"}},
+      "required": ["name"],
+      "additionalProperties": false
+    }'
+) AS profile;
 ```
 
-Claude is configured for completion calls. Embeddings are not configured for this
-provider.
+For `response_schema := ...`, the extension sends Anthropic's
+`output_config.format` JSON Schema request shape. Claude is configured for
+completion calls; embeddings are not configured for this provider.
 
 ## Gemini
 

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -3662,12 +3662,6 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 	if (config.protocol == "anthropic_messages") {
 		ValidateResponseSchema(options);
 		auto format = NormalizeResponseFormat(options);
-		if (!options.response_schema.empty()) {
-			throw InvalidInputException(
-			    "AI option \"response_schema\" is not supported for provider \"%s\". Use an OpenAI-compatible or "
-			    "Ollama provider for enforced JSON Schema output.",
-			    config.provider);
-		}
 		if (format == "json_schema" && options.response_schema.empty()) {
 			throw InvalidInputException(
 			    "AI option \"response_schema\" must be provided when response_format is json_schema");
@@ -3684,6 +3678,10 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 		}
 		if (options.has_temperature) {
 			payload += ",\"temperature\":" + JsonDouble(options.temperature);
+		}
+		if (!options.response_schema.empty()) {
+			payload +=
+			    ",\"output_config\":{\"format\":{\"type\":\"json_schema\",\"schema\":" + options.response_schema + "}}";
 		}
 		payload += ",\"messages\":[{\"role\":\"user\",\"content\":\"" + JsonEscape(prompt) + "\"}]}";
 		return payload;

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -617,6 +617,12 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             system_prompt := 'be exact',
             max_tokens := 13
         ) AS claude_completion;
+        SELECT ai_completion_request_json(
+            'extract structured claude output',
+            provider := 'anthropic',
+            model := 'claude-haiku-4-5',
+            response_schema := '{{"type":"object","properties":{{"summary":{{"type":"string"}}}},"required":["summary"],"additionalProperties":false}}'
+        ) AS claude_structured_request;
         SELECT ai_complete(
             'builtin pricing smoke',
             model := 'gpt-5.4-mini',
@@ -1313,6 +1319,7 @@ def assert_smoke_result(output: str):
         "mock retry completion",
         "mock ollama completion",
         "mock claude completion",
+        '"output_config":{"format":{"type":"json_schema","schema":{"type":"object"',
         "gpt-5.4-mini",
         "This query returns a single row with 42.",
         "SELECT 42",

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -430,6 +430,11 @@ SELECT contains(request, '"type":"array"') AND contains(request, '"type":"boolea
 true
 
 query I
+SELECT contains(request, '"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties"') AND NOT contains(request, '"response_format"') FROM (SELECT ai_completion_request_json('extract', provider := 'anthropic', model := 'claude-haiku-4-5', response_schema := '{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"],"additionalProperties":false}') AS request);
+----
+true
+
+query I
 SELECT contains(request, '"response_format":{"type":"json_object","schema":{"type":"object"') AND NOT contains(request, '"json_schema"') FROM (SELECT ai_completion_request_json('extract', provider := 'cohere', model := 'command-test', response_schema := '{"type":"object","properties":{"summary":{"type":"string"}}}') AS request);
 ----
 true


### PR DESCRIPTION
## Summary

- send `response_schema` to Anthropic Messages through the current `output_config.format` JSON Schema request shape
- cover the generated payload in SQLLogic and the real DuckDB mock-provider smoke
- document structured Claude completions and the provider-enforced schema contract

## Why

Anthropic structured outputs are now generally available for supported Claude models, while the extension still rejected every Anthropic `response_schema` request.

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release`
- `GEN=ninja make test`
- `python3 test/smoke/mock_provider_smoke.py`
- `npm run typecheck` in `website/`
- `npm run build` in `website/`
- `npm audit --omit=dev` in `website/`

TypeScript 7.0.2 was evaluated but intentionally not updated because it removes the `baseUrl` option still used by the current Docusaurus tsconfig. The locked dependency set was restored and revalidated.

## Release

A release is intentionally not triggered by this maintenance PR; the change remains under Unreleased.