### PR TITLE
release: prepare duckdb_ai 0.4.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.18 - 2026-08-18
+
 ### Fixed
 
 - Corrected the built-in Anthropic prices for Claude Haiku 4.5, Sonnet 4.5,

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.17
+    EXTENSION_VERSION 0.4.18
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
## Summary

Prepare duckdb_ai 0.4.18 from the two maintenance fixes merged since v0.4.17.

## Changes

- Remove the retired GitHub Models integration and update reduced OpenAI GPT-5.6 Terra/Luna prices ([#69](https://github.com/leonardovida/duckdb-ai/pull/69)).
- Correct Anthropic Haiku 4.5, Sonnet 4.5, and Sonnet 5 rates, including the automatic Sonnet 5 post-promotion transition ([#70](https://github.com/leonardovida/duckdb-ai/pull/70)).
- Move the Unreleased entries into the 0.4.18 changelog section and bump the extension version.

## Validation

Both included PRs passed format, clang-tidy, release build, SQLLogic, TLS/mock-provider smoke, and CodeQL checks. This release PR will be merged only after its own hosted CI is green.

No DuckDB community-publication change is included.