### PR TITLE
release: prepare duckdb_ai 0.4.15

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -171,6 +171,6 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.distribution }}
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       ci_tools_version: v1.5-variegata
       extension_name: ai

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.15 - 2026-07-30
+
 ### Changed
 
 - Updated the local DuckDB and extension CI tooling to the 1.5.5 bugfix,

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.14
+    EXTENSION_VERSION 0.4.15
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
## Summary

- publish the merged provider-contract fixes as duckdb_ai 0.4.15
- build release distribution artifacts against DuckDB v1.5.5, matching the repository pin
- keep an empty Unreleased section for subsequent work

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `GEN=ninja make release`
- `GEN=ninja make test` (367 assertions)
- `python3 test/smoke/mock_provider_smoke.py`
- direct built-binary request JSON and extension-version smoke
- `python3 test/benchmarks/ai_runtime_benchmark.py --duckdb build/release/duckdb --json`
- `npm ci`, `npm run typecheck`, and `npm run build`
- `scripts/preview_community_docs.sh --check`
- actionlint v1.7.12 and `git diff --check`

A patch release is warranted because the merged provider fix removes an invalid implicit sampling value that breaks fixed-temperature model contracts.