### PR TITLE
fix(pricing): restore Anthropic standard rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Fixed
+
+- Corrected Anthropic's built-in standard API prices after discounted Batch API
+  rates were applied to opt-in usage-cost estimates by mistake.
+
 ## 0.4.19 - 2026-08-21
 
 ### Changed

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -899,13 +899,13 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	    {"openai", "text-embedding-3-small", "embedding", 0.02, -1,
 	     "https://developers.openai.com/api/docs/models/text-embedding-3-small", "embedding input tokens only",
 	     "2026-06-30"},
-	    {"anthropic", "claude-haiku-4-5", "completion", 0.50, 2.50,
-	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-08-18"},
-	    {"anthropic", "claude-sonnet-5", "completion", 1.50, 7.50,
+	    {"anthropic", "claude-haiku-4-5", "completion", 1.00, 5.00,
+	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-08-21"},
+	    {"anthropic", "claude-sonnet-5", "completion", 3.00, 15.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing starting 2026-09-01",
-	     "2026-08-18"},
-	    {"anthropic", "claude-sonnet-4-5", "completion", 1.50, 7.50,
-	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-08-18"},
+	     "2026-08-21"},
+	    {"anthropic", "claude-sonnet-4-5", "completion", 3.00, 15.00,
+	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-08-21"},
 	    {"gemini", "gemini-3.5-flash", "completion", 1.50, 9.00, "https://ai.google.dev/gemini-api/docs/pricing",
 	     "standard text token pricing", "2026-07-08"},
 	    {"gemini", "gemini-3.6-flash", "completion", 1.50, 7.50, "https://ai.google.dev/gemini-api/docs/pricing",
@@ -5265,8 +5265,8 @@ std::vector<ModelPrice> ModelPrices() {
 	if (CurrentTimestamp().compare(0, 10, "2026-09-01") < 0) {
 		for (auto &price : prices) {
 			if (price.provider == "anthropic" && price.model == "claude-sonnet-5" && price.operation == "completion") {
-				price.input_token_price_per_million = 1.00;
-				price.output_token_price_per_million = 5.00;
+				price.input_token_price_per_million = 2.00;
+				price.output_token_price_per_million = 10.00;
 				price.source_note = "introductory text token pricing through 2026-08-31";
 				break;
 			}

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1854,7 +1854,7 @@ def assert_smoke_result(output: str):
     if anthropic_price_log is None:
         raise AssertionError(f"missing Anthropic builtin pricing log: {completion_logs}")
     anthropic_estimated_cost = anthropic_price_log.get("estimated_cost_usd")
-    if anthropic_estimated_cost is None or abs(anthropic_estimated_cost - 0.0000145) > 0.000000001:
+    if anthropic_estimated_cost is None or abs(anthropic_estimated_cost - 0.000029) > 0.000000001:
         raise AssertionError(f"unexpected Anthropic builtin pricing cost: {anthropic_price_log}")
     gemini_price_log = next(
         (request for request in completion_logs if request.get("model") == "gemini-3.7-flash"), None

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -71,11 +71,11 @@ openai	gpt-5.6-terra	completion	2.00	12.00
 query IIIII
 SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'anthropic' AND model != 'claude-sonnet-5' ORDER BY model;
 ----
-anthropic	claude-haiku-4-5	completion	0.50	2.50
-anthropic	claude-sonnet-4-5	completion	1.50	7.50
+anthropic	claude-haiku-4-5	completion	1.00	5.00
+anthropic	claude-sonnet-4-5	completion	3.00	15.00
 
 query I
-SELECT (input_token_price_per_million = 1.00 AND output_token_price_per_million = 5.00 AND contains(source_note, 'through 2026-08-31')) OR (input_token_price_per_million = 1.50 AND output_token_price_per_million = 7.50 AND contains(source_note, 'starting 2026-09-01')) FROM ai_model_prices() WHERE provider = 'anthropic' AND model = 'claude-sonnet-5';
+SELECT (input_token_price_per_million = 2.00 AND output_token_price_per_million = 10.00 AND contains(source_note, 'through 2026-08-31')) OR (input_token_price_per_million = 3.00 AND output_token_price_per_million = 15.00 AND contains(source_note, 'starting 2026-09-01')) FROM ai_model_prices() WHERE provider = 'anthropic' AND model = 'claude-sonnet-5';
 ----
 true
 


### PR DESCRIPTION
The built-in Anthropic catalog was using discounted Batch API rates for standard opt-in usage estimates. This restores the published standard and promotional rates so estimated costs match normal Messages API billing.

### Codex description

- restore Claude Haiku 4.5 and Sonnet 4.5 standard token prices
- restore Sonnet 5 promotional pricing through August 31 and its September rollover
- verify SQL catalog values and mock-HTTP usage-cost estimates
- validated with format, release build, 382 SQLLogic assertions, mock-provider smoke, runtime benchmark, and website typecheck/build
- trigger a patch release after merge because this corrects a released public pricing bug