### PR TITLE
release: prepare duckdb_ai 0.4.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.17 - 2026-08-09
+
 ### Fixed
 
 - Replaced Fireworks AI's non-serverless completion default with the supported

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.16
+    EXTENSION_VERSION 0.4.17
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
## What

- bump the extension version to `0.4.17`
- finalize the 2026-08-09 changelog entry

This patch release includes the Fireworks serverless-default bug fix, the OpenAI GPT-5.6 Luna default update, and patched compatible docs dependencies.

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make tidy-check`
- `GEN=ninja make release`
- `GEN=ninja make test` (374 assertions)
- `python3 test/smoke/mock_provider_smoke.py`
- `python3 test/benchmarks/ai_runtime_benchmark.py`
- `scripts/preview_community_docs.sh --check`
- clean `npm ci`, `npm run typecheck`, and `npm run build`
- local extension reports `0.4.17` and emits the Fireworks `gpt-oss-20b` default payload