### PR TITLE
release: prepare duckdb_ai 0.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.19 - 2026-08-21
+
 ### Changed
 
 - Updated Gemini's completion default to stable `gemini-3.7-flash` and omitted

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.18
+    EXTENSION_VERSION 0.4.19
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
## Summary

Prepare the 0.4.19 patch release for the Gemini pricing correction and its verified runtime/dependency follow-up.

## What changed and why

- Move the Gemini 3.7 default and 3.6/3.7 pricing schedule from Unreleased into 0.4.19 (#72).
- Include the mock-HTTP usage-cost verification and NanoID 3.3.18 advisory fix (#73).
- Bump the extension metadata from 0.4.18 to 0.4.19.

## Validation

- DuckDB 1.5.5 release build reports `ai` version 0.4.19
- 382 SQLLogic assertions and full mock-provider HTTP smoke pass
- #72 and #73 passed format, clang-tidy, build/test, docs, CodeQL, and GitGuardian checks

After merge, the `v0.4.19` release will be tagged on the exact release commit and the full distribution matrix will be verified.