### PR TITLE
fix(providers): remove retired GitHub Models support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Fixed
+
+- Updated built-in GPT-5.6 Terra and Luna token prices after OpenAI reduced
+  their API prices.
+
+### Removed
+
+- Removed GitHub Models provider defaults, aliases, credentials, and docs
+  because GitHub fully retired the inference API on July 30, 2026.
+
 ## 0.4.17 - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -362,7 +362,6 @@ End-to-end setup examples for each provider are in
 | `deepseek` | DeepSeek chat models | `https://api.deepseek.com`; `DEEPSEEK_API_KEY` |
 | `fireworks` | Fireworks AI hosted open-weight chat and embedding models | `https://api.fireworks.ai/inference/v1`; `FIREWORKS_API_KEY` |
 | `gemini` / `gcp` / `google` | Gemini through the OpenAI-compatible endpoint | `GEMINI_API_KEY` |
-| `github` / `github_models` | GitHub Models for prototyping and CI workflows | `https://models.github.ai/inference`; `GITHUB_TOKEN` |
 | `groq` | GroqCloud low-latency hosted open-weight models | `https://api.groq.com/openai/v1`; `GROQ_API_KEY` |
 | `huggingface` / `hf` | Hugging Face Inference Providers router | `https://router.huggingface.co/v1`; `HF_TOKEN` |
 | `hunyuan` / `tencent_hunyuan` | Tencent TokenHub Hy3 models | `https://tokenhub.tencentmaas.com/v1`; `HUNYUAN_API_KEY` or `TOKENHUB_API_KEY` |

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -59,7 +59,6 @@ Use provider-specific environment variables for local development:
 | `deepseek` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
 | `fireworks` | `FIREWORKS_API_KEY` | `FIREWORKS_BASE_URL` |
 | `gemini` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-| `github` / `github_models` | `GITHUB_TOKEN`, `GITHUB_MODELS_TOKEN`, or `GITHUB_API_KEY` | `GITHUB_BASE_URL` |
 | `groq` | `GROQ_API_KEY` | `GROQ_BASE_URL` |
 | `huggingface` / `hf` | `HF_TOKEN`, `HUGGINGFACE_API_KEY`, or `HUGGING_FACE_HUB_TOKEN` | `HUGGINGFACE_BASE_URL` |
 | `hunyuan` / `tencent_hunyuan` | `HUNYUAN_API_KEY` or `TENCENT_HUNYUAN_API_KEY` | `HUNYUAN_BASE_URL` or `TENCENT_HUNYUAN_BASE_URL` |

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1151,7 +1151,6 @@ Supported provider names and aliases are:
 | `deepseek` | none | Yes | No | `deepseek-v4-flash` |
 | `fireworks` | `fireworks_ai` | Yes | Yes | `accounts/fireworks/models/gpt-oss-20b` |
 | `gemini` | `gcp`, `google`, `google_gemini` | Yes | Yes | `gemini-3.6-flash` |
-| `github` | `github_models`, `github-models`, `gh_models` | Yes | Yes | `openai/gpt-4o` |
 | `groq` | `groqcloud`, `groq_cloud` | Yes | No | `openai/gpt-oss-20b` |
 | `huggingface` | `hf`, `hugging_face`, `huggingface_hub` | Yes | No | `openai/gpt-oss-120b` |
 | `hunyuan` | `tencent`, `tencent_hunyuan` | Yes | No | `hy3` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -45,7 +45,6 @@ LIMIT 1;
 | `deepinfra` | OpenAI-compatible chat and embeddings | `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`; embeddings use `BAAI/bge-large-en-v1.5` | `DEEPINFRA_API_KEY` | Defaults to `https://api.deepinfra.com/v1/openai`. |
 | `fireworks` | OpenAI-compatible chat and embeddings | `accounts/fireworks/models/gpt-oss-20b`; embeddings use `nomic-ai/nomic-embed-text-v1.5` | `FIREWORKS_API_KEY` | Defaults to `https://api.fireworks.ai/inference/v1`. |
 | `gemini` / `gcp` / `google` | OpenAI-compatible chat and embeddings | `gemini-3.6-flash`; embeddings use `gemini-embedding-2` | `GEMINI_API_KEY` | Defaults to Google's OpenAI-compatible endpoint. |
-| `github` / `github_models` | OpenAI-compatible chat and embeddings | `openai/gpt-4o`; embeddings use `openai/text-embedding-3-small` | `GITHUB_TOKEN`, `GITHUB_MODELS_TOKEN`, or `GITHUB_API_KEY` | Defaults to `https://models.github.ai/inference`. |
 | `groq` | OpenAI-compatible chat | `openai/gpt-oss-20b` | `GROQ_API_KEY` | Defaults to `https://api.groq.com/openai/v1`. |
 | `huggingface` / `hf` | OpenAI-compatible chat | `openai/gpt-oss-120b` | `HF_TOKEN`, `HUGGINGFACE_API_KEY`, or `HUGGING_FACE_HUB_TOKEN` | Defaults to `https://router.huggingface.co/v1`. |
 | `hunyuan` / `tencent_hunyuan` | OpenAI-compatible chat through Tencent TokenHub | `hy3` | `HUNYUAN_API_KEY`, `TOKENHUB_API_KEY`, or `TENCENT_TOKENHUB_API_KEY` | Defaults to `https://tokenhub.tencentmaas.com/v1`; `TOKENHUB_BASE_URL` selects another TokenHub region. |
@@ -944,31 +943,6 @@ SELECT ai_complete(
 Aliases `hf`, `hugging_face`, `huggingface_hub`, and `hf_inference` resolve to
 `huggingface`. Embeddings are not configured by default; use
 `openai_compatible` with an embedding-capable router endpoint if needed.
-
-## GitHub Models
-
-```sh
-export GITHUB_TOKEN='...'
-./build/release/duckdb
-```
-
-```sql
-LOAD ai;
-
-CREATE OR REPLACE SECRET github_models_ai (
-    TYPE duckdb_ai,
-    AI_PROVIDER 'github_models',
-    MODEL 'openai/gpt-4o'
-);
-
-SELECT ai_complete(
-    'Write one concise test-case title for an AI SQL helper.',
-    secret := 'github_models_ai'
-) AS answer;
-```
-
-Aliases `github`, `github_models`, `github-models`, and `gh_models` resolve to
-the same provider.
 
 ## xAI / SpaceXAI
 

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -249,10 +249,6 @@ std::string NormalizeProviderNameInternal(const std::string &provider_input) {
 	if (provider == "fireworks_ai" || provider == "fireworks-ai") {
 		return "fireworks";
 	}
-	if (provider == "github_models" || provider == "github-models" || provider == "github_model" ||
-	    provider == "github-model" || provider == "gh_models" || provider == "gh-models") {
-		return "github";
-	}
 	if (provider == "groqcloud" || provider == "groq_cloud" || provider == "groq-cloud") {
 		return "groq";
 	}
@@ -888,10 +884,10 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	static const std::vector<ModelPrice> prices {
 	    {"openai", "gpt-5.6-sol", "completion", 5.00, 30.00, "https://developers.openai.com/api/docs/pricing",
 	     "standard text token pricing", "2026-07-15"},
-	    {"openai", "gpt-5.6-terra", "completion", 2.50, 15.00, "https://developers.openai.com/api/docs/pricing",
-	     "standard text token pricing", "2026-07-15"},
-	    {"openai", "gpt-5.6-luna", "completion", 1.00, 6.00, "https://developers.openai.com/api/docs/pricing",
-	     "standard text token pricing", "2026-07-15"},
+	    {"openai", "gpt-5.6-terra", "completion", 2.00, 12.00, "https://developers.openai.com/api/docs/pricing",
+	     "standard text token pricing", "2026-07-30"},
+	    {"openai", "gpt-5.6-luna", "completion", 0.20, 1.20, "https://developers.openai.com/api/docs/pricing",
+	     "standard text token pricing", "2026-07-30"},
 	    {"openai", "gpt-5.5", "completion", 5.00, 30.00, "https://developers.openai.com/api/docs/pricing",
 	     "standard text token pricing for <272K context length", "2026-07-07"},
 	    {"openai", "gpt-5.4", "completion", 2.50, 15.00, "https://developers.openai.com/api/docs/pricing",
@@ -2874,8 +2870,6 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	     "https://api.fireworks.ai/inference/v1", "FIREWORKS_API_KEY", true},
 	    {"gemini", "openai_chat", "gemini-3.6-flash", "gemini-embedding-2",
 	     "https://generativelanguage.googleapis.com/v1beta/openai", "GEMINI_API_KEY", true},
-	    {"github", "openai_chat", "openai/gpt-4o", "openai/text-embedding-3-small",
-	     "https://models.github.ai/inference", "GITHUB_TOKEN", true},
 	    {"groq", "openai_chat", "openai/gpt-oss-20b", "", "https://api.groq.com/openai/v1", "GROQ_API_KEY", true},
 	    {"huggingface", "openai_chat", "openai/gpt-oss-120b", "", "https://router.huggingface.co/v1", "HF_TOKEN", true},
 	    {"hunyuan", "openai_chat", "hy3", "", "https://tokenhub.tencentmaas.com/v1", "HUNYUAN_API_KEY", true},
@@ -2934,7 +2928,7 @@ std::string SupportedProvidersList() {
 		}
 		result += ProviderCatalog()[i].provider;
 	}
-	result += ", claude, gcp, google, zhipu, azure_openai, databricks_ai, local, llama.cpp, github_models, "
+	result += ", claude, gcp, google, zhipu, azure_openai, databricks_ai, local, llama.cpp, "
 	          "hugging_face, x.ai, nvidia_nim, aws_bedrock, google_vertex, workers_ai, qwen, alibaba, "
 	          "nebius_token_factory, sambanova_ai, silicon_flow, vercel_ai_gateway, kimi, baidu, ernie, "
 	          "tencent_hunyuan, step, mini_max, doubao, ark";
@@ -3295,12 +3289,6 @@ std::string ResolveApiKey(const ProviderConfig &config) {
 			return vertex_api_key;
 		}
 	}
-	if (config.provider == "github") {
-		auto github_models_token = GetEnv("GITHUB_MODELS_TOKEN");
-		if (!github_models_token.empty()) {
-			return github_models_token;
-		}
-	}
 	if (config.provider == "huggingface") {
 		auto hub_token = GetEnv("HUGGING_FACE_HUB_TOKEN");
 		if (!hub_token.empty()) {
@@ -3449,12 +3437,6 @@ std::string ResolveModel(const ProviderConfig &config, const std::string &model_
 		auto google_vertex_model = GetEnv("GOOGLE_VERTEX_MODEL");
 		if (!google_vertex_model.empty()) {
 			return google_vertex_model;
-		}
-	}
-	if (config.provider == "github") {
-		auto github_models_model = GetEnv("GITHUB_MODELS_MODEL");
-		if (!github_models_model.empty()) {
-			return github_models_model;
 		}
 	}
 	if (config.provider == "huggingface") {

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1305,7 +1305,6 @@ def run_duckdb_provider_metadata(duckdb_path: Path) -> str:
         SELECT ai_provider_base_url('step') AS stepfun_url;
         SELECT ai_provider_base_url('vercel_ai_gateway') AS vercel_url;
         SELECT ai_provider_base_url('doubao') AS volcengine_url;
-        SELECT ai_provider_protocol('github_models') AS github_protocol;
         SELECT ai_provider_protocol('hf') AS huggingface_protocol;
         SELECT ai_provider_protocol('mini_max') AS minimax_protocol;
         SELECT ai_provider_protocol('poe_api') AS poe_protocol;
@@ -1399,7 +1398,6 @@ def assert_provider_metadata(output: str):
         "https://api.stepfun.com/v1",
         "https://ai-gateway.vercel.sh/v1",
         "https://ark.cn-beijing.volces.com/api/v3",
-        "github_protocol",
         "huggingface_protocol",
         "minimax_protocol",
         "poe_protocol",

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -62,10 +62,11 @@ SELECT provider, model, operation, printf('%.2f', input_token_price_per_million)
 ----
 xai	grok-4.5	completion	2.00	6.00
 
-query IIIII
-SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'openai' AND model = 'gpt-5.6-luna';
+query IIIII rowsort
+SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'openai' AND model IN ('gpt-5.6-terra', 'gpt-5.6-luna');
 ----
-openai	gpt-5.6-luna	completion	1.00	6.00
+openai	gpt-5.6-luna	completion	0.20	1.20
+openai	gpt-5.6-terra	completion	2.00	12.00
 
 query IIIII
 SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'anthropic' AND model = 'claude-sonnet-5';
@@ -153,9 +154,9 @@ SELECT ai_provider_protocol('groq') || '@' || ai_provider_base_url('groq') || '|
 openai_chat@https://api.groq.com/openai/v1|openai_chat@https://api.together.xyz/v1|openai_chat@https://api.fireworks.ai/inference/v1|openai_chat@https://api.deepinfra.com/v1/openai
 
 query I
-SELECT ai_provider_protocol('cerebras') || '@' || ai_provider_base_url('cerebras') || '|' || ai_provider_protocol('cohere') || '@' || ai_provider_base_url('cohere') || '|' || ai_provider_protocol('github_models') || '@' || ai_provider_base_url('github_models') || '|' || ai_provider_protocol('hf') || '@' || ai_provider_base_url('hf');
+SELECT ai_provider_protocol('cerebras') || '@' || ai_provider_base_url('cerebras') || '|' || ai_provider_protocol('cohere') || '@' || ai_provider_base_url('cohere') || '|' || ai_provider_protocol('hf') || '@' || ai_provider_base_url('hf');
 ----
-openai_chat@https://api.cerebras.ai/v1|openai_chat@https://api.cohere.ai/compatibility/v1|openai_chat@https://models.github.ai/inference|openai_chat@https://router.huggingface.co/v1
+openai_chat@https://api.cerebras.ai/v1|openai_chat@https://api.cohere.ai/compatibility/v1|openai_chat@https://router.huggingface.co/v1
 
 query I
 SELECT ai_provider_protocol('nvidia_nim') || '@' || ai_provider_base_url('nvidia_nim') || '|' || ai_provider_protocol('perplexity') || '@' || ai_provider_base_url('perplexity') || '|' || ai_provider_protocol('x.ai') || '@' || ai_provider_base_url('x.ai');
@@ -198,7 +199,7 @@ SELECT contains(ai_embedding_request_json('duck', provider := 'workers_ai'), '"m
 true	true	true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'groq'), '"model":"openai/gpt-oss-20b"') AND contains(ai_completion_request_json('hello', provider := 'github'), '"model":"openai/gpt-4o"') AND contains(ai_completion_request_json('hello', provider := 'bedrock'), '"model":"openai.gpt-oss-120b"') AND contains(ai_completion_request_json('hello', provider := 'vertex'), '"model":"google/gemini-2.5-flash"');
+SELECT contains(ai_completion_request_json('hello', provider := 'groq'), '"model":"openai/gpt-oss-20b"') AND contains(ai_completion_request_json('hello', provider := 'bedrock'), '"model":"openai.gpt-oss-120b"') AND contains(ai_completion_request_json('hello', provider := 'vertex'), '"model":"google/gemini-2.5-flash"');
 ----
 true
 
@@ -1027,6 +1028,11 @@ statement error
 SELECT ai_provider_base_url('not-a-provider');
 ----
 Invalid Input Error: Unsupported AI provider "not-a-provider".
+
+statement error
+SELECT ai_provider_base_url('github_models');
+----
+Invalid Input Error: Unsupported AI provider "github_models".
 
 # Deterministic Unicode-aware chunking uses code-point offsets and exclusive ends.
 query IIIII


### PR DESCRIPTION
## Summary

- remove GitHub Models provider defaults, aliases, credential fallbacks, tests, and documentation after GitHub fully retired the inference API on July 30, 2026
- update built-in OpenAI GPT-5.6 Terra pricing to $2 input / $12 output and Luna pricing to $0.20 input / $1.20 output per million tokens
- synchronize the changelog, SQLLogic coverage, mock-provider metadata checks, and public provider documentation

## Why

The GitHub Models provider can no longer serve requests, while the built-in Terra and Luna prices still reflected their launch rates after OpenAI reduced them. Removing the ended integration prevents users from selecting a guaranteed-dead endpoint, and the pricing refresh keeps opt-in cost estimates aligned with the published API rates.

Sources:
- https://docs.github.com/en/github-models
- https://openai.com/index/building-abundant-intelligence/

## Validation

- `GEN=ninja make release`
- `GEN=ninja make test` — 380 assertions
- direct DuckDB pricing and retired-alias PoCs
- changed-file DuckDB formatting check
- `npm ci --offline` — zero vulnerabilities
- `npm run typecheck`
- `npm run build`
- `git diff --check`

The local sandbox prohibited binding the loopback port required by `mock_provider_smoke.py`; hosted CI remains the authoritative full-smoke gate.

## Release

Release intentionally skipped; these maintenance fixes remain in `Unreleased`. No DuckDB community-publication changes are included.