### PR TITLE
feat(providers): default OpenAI to GPT-5.6 Luna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Changed
+
+- Updated the OpenAI completion default from `gpt-4o-mini` to
+  `gpt-5.6-luna` for stronger quality at a cost-efficient GPT-5.6 tier. Explicit
+  per-call, secret, environment, and session model overrides remain unchanged.
+
 ## 0.4.16 - 2026-07-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ CREATE OR REPLACE SECRET openai_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'openai',
     API_KEY '...',
-    MODEL 'gpt-4o-mini'
+    MODEL 'gpt-5.6-luna'
 );
 
 SELECT ai_complete(
@@ -399,7 +399,7 @@ You can configure providers three ways:
 ```sql
 -- Session defaults.
 SET duckdb_ai_provider = 'openai';
-SET duckdb_ai_model = 'gpt-4o-mini';
+SET duckdb_ai_model = 'gpt-5.6-luna';
 SET duckdb_ai_embedding_model = 'text-embedding-3-small';
 SET duckdb_ai_timeout_seconds = 120;
 
@@ -435,10 +435,10 @@ to different models. These override `duckdb_ai_model`, and per-call `model := ..
 still overrides both:
 
 ```sql
-SET duckdb_ai_completion_model = 'gpt-4o-mini';
-SET duckdb_ai_task_model = 'gpt-4o-mini';
-SET duckdb_ai_aggregate_model = 'gpt-4o-mini';
-SET duckdb_ai_sql_assistant_model = 'gpt-4o';
+SET duckdb_ai_completion_model = 'gpt-5.6-luna';
+SET duckdb_ai_task_model = 'gpt-5.6-luna';
+SET duckdb_ai_aggregate_model = 'gpt-5.6-luna';
+SET duckdb_ai_sql_assistant_model = 'gpt-5.6-luna';
 SET duckdb_ai_embedding_model = 'text-embedding-3-small';
 ```
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1138,7 +1138,7 @@ Supported provider names and aliases are:
 | Provider | Aliases | Completion support | Embedding support | Default completion model |
 | --- | --- | --- | --- | --- |
 | `ollama` | none | Yes | Yes | `llama3.2` |
-| `openai` | none | Yes | Yes | `gpt-4o-mini` |
+| `openai` | none | Yes | Yes | `gpt-5.6-luna` |
 | `azure` | `azure_openai`, `azure-openai` | Yes | Yes | `gpt-4o` |
 | `anthropic` | `claude` | Yes | No | `claude-haiku-4-5` |
 | `bedrock` | `aws_bedrock`, `amazon_bedrock`, `bedrock_mantle` | Yes | No | `openai.gpt-oss-120b` |
@@ -1182,7 +1182,7 @@ Session defaults can be configured with DuckDB settings:
 
 ```sql
 SET duckdb_ai_provider = 'openai';
-SET duckdb_ai_model = 'gpt-4o-mini';
+SET duckdb_ai_model = 'gpt-5.6-luna';
 SET duckdb_ai_embedding_model = 'text-embedding-3-small';
 SET duckdb_ai_base_url = 'https://api.openai.com/v1';
 SET duckdb_ai_timeout_seconds = 120;
@@ -1217,7 +1217,7 @@ CREATE OR REPLACE SECRET openai_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'openai',
     API_KEY '...',
-    MODEL 'gpt-4o-mini'
+    MODEL 'gpt-5.6-luna'
 );
 
 SELECT ai_complete('hello', secret := 'openai_ai');

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -34,7 +34,7 @@ LIMIT 1;
 | Provider | Protocol | Default model | Credentials | Base URL behavior |
 | --- | --- | --- | --- | --- |
 | `ollama` | Ollama chat and embeddings | `llama3.2`; embeddings use `nomic-embed-text` | Optional `OLLAMA_API_KEY` | Defaults to `http://localhost:11434`; `OLLAMA_HOST` overrides it. |
-| `openai` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | `OPENAI_API_KEY` | Defaults to `https://api.openai.com/v1`. |
+| `openai` | OpenAI-compatible chat and embeddings | `gpt-5.6-luna`; embeddings use `text-embedding-3-small` | `OPENAI_API_KEY` | Defaults to `https://api.openai.com/v1`. |
 | `azure` | OpenAI-compatible chat and embeddings | `gpt-4o`; embeddings use `text-embedding-3-small` | `AZURE_OPENAI_API_KEY` | Appends `/openai/v1` to `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, or secret `BASE_URL` when needed. |
 | `anthropic` / `claude` | Anthropic Messages | `claude-haiku-4-5` | `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | Defaults to `https://api.anthropic.com/v1`. |
 | `bedrock` | OpenAI-compatible chat | `openai.gpt-oss-120b` | `AWS_BEDROCK_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, or `BEDROCK_API_KEY` | Set `AWS_REGION`, `AWS_BEDROCK_REGION`, `AWS_BEDROCK_BASE_URL`, or secret `BASE_URL`. |
@@ -126,7 +126,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET openai_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'openai',
-    MODEL 'gpt-4o-mini'
+    MODEL 'gpt-5.6-luna'
 );
 
 SELECT ai_complete(

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -2853,7 +2853,7 @@ std::string ProviderSpecificEnvPrefix(const std::string &provider) {
 const std::vector<ProviderSpec> &ProviderCatalog() {
 	static const std::vector<ProviderSpec> providers {
 	    {"ollama", "ollama_chat", "llama3.2", "nomic-embed-text", "http://localhost:11434", "OLLAMA_API_KEY", false},
-	    {"openai", "openai_chat", "gpt-4o-mini", "text-embedding-3-small", "https://api.openai.com/v1",
+	    {"openai", "openai_chat", "gpt-5.6-luna", "text-embedding-3-small", "https://api.openai.com/v1",
 	     "OPENAI_API_KEY", true},
 	    {"azure", "openai_chat", "gpt-4o", "text-embedding-3-small", "", "AZURE_OPENAI_API_KEY", true},
 	    {"anthropic", "anthropic_messages", "claude-haiku-4-5", "", "https://api.anthropic.com/v1", "ANTHROPIC_API_KEY",

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1089,7 +1089,6 @@ def run_duckdb_openai_prompt_cache(duckdb_path: Path, base_url: str) -> str:
         SELECT ai_complete(
             'changing row prompt',
             provider := 'openai',
-            model := 'gpt-5.6',
             base_url := '{base_url}',
             system_prompt := repeat('stable prefix ', 100),
             prompt_cache := true
@@ -1132,6 +1131,8 @@ def assert_openai_prompt_cache(output: str):
         )
 
     current_request, older_request = MockProviderHandler.completion_requests
+    if current_request.get("model") != "gpt-5.6-luna":
+        raise AssertionError(f"unexpected OpenAI default model: {current_request}")
     current_system_content = current_request["messages"][0]["content"]
     if (
         not isinstance(current_system_content, list)

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -143,6 +143,11 @@ SELECT contains(ai_completion_request_json('hello', provider := 'zai'), '"model"
 true	true	true	true
 
 query I
+SELECT contains(ai_completion_request_json('hello', provider := 'openai'), '"model":"gpt-5.6-luna"');
+----
+true
+
+query I
 SELECT ai_provider_protocol('groq') || '@' || ai_provider_base_url('groq') || '|' || ai_provider_protocol('together') || '@' || ai_provider_base_url('together') || '|' || ai_provider_protocol('fireworks') || '@' || ai_provider_base_url('fireworks') || '|' || ai_provider_protocol('deepinfra') || '@' || ai_provider_base_url('deepinfra');
 ----
 openai_chat@https://api.groq.com/openai/v1|openai_chat@https://api.together.xyz/v1|openai_chat@https://api.fireworks.ai/inference/v1|openai_chat@https://api.deepinfra.com/v1/openai


### PR DESCRIPTION
Use GPT-5.6 Luna as the OpenAI completion fallback so model-omitting functions get the preferred quality-to-price profile while preserving every explicit override.

### Codex description

- change only the OpenAI completion default to `gpt-5.6-luna`
- prove the default through SQLLogic and mock HTTP request coverage
- synchronize the README, provider reference, function reference, and changelog