### PR TITLE
test(gemini): verify pricing usage logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 - Applied Google's introductory Gemini 3.7/3.6 Flash prices through December
   31, 2026, with an automatic rollover to the published standard rate.
+- Updated the documentation lockfile to NanoID 3.3.18, resolving its
+  zero-length custom-generator denial-of-service advisory.
 
 ## 0.4.18 - 2026-08-18
 

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -625,6 +625,13 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
             max_tokens := 13,
             use_builtin_model_prices := true
         ) AS claude_completion;
+        SELECT ai_complete(
+            'gemini builtin pricing smoke',
+            provider := 'gemini',
+            model := 'gemini-3.7-flash',
+            base_url := '{base_url}',
+            use_builtin_model_prices := true
+        ) AS gemini_completion;
         SELECT ai_completion_request_json(
             'extract structured claude output',
             provider := 'anthropic',
@@ -698,6 +705,7 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
         {
             "OPENAI_API_KEY": "test-key",
             "ANTHROPIC_API_KEY": "anthropic-test-key",
+            "GEMINI_API_KEY": "gemini-test-key",
         }
     )
     result = subprocess.run(
@@ -1485,13 +1493,14 @@ def assert_smoke_result(output: str):
     if missing:
         raise AssertionError(f"duckdb output missing {missing}\n{output}")
 
-    if len(MockProviderHandler.completion_requests) != 34:
-        raise AssertionError(f"expected 34 completion requests, got {len(MockProviderHandler.completion_requests)}")
-    if len(MockProviderHandler.authorization_headers) != 40:
-        raise AssertionError(f"expected 40 auth headers, got {len(MockProviderHandler.authorization_headers)}")
-    for header in MockProviderHandler.authorization_headers:
-        if header != "Bearer test-key":
-            raise AssertionError(f"unexpected authorization header: {header}")
+    if len(MockProviderHandler.completion_requests) != 35:
+        raise AssertionError(f"expected 35 completion requests, got {len(MockProviderHandler.completion_requests)}")
+    if len(MockProviderHandler.authorization_headers) != 41:
+        raise AssertionError(f"expected 41 auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if MockProviderHandler.authorization_headers.count("Bearer test-key") != 40:
+        raise AssertionError(f"unexpected default authorization headers: {MockProviderHandler.authorization_headers}")
+    if MockProviderHandler.authorization_headers.count("Bearer gemini-test-key") != 1:
+        raise AssertionError(f"unexpected Gemini authorization headers: {MockProviderHandler.authorization_headers}")
 
     completion_models = [request["model"] for request in MockProviderHandler.completion_requests]
     if completion_models[0:9] != ["mock-completion-model"] * 9:
@@ -1644,34 +1653,39 @@ def assert_smoke_result(output: str):
     otlp_prompt = MockProviderHandler.completion_requests[27]["messages"][-1]["content"]
     if otlp_prompt != "otlp log smoke":
         raise AssertionError(f"unexpected OTLP completion prompt: {otlp_prompt}")
-    builtin_price_request = MockProviderHandler.completion_requests[28]
+    gemini_price_request = MockProviderHandler.completion_requests[28]
+    if gemini_price_request.get("model") != "gemini-3.7-flash":
+        raise AssertionError(f"unexpected Gemini pricing model: {gemini_price_request}")
+    if gemini_price_request["messages"][-1]["content"] != "gemini builtin pricing smoke":
+        raise AssertionError(f"unexpected Gemini pricing prompt: {gemini_price_request}")
+    builtin_price_request = MockProviderHandler.completion_requests[29]
     if builtin_price_request.get("model") != "gpt-5.4-mini":
         raise AssertionError(f"unexpected builtin pricing model: {builtin_price_request}")
     if builtin_price_request["messages"][-1]["content"] != "builtin pricing smoke":
         raise AssertionError(f"unexpected builtin pricing prompt: {builtin_price_request}")
-    databricks_request = MockProviderHandler.completion_requests[29]
+    databricks_request = MockProviderHandler.completion_requests[30]
     if databricks_request.get("model") != "databricks-gpt-oss-120b":
         raise AssertionError(f"unexpected Databricks model: {databricks_request}")
     if databricks_request["messages"][-1]["content"] != "hello databricks":
         raise AssertionError(f"unexpected Databricks prompt: {databricks_request}")
-    snowflake_request = MockProviderHandler.completion_requests[30]
+    snowflake_request = MockProviderHandler.completion_requests[31]
     if snowflake_request.get("model") != "claude-sonnet-4-5":
         raise AssertionError(f"unexpected Snowflake model: {snowflake_request}")
     if snowflake_request.get("max_completion_tokens") != 19 or "max_tokens" in snowflake_request:
         raise AssertionError(f"unexpected Snowflake token limit: {snowflake_request}")
     if snowflake_request["messages"][-1]["content"] != "hello snowflake":
         raise AssertionError(f"unexpected Snowflake prompt: {snowflake_request}")
-    try_complete_request = MockProviderHandler.completion_requests[31]
+    try_complete_request = MockProviderHandler.completion_requests[32]
     if try_complete_request["messages"][-1]["content"] != "try complete smoke":
         raise AssertionError(f"unexpected try completion prompt: {try_complete_request}")
     if try_complete_request.get("max_completion_tokens") != 5 or "max_tokens" in try_complete_request:
         raise AssertionError(f"unexpected try completion token limit: {try_complete_request}")
-    extract_record_request = MockProviderHandler.completion_requests[32]
+    extract_record_request = MockProviderHandler.completion_requests[33]
     if extract_record_request["messages"][-1]["content"] != "return scalar record JSON object":
         raise AssertionError(f"unexpected extract record prompt: {extract_record_request}")
     if "Return only valid JSON" not in extract_record_request["messages"][0]["content"]:
         raise AssertionError(f"unexpected extract record system prompt: {extract_record_request}")
-    rerank_request = MockProviderHandler.completion_requests[33]
+    rerank_request = MockProviderHandler.completion_requests[34]
     if "Score candidate relevance" not in rerank_request["messages"][0]["content"]:
         raise AssertionError(f"unexpected rerank system prompt: {rerank_request}")
     if (
@@ -1745,25 +1759,25 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"unexpected packed constant similarity inputs: {constant_similarity_inputs}")
 
     log_deadline = time.time() + 5
-    while len(MockProviderHandler.log_requests) < 47 and time.time() < log_deadline:
+    while len(MockProviderHandler.log_requests) < 48 and time.time() < log_deadline:
         time.sleep(0.05)
-    if len(MockProviderHandler.log_requests) != 47:
+    if len(MockProviderHandler.log_requests) != 48:
         event_counts = {}
         for request in MockProviderHandler.log_requests:
             event = "otlp" if "resourceLogs" in request else request.get("event", "unknown")
             event_counts[event] = event_counts.get(event, 0) + 1
-        raise AssertionError(f"expected 47 log requests, got {len(MockProviderHandler.log_requests)}: {event_counts}")
+        raise AssertionError(f"expected 48 log requests, got {len(MockProviderHandler.log_requests)}: {event_counts}")
     completion_logs = [
         request for request in MockProviderHandler.log_requests if request.get("event") == "ai_completion"
     ]
     embedding_logs = [request for request in MockProviderHandler.log_requests if request.get("event") == "ai_embedding"]
     otlp_logs = [request for request in MockProviderHandler.log_requests if "resourceLogs" in request]
-    if len(completion_logs) != 34 or len(embedding_logs) != 12:
+    if len(completion_logs) != 35 or len(embedding_logs) != 12:
         raise AssertionError(f"unexpected log events: {MockProviderHandler.log_requests}")
     if len(otlp_logs) != 1:
         raise AssertionError(f"expected 1 OTLP log request, got {otlp_logs}")
     logged_providers = {request.get("provider") for request in completion_logs}
-    if not {"openai", "ollama", "anthropic", "databricks", "snowflake", "openai_privacy_filter"}.issubset(
+    if not {"openai", "ollama", "anthropic", "gemini", "databricks", "snowflake", "openai_privacy_filter"}.issubset(
         logged_providers
     ):
         raise AssertionError(f"missing provider logs: {completion_logs}")
@@ -1842,6 +1856,14 @@ def assert_smoke_result(output: str):
     anthropic_estimated_cost = anthropic_price_log.get("estimated_cost_usd")
     if anthropic_estimated_cost is None or abs(anthropic_estimated_cost - 0.0000145) > 0.000000001:
         raise AssertionError(f"unexpected Anthropic builtin pricing cost: {anthropic_price_log}")
+    gemini_price_log = next(
+        (request for request in completion_logs if request.get("model") == "gemini-3.7-flash"), None
+    )
+    if gemini_price_log is None:
+        raise AssertionError(f"missing Gemini builtin pricing log: {completion_logs}")
+    gemini_estimated_cost = gemini_price_log.get("estimated_cost_usd")
+    if gemini_estimated_cost is None or abs(gemini_estimated_cost - 0.0000165) > 0.000000001:
+        raise AssertionError(f"unexpected Gemini builtin pricing cost: {gemini_price_log}")
     databricks_log = next(
         (request for request in completion_logs if request.get("model") == "databricks-gpt-oss-120b"), None
     )

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -405,7 +405,7 @@ SELECT contains(ai_completion_request_json('hello', provider := 'openai', temper
 true
 
 query I
-SELECT NOT contains(ai_completion_request_json('hello', provider := 'gemini', temperature := 0.7), '"temperature"') AND NOT contains(ai_completion_request_json('hello', provider := 'gemini', model := 'gemini-3.5-flash-lite', temperature := 0.7), '"temperature"');
+SELECT NOT contains(ai_completion_request_json('hello', provider := 'gemini', temperature := 0.7), '"temperature"') AND NOT contains(ai_completion_request_json('hello', provider := 'gemini', model := 'gemini-3.6-flash', temperature := 0.7), '"temperature"') AND NOT contains(ai_completion_request_json('hello', provider := 'gemini', model := 'gemini-3.5-flash-lite', temperature := 0.7), '"temperature"');
 ----
 true
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14121,9 +14121,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -35,7 +35,7 @@
     "brace-expansion": "5.0.9",
     "fast-uri": "3.1.5",
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.26",
     "serialize-javascript": "^7.0.5",
     "uuid": "11.1.1"


### PR DESCRIPTION
## Summary

Add runtime verification for the Gemini pricing fix already merged in #72, and update the docs dependency lock to the patched NanoID release.

## What changed and why

- Exercise a real mock-HTTP Gemini completion and verify the usage log estimates 7 input plus 3 output tokens at the current introductory rates.
- Keep explicit Gemini 3.6 sampling-parameter compatibility covered alongside the new 3.7 default.
- Update NanoID from 3.3.17 to 3.3.18, removing its zero-length custom-generator denial-of-service advisory and reducing the audit from 139 to 17 transitive findings. The remaining findings all trace to `image-size`, which has no fixed release.

## Validation

- 382 SQLLogic assertions and full mock-provider HTTP smoke
- Formatter and clean docs install/typecheck/build
- Dependency audit confirms the NanoID advisory is resolved

A 0.4.19 patch release will follow #72 and this PR because the shipped Gemini pricing fix corrects 2x-overstated opt-in usage estimates.