### PR TITLE
fix(gemini): default to 3.7 flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Changed
+
+- Updated Gemini's completion default to stable `gemini-3.7-flash` and omitted
+  sampling parameters that Google no longer accepts for this model.
+
+### Fixed
+
+- Applied Google's introductory Gemini 3.7/3.6 Flash prices through December
+  31, 2026, with an automatic rollover to the published standard rate.
+
 ## 0.4.18 - 2026-08-18
 
 ### Fixed

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1150,7 +1150,7 @@ Supported provider names and aliases are:
 | `deepinfra` | `deepinfra_ai` | Yes | Yes | `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo` |
 | `deepseek` | none | Yes | No | `deepseek-v4-flash` |
 | `fireworks` | `fireworks_ai` | Yes | Yes | `accounts/fireworks/models/gpt-oss-20b` |
-| `gemini` | `gcp`, `google`, `google_gemini` | Yes | Yes | `gemini-3.6-flash` |
+| `gemini` | `gcp`, `google`, `google_gemini` | Yes | Yes | `gemini-3.7-flash` |
 | `groq` | `groqcloud`, `groq_cloud` | Yes | No | `openai/gpt-oss-20b` |
 | `huggingface` | `hf`, `hugging_face`, `huggingface_hub` | Yes | No | `openai/gpt-oss-120b` |
 | `hunyuan` | `tencent`, `tencent_hunyuan` | Yes | No | `hy3` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -44,7 +44,7 @@ LIMIT 1;
 | `dashscope` / `qwen` | OpenAI-compatible chat and embeddings | `qwen-plus`; embeddings use `text-embedding-v4` | `DASHSCOPE_API_KEY`, `ALIBABA_API_KEY`, or `QWEN_API_KEY` | Defaults to `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; override with a workspace-specific base URL when needed. |
 | `deepinfra` | OpenAI-compatible chat and embeddings | `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`; embeddings use `BAAI/bge-large-en-v1.5` | `DEEPINFRA_API_KEY` | Defaults to `https://api.deepinfra.com/v1/openai`. |
 | `fireworks` | OpenAI-compatible chat and embeddings | `accounts/fireworks/models/gpt-oss-20b`; embeddings use `nomic-ai/nomic-embed-text-v1.5` | `FIREWORKS_API_KEY` | Defaults to `https://api.fireworks.ai/inference/v1`. |
-| `gemini` / `gcp` / `google` | OpenAI-compatible chat and embeddings | `gemini-3.6-flash`; embeddings use `gemini-embedding-2` | `GEMINI_API_KEY` | Defaults to Google's OpenAI-compatible endpoint. |
+| `gemini` / `gcp` / `google` | OpenAI-compatible chat and embeddings | `gemini-3.7-flash`; embeddings use `gemini-embedding-2` | `GEMINI_API_KEY` | Defaults to Google's OpenAI-compatible endpoint. |
 | `groq` | OpenAI-compatible chat | `openai/gpt-oss-20b` | `GROQ_API_KEY` | Defaults to `https://api.groq.com/openai/v1`. |
 | `huggingface` / `hf` | OpenAI-compatible chat | `openai/gpt-oss-120b` | `HF_TOKEN`, `HUGGINGFACE_API_KEY`, or `HUGGING_FACE_HUB_TOKEN` | Defaults to `https://router.huggingface.co/v1`. |
 | `hunyuan` / `tencent_hunyuan` | OpenAI-compatible chat through Tencent TokenHub | `hy3` | `HUNYUAN_API_KEY`, `TOKENHUB_API_KEY`, or `TENCENT_TOKENHUB_API_KEY` | Defaults to `https://tokenhub.tencentmaas.com/v1`; `TOKENHUB_BASE_URL` selects another TokenHub region. |
@@ -247,7 +247,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET gemini_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'gemini',
-    MODEL 'gemini-3.6-flash'
+    MODEL 'gemini-3.7-flash'
 );
 
 SELECT ai_complete(
@@ -263,8 +263,11 @@ SELECT ai_embed(
 ```
 
 Provider aliases `gcp`, `google`, and `google_gemini` also resolve to Gemini.
-Gemini 3.6 Flash deprecates sampling parameters, so `duckdb_ai` omits
-`temperature` for this model even when the generic SQL option is provided.
+Gemini 3.7 Flash and 3.6 Flash deprecate sampling parameters, so `duckdb_ai`
+omits `temperature` for these models even when the generic SQL option is
+provided. Built-in cost estimates use Google's introductory 3.7/3.6 Flash
+pricing through December 31, 2026 and roll over to the published standard rate
+on January 1, 2027.
 
 ## Mistral
 

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -909,7 +909,9 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	    {"gemini", "gemini-3.5-flash", "completion", 1.50, 9.00, "https://ai.google.dev/gemini-api/docs/pricing",
 	     "standard text token pricing", "2026-07-08"},
 	    {"gemini", "gemini-3.6-flash", "completion", 1.50, 7.50, "https://ai.google.dev/gemini-api/docs/pricing",
-	     "standard text token pricing", "2026-07-24"},
+	     "standard text token pricing starting 2027-01-01", "2026-08-21"},
+	    {"gemini", "gemini-3.7-flash", "completion", 1.50, 7.50, "https://ai.google.dev/gemini-api/docs/pricing",
+	     "standard text token pricing starting 2027-01-01", "2026-08-21"},
 	    {"gemini", "gemini-embedding-2", "embedding", 0.20, -1, "https://ai.google.dev/gemini-api/docs/pricing",
 	     "standard text embedding input tokens only", "2026-07-17"},
 	    {"mistral", "mistral-small-latest", "completion", 0.15, 0.60, "https://mistral.ai/pricing/api/",
@@ -2869,7 +2871,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	    {"deepseek", "openai_chat", "deepseek-v4-flash", "", "https://api.deepseek.com", "DEEPSEEK_API_KEY", true},
 	    {"fireworks", "openai_chat", "accounts/fireworks/models/gpt-oss-20b", "nomic-ai/nomic-embed-text-v1.5",
 	     "https://api.fireworks.ai/inference/v1", "FIREWORKS_API_KEY", true},
-	    {"gemini", "openai_chat", "gemini-3.6-flash", "gemini-embedding-2",
+	    {"gemini", "openai_chat", "gemini-3.7-flash", "gemini-embedding-2",
 	     "https://generativelanguage.googleapis.com/v1beta/openai", "GEMINI_API_KEY", true},
 	    {"groq", "openai_chat", "openai/gpt-oss-20b", "", "https://api.groq.com/openai/v1", "GROQ_API_KEY", true},
 	    {"huggingface", "openai_chat", "openai/gpt-oss-120b", "", "https://router.huggingface.co/v1", "HF_TOKEN", true},
@@ -3632,8 +3634,8 @@ std::string LlamaCppResponseFormatJson(const CompletionOptions &options) {
 }
 
 bool GeminiOmitsSamplingParameters(const ProviderConfig &config) {
-	return config.provider == "gemini" &&
-	       (config.model == "gemini-3.6-flash" || config.model == "gemini-3.5-flash-lite");
+	return config.provider == "gemini" && (config.model == "gemini-3.7-flash" || config.model == "gemini-3.6-flash" ||
+	                                       config.model == "gemini-3.5-flash-lite");
 }
 
 void ValidateProviderResponseFormat(const ProviderConfig &config, const CompletionOptions &options) {
@@ -5267,6 +5269,17 @@ std::vector<ModelPrice> ModelPrices() {
 				price.output_token_price_per_million = 5.00;
 				price.source_note = "introductory text token pricing through 2026-08-31";
 				break;
+			}
+		}
+	}
+	if (CurrentTimestamp().compare(0, 10, "2027-01-01") < 0) {
+		for (auto &price : prices) {
+			if (price.provider == "gemini" &&
+			    (price.model == "gemini-3.6-flash" || price.model == "gemini-3.7-flash") &&
+			    price.operation == "completion") {
+				price.input_token_price_per_million = 0.75;
+				price.output_token_price_per_million = 3.75;
+				price.source_note = "introductory text token pricing through 2026-12-31";
 			}
 		}
 	}

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1418,7 +1418,7 @@ def assert_provider_metadata(output: str):
         "fireworks_provider_default_temperature",
         '"model":"doubao-seed-2-1-pro-260628"',
         '"model":"step-3.5-flash"',
-        '"model":"gemini-3.6-flash"',
+        '"model":"gemini-3.7-flash"',
         "gemini_sampling_parameter_omitted",
         '"model":"@cf/baai/bge-base-en-v1.5"',
         '"model":"meta/llama-3.3-70b-instruct"',

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -42,10 +42,10 @@ SELECT provider, model, operation, printf('%.2f', input_token_price_per_million)
 ----
 gemini	gemini-3.5-flash	completion	1.50	9.00
 
-query IIIII
-SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'gemini' AND model = 'gemini-3.6-flash';
+query I
+SELECT count(*) = 2 AND bool_and((input_token_price_per_million = 0.75 AND output_token_price_per_million = 3.75 AND contains(source_note, 'through 2026-12-31')) OR (input_token_price_per_million = 1.50 AND output_token_price_per_million = 7.50 AND contains(source_note, 'starting 2027-01-01'))) FROM ai_model_prices() WHERE provider = 'gemini' AND model IN ('gemini-3.6-flash', 'gemini-3.7-flash');
 ----
-gemini	gemini-3.6-flash	completion	1.50	7.50
+true
 
 query IIII
 SELECT provider, model, operation, printf('%.2f', input_token_price_per_million) FROM ai_model_prices() WHERE provider = 'gemini' AND model = 'gemini-embedding-2';
@@ -145,7 +145,7 @@ SELECT ai_provider_protocol('gemini') || '@' || ai_provider_base_url('gemini') |
 openai_chat@https://generativelanguage.googleapis.com/v1beta/openai|openai_chat@https://api.mistral.ai/v1|openai_chat@https://api.z.ai/api/paas/v4|openai_chat@https://api.deepseek.com|openai_chat@https://openrouter.ai/api/v1
 
 query IIII
-SELECT contains(ai_completion_request_json('hello', provider := 'zai'), '"model":"glm-4.7-flash"'), contains(ai_completion_request_json('hello', provider := 'deepseek'), '"model":"deepseek-v4-flash"'), contains(ai_completion_request_json('hello', provider := 'gemini'), '"model":"gemini-3.6-flash"'), contains(ai_embedding_request_json('duck', provider := 'gemini'), '"model":"gemini-embedding-2"');
+SELECT contains(ai_completion_request_json('hello', provider := 'zai'), '"model":"glm-4.7-flash"'), contains(ai_completion_request_json('hello', provider := 'deepseek'), '"model":"deepseek-v4-flash"'), contains(ai_completion_request_json('hello', provider := 'gemini'), '"model":"gemini-3.7-flash"'), contains(ai_embedding_request_json('duck', provider := 'gemini'), '"model":"gemini-embedding-2"');
 ----
 true	true	true	true
 


### PR DESCRIPTION
Gemini 3.7 Flash is now the latest stable Flash model, and Google applies introductory pricing to both 3.7 and 3.6 through December 31. This updates the default request contract and keeps built-in cost estimates aligned with the published pricing schedule.

### Codex description

- default Gemini completions to gemini-3.7-flash and omit deprecated sampling parameters
- apply current 0.75 USD input and 3.75 USD output rates with an automatic January 1 rollover
- synchronize provider docs, changelog, SQLLogic coverage, and mock-provider metadata checks
- validated format, release build, 382 SQLLogic assertions, mock smoke, runtime benchmark, docs typecheck/build, and a real DuckDB request/pricing PoC
- intentionally skip a release; the changes remain in Unreleased