### PR TITLE
fix(providers): preserve model-specific sampling defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ include SQL API changes and patch versions should preserve the SQL API.
   performance, and security patch release.
 - Updated Gemini's completion default and built-in pricing to stable
   `gemini-3.6-flash`, omitting sampling parameters that the model deprecates.
+- Updated Kimi's default completion model to `kimi-k3`.
+- Stopped injecting a generic sampling temperature when callers omit it, so
+  model-specific provider defaults remain valid across Kimi, Fireworks, and
+  other OpenAI-compatible catalogs.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,13 @@ End-to-end setup examples for each provider are in
 | `xai` / `grok` | xAI Grok chat models | `https://api.x.ai/v1`; `XAI_API_KEY` |
 | `zai` | Z.ai / BigModel chat models | `https://api.z.ai/api/paas/v4`; `ZAI_API_KEY` |
 
+Provider model catalogs are dynamic. The `model` option is passed through to the
+selected provider instead of being restricted to the documented default, so
+current text/chat model IDs, Fireworks routers and account deployments, and
+provider embedding IDs can be selected without an extension update. The
+extension does not expose provider-specific image, video, or audio generation
+APIs.
+
 You can configure providers three ways:
 
 ```sql

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1064,7 +1064,7 @@ not from direct API key arguments.
 | `model` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider model name. |
 | `provider` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider name or alias. |
 | `profile`, `secret`, `secret_name` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | DuckDB secret name or profile. |
-| `temperature` | `DOUBLE` | Completion, SQL assistant, aggregate | Sampling temperature between 0 and 2. |
+| `temperature` | `DOUBLE` | Completion, SQL assistant, aggregate | Optional sampling temperature between 0 and 2. When omitted, the provider or model default is used. |
 | `system_prompt` | `VARCHAR` | Completion, SQL assistant, aggregate | Optional system message for providers that support chat-style payloads. |
 | `max_tokens` | `BIGINT` | Completion, SQL assistant, aggregate | Maximum provider output tokens. Must be greater than 0. OpenAI, Cloudflare, MiniMax, Moonshot/Kimi, and Snowflake requests emit the current `max_completion_tokens` API field; other compatible providers retain `max_tokens`. |
 | `base_url` | `VARCHAR` | Completion, embedding, SQL assistant, aggregate | Provider or gateway base URL override. |
@@ -1157,7 +1157,7 @@ Supported provider names and aliases are:
 | `hunyuan` | `tencent`, `tencent_hunyuan` | Yes | No | `hy3` |
 | `minimax` | `mini_max` | Yes | No | `MiniMax-M2.7` |
 | `mistral` | none | Yes | Yes | `mistral-small-latest` |
-| `moonshot` | `kimi`, `moonshot_ai`, `kimi_api` | Yes | No | `kimi-k2.7-code` |
+| `moonshot` | `kimi`, `moonshot_ai`, `kimi_api` | Yes | No | `kimi-k3` |
 | `nebius` | `nebius_token_factory`, `token_factory` | Yes | No | `meta-llama/Meta-Llama-3.1-70B-Instruct` |
 | `nvidia` | `nvidia_nim`, `nim` | Yes | No | `meta/llama-3.3-70b-instruct` |
 | `openrouter` | none | Yes | Yes | `openai/gpt-4o-mini` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -51,7 +51,7 @@ LIMIT 1;
 | `hunyuan` / `tencent_hunyuan` | OpenAI-compatible chat through Tencent TokenHub | `hy3` | `HUNYUAN_API_KEY`, `TOKENHUB_API_KEY`, or `TENCENT_TOKENHUB_API_KEY` | Defaults to `https://tokenhub.tencentmaas.com/v1`; `TOKENHUB_BASE_URL` selects another TokenHub region. |
 | `minimax` | OpenAI-compatible chat | `MiniMax-M2.7` | `MINIMAX_API_KEY` or `MINI_MAX_API_KEY` | Defaults to `https://api.minimax.io/v1`. |
 | `mistral` | OpenAI-compatible chat and embeddings | `mistral-small-latest`; embeddings use `mistral-embed` | `MISTRAL_API_KEY` | Defaults to `https://api.mistral.ai/v1`. |
-| `moonshot` / `kimi` | OpenAI-compatible chat | `kimi-k2.7-code` | `MOONSHOT_API_KEY` or `KIMI_API_KEY` | Defaults to `https://api.moonshot.ai/v1`. |
+| `moonshot` / `kimi` | OpenAI-compatible chat | `kimi-k3` | `MOONSHOT_API_KEY` or `KIMI_API_KEY` | Defaults to `https://api.moonshot.ai/v1`. |
 | `nebius` / `nebius_token_factory` | OpenAI-compatible chat | `meta-llama/Meta-Llama-3.1-70B-Instruct` | `NEBIUS_API_KEY` or `TOKEN_FACTORY_API_KEY` | Defaults to `https://api.tokenfactory.nebius.com/v1`. |
 | `nvidia` / `nvidia_nim` | OpenAI-compatible chat | `meta/llama-3.3-70b-instruct` | `NVIDIA_API_KEY` | Defaults to `https://integrate.api.nvidia.com/v1`. |
 | `zai` / `zhipu` | OpenAI-compatible chat and embeddings | `glm-4.7-flash`; embeddings use `embedding-3` | `ZAI_API_KEY` | Defaults to `https://api.z.ai/api/paas/v4`. |
@@ -471,6 +471,12 @@ SELECT ai_embed(
 )[1] AS first_embedding_value;
 ```
 
+Fireworks model IDs are passed through unchanged. This supports serverless base
+models such as `accounts/fireworks/models/deepseek-v3p1`, fast routers such as
+`accounts/fireworks/routers/kimi-k2p6-turbo`, account deployments, and embedding
+models such as `fireworks/qwen3-embedding-8b`. Use a model ID available to the
+configured Fireworks account.
+
 ## DeepInfra
 
 ```sh
@@ -742,7 +748,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET kimi_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'kimi',
-    MODEL 'kimi-k2.7-code'
+    MODEL 'kimi-k3'
 );
 
 SELECT ai_complete(
@@ -752,7 +758,10 @@ SELECT ai_complete(
 ```
 
 Aliases `moonshot`, `kimi`, `moonshot_ai`, and `kimi_api` resolve to the same
-provider. Embeddings are not configured for this provider.
+provider. The current Kimi chat model IDs are passed through unchanged, including
+`kimi-k3`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`, `kimi-k2.6`, and
+`kimi-k2.5`. Moonshot V1 model IDs are also accepted while they remain available
+to the configured account. Embeddings are not configured for this provider.
 
 ## Baidu Qianfan / ERNIE
 

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -2883,7 +2883,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	    {"minimax", "openai_chat", "MiniMax-M2.7", "", "https://api.minimax.io/v1", "MINIMAX_API_KEY", true},
 	    {"mistral", "openai_chat", "mistral-small-latest", "mistral-embed", "https://api.mistral.ai/v1",
 	     "MISTRAL_API_KEY", true},
-	    {"moonshot", "openai_chat", "kimi-k2.7-code", "", "https://api.moonshot.ai/v1", "MOONSHOT_API_KEY", true},
+	    {"moonshot", "openai_chat", "kimi-k3", "", "https://api.moonshot.ai/v1", "MOONSHOT_API_KEY", true},
 	    {"nebius", "openai_chat", "meta-llama/Meta-Llama-3.1-70B-Instruct", "",
 	     "https://api.tokenfactory.nebius.com/v1", "NEBIUS_API_KEY", true},
 	    {"nvidia", "openai_chat", "meta/llama-3.3-70b-instruct", "", "https://integrate.api.nvidia.com/v1",
@@ -3720,9 +3720,8 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 	}
 	auto payload =
 	    "{\"model\":\"" + escaped_model + "\",\"messages\":" + ChatMessagesJson(prompt, options.system_prompt);
-	if (!GeminiOmitsSamplingParameters(config)) {
-		auto temperature = options.has_temperature ? options.temperature : 0.1;
-		payload += ",\"temperature\":" + JsonDouble(temperature);
+	if (options.has_temperature && !GeminiOmitsSamplingParameters(config)) {
+		payload += ",\"temperature\":" + JsonDouble(options.temperature);
 	}
 	if (options.has_max_tokens) {
 		if (config.provider == "openai" || config.provider == "cloudflare" || config.provider == "minimax" ||

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1238,6 +1238,38 @@ def run_duckdb_provider_metadata(duckdb_path: Path) -> str:
         SELECT ai_completion_request_json('hello bedrock', provider := 'aws_bedrock') AS bedrock_request;
         SELECT ai_completion_request_json('hello qwen', provider := 'qwen') AS dashscope_request;
         SELECT ai_completion_request_json('hello kimi', provider := 'kimi') AS moonshot_request;
+        SELECT ai_completion_request_json(
+            'hello kimi high speed',
+            provider := 'kimi',
+            model := 'kimi-k2.7-code-highspeed'
+        ) AS moonshot_highspeed_request;
+        SELECT ai_completion_request_json(
+            'hello fireworks router',
+            provider := 'fireworks',
+            model := 'accounts/fireworks/routers/kimi-k2p6-turbo'
+        ) AS fireworks_router_request;
+        SELECT CASE
+            WHEN contains(
+                ai_completion_request_json(
+                    'hello fireworks router',
+                    provider := 'fireworks',
+                    model := 'accounts/fireworks/routers/kimi-k2p6-turbo'
+                ),
+                '"temperature"'
+            )
+                THEN 'fireworks_implicit_temperature_present'
+            ELSE 'fireworks_provider_default_temperature'
+        END AS fireworks_temperature_contract;
+        SELECT ai_completion_request_json(
+            'hello fireworks deployment',
+            provider := 'fireworks',
+            model := 'accounts/example/deployments/custom-chat'
+        ) AS fireworks_deployment_request;
+        SELECT ai_embedding_request_json(
+            'hello fireworks embedding',
+            provider := 'fireworks',
+            model := 'fireworks/qwen3-embedding-8b'
+        ) AS fireworks_embedding_request;
         SELECT ai_completion_request_json('hello ark', provider := 'ark') AS volcengine_request;
         SELECT ai_completion_request_json('hello stepfun', provider := 'step') AS stepfun_request;
         SELECT ai_completion_request_json('hello gemini', provider := 'gemini') AS gemini_request;
@@ -1294,7 +1326,12 @@ def assert_provider_metadata(output: str):
         "openai_chat",
         '"model":"openai.gpt-oss-120b"',
         '"model":"qwen-plus"',
-        '"model":"kimi-k2.7-code"',
+        '"model":"kimi-k3"',
+        '"model":"kimi-k2.7-code-highspeed"',
+        '"model":"accounts/fireworks/routers/kimi-k2p6-turbo"',
+        '"model":"accounts/example/deployments/custom-chat"',
+        '"model":"fireworks/qwen3-embedding-8b"',
+        "fireworks_provider_default_temperature",
         '"model":"doubao-seed-2-1-pro-260628"',
         '"model":"step-3.5-flash"',
         '"model":"gemini-3.6-flash"',

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -208,9 +208,19 @@ SELECT contains(ai_completion_request_json('hello', provider := 'workers_ai'), '
 true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'kimi'), '"model":"kimi-k2.7-code"') AND contains(ai_completion_request_json('hello', provider := 'baidu'), '"model":"ernie-4.5-turbo-128k"') AND contains(ai_completion_request_json('hello', provider := 'hunyuan'), '"model":"hy3"') AND contains(ai_completion_request_json('hello', provider := 'step_fun'), '"model":"step-3.5-flash"') AND contains(ai_completion_request_json('hello', provider := 'minimax'), '"model":"MiniMax-M2.7"') AND contains(ai_completion_request_json('hello', provider := 'poe'), '"model":"GPT-5.4"') AND contains(ai_completion_request_json('hello', provider := 'ark'), '"model":"doubao-seed-2-1-pro-260628"');
+SELECT contains(ai_completion_request_json('hello', provider := 'kimi'), '"model":"kimi-k3"') AND contains(ai_completion_request_json('hello', provider := 'baidu'), '"model":"ernie-4.5-turbo-128k"') AND contains(ai_completion_request_json('hello', provider := 'hunyuan'), '"model":"hy3"') AND contains(ai_completion_request_json('hello', provider := 'step_fun'), '"model":"step-3.5-flash"') AND contains(ai_completion_request_json('hello', provider := 'minimax'), '"model":"MiniMax-M2.7"') AND contains(ai_completion_request_json('hello', provider := 'poe'), '"model":"GPT-5.4"') AND contains(ai_completion_request_json('hello', provider := 'ark'), '"model":"doubao-seed-2-1-pro-260628"');
 ----
 true
+
+query I
+SELECT contains(ai_completion_request_json('hello', provider := 'kimi', model := 'kimi-k3'), '"model":"kimi-k3"') AND contains(ai_completion_request_json('hello', provider := 'kimi', model := 'kimi-k2.7-code'), '"model":"kimi-k2.7-code"') AND contains(ai_completion_request_json('hello', provider := 'kimi', model := 'kimi-k2.7-code-highspeed'), '"model":"kimi-k2.7-code-highspeed"') AND contains(ai_completion_request_json('hello', provider := 'kimi', model := 'kimi-k2.6'), '"model":"kimi-k2.6"') AND contains(ai_completion_request_json('hello', provider := 'kimi', model := 'kimi-k2.5'), '"model":"kimi-k2.5"') AND contains(ai_completion_request_json('hello', provider := 'kimi', model := 'moonshot-v1-128k'), '"model":"moonshot-v1-128k"') AND NOT contains(ai_completion_request_json('hello', provider := 'kimi'), '"temperature"');
+----
+true
+
+query IIII
+SELECT contains(ai_completion_request_json('hello', provider := 'fireworks', model := 'accounts/fireworks/models/deepseek-v3p1'), '"model":"accounts/fireworks/models/deepseek-v3p1"'), contains(ai_completion_request_json('hello', provider := 'fireworks', model := 'accounts/fireworks/routers/kimi-k2p6-turbo'), '"model":"accounts/fireworks/routers/kimi-k2p6-turbo"') AND NOT contains(ai_completion_request_json('hello', provider := 'fireworks', model := 'accounts/fireworks/routers/kimi-k2p6-turbo'), '"temperature"'), contains(ai_completion_request_json('hello', provider := 'fireworks', model := 'accounts/example/deployments/custom-chat'), '"model":"accounts/example/deployments/custom-chat"'), contains(ai_embedding_request_json('duck', provider := 'fireworks', model := 'fireworks/qwen3-embedding-8b'), '"model":"fireworks/qwen3-embedding-8b"');
+----
+true	true	true	true
 
 query I
 SELECT contains(ai_completion_request_json('hello', provider := 'x.ai'), '"model":"grok-4.5"');
@@ -368,7 +378,7 @@ SELECT contains(ai_completion_request_json('hello', provider := 'anthropic', sys
 true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'openai', temperature := 0.7, max_tokens := 42), '"temperature":0.7,"max_completion_tokens":42') AND NOT contains(ai_completion_request_json('hello', provider := 'openai', max_tokens := 42), '"max_tokens"');
+SELECT contains(ai_completion_request_json('hello', provider := 'openai', temperature := 0.7, max_tokens := 42), '"temperature":0.7,"max_completion_tokens":42') AND NOT contains(ai_completion_request_json('hello', provider := 'openai', max_tokens := 42), '"max_tokens"') AND NOT contains(ai_completion_request_json('hello', provider := 'openai', max_tokens := 42), '"temperature"');
 ----
 true
 
@@ -467,12 +477,12 @@ SELECT ai_completion_request_json('redact email alice@example.com', provider := 
 query I
 SELECT ai_completion_request_json('hello databricks', provider := 'databricks');
 ----
-{"model":"databricks-gpt-oss-120b","messages":[{"role":"user","content":"hello databricks"}],"temperature":0.1}
+{"model":"databricks-gpt-oss-120b","messages":[{"role":"user","content":"hello databricks"}]}
 
 query I
 SELECT ai_completion_request_json('hello snowflake', provider := 'snowflake');
 ----
-{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello snowflake"}],"temperature":0.1}
+{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello snowflake"}]}
 
 statement ok
 SET duckdb_ai_provider = 'openai';


### PR DESCRIPTION
Kimi and Fireworks expose dynamic model catalogs with model-specific sampling constraints. This change updates Kimi’s default to `kimi-k3`, stops injecting a generic temperature when callers omit it, and documents and tests model-ID pass-through so current provider resources work without extension updates.

### Codex description

- preserve each provider or model’s sampling default unless SQL explicitly supplies `temperature`
- cover current Kimi models plus Fireworks base, router, deployment, and embedding identifiers
- synchronize the provider catalog, public documentation, changelog, SQLLogic tests, and mock-provider smoke coverage