### PR TITLE
release: prepare duckdb_ai 0.4.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.20 - 2026-08-21
+
 ### Fixed
 
 - Corrected Anthropic's built-in standard API prices after discounted Batch API

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.19
+    EXTENSION_VERSION 0.4.20
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
Prepare the 0.4.20 patch release for the Anthropic standard-pricing correction merged in #75.

### Codex description

- move the Anthropic pricing correction into the 0.4.20 changelog section
- bump extension metadata from 0.4.19 to 0.4.20
- validated a 0.4.20 release build, 382 SQLLogic assertions, mock-provider smoke, and format check
- publish v0.4.20 from the exact merged release commit and verify the full distribution matrix