### PR TITLE
release: prepare duckdb_ai 0.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.16 - 2026-07-31
+
 ### Fixed
 
 - Marked stable OpenAI GPT-5.6 system-message prefixes with explicit prompt

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.15
+    EXTENSION_VERSION 0.4.16
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
## Summary

- bump the extension version from 0.4.15 to 0.4.16
- cut the accumulated prompt-cache and documentation dependency fixes into the 2026-07-31 changelog section

## Validation

- DuckDB v1.5.5 release build reports extension version 0.4.16
- 370 SQLLogic assertions
- full mock-provider HTTP smoke
- diff checks

## Release plan

After merge, publish the v0.4.16 GitHub release at the merge commit and wait for the tag-pinned distribution workflow to pass.