### PR TITLE
fix(pricing): correct GPT-5.6 Sol estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Fixed
+
+- Corrected GPT-5.6 Sol built-in token prices and applied the same rates to the
+  `gpt-5.6` alias so opt-in usage-cost estimates match current OpenAI billing.
+
 ## 0.4.20 - 2026-08-21
 
 ### Fixed

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -882,8 +882,10 @@ bool HasEstimatedCost(double estimated_cost_usd) {
 
 const std::vector<ModelPrice> &BuiltinModelPrices() {
 	static const std::vector<ModelPrice> prices {
-	    {"openai", "gpt-5.6-sol", "completion", 5.00, 30.00, "https://developers.openai.com/api/docs/pricing",
-	     "standard text token pricing", "2026-07-15"},
+	    {"openai", "gpt-5.6", "completion", 4.00, 20.00, "https://developers.openai.com/api/docs/models",
+	     "standard text token pricing; alias routes to gpt-5.6-sol", "2026-08-26"},
+	    {"openai", "gpt-5.6-sol", "completion", 4.00, 20.00, "https://developers.openai.com/api/docs/models",
+	     "standard text token pricing", "2026-08-26"},
 	    {"openai", "gpt-5.6-terra", "completion", 2.00, 12.00, "https://developers.openai.com/api/docs/pricing",
 	     "standard text token pricing", "2026-07-30"},
 	    {"openai", "gpt-5.6-luna", "completion", 0.20, 1.20, "https://developers.openai.com/api/docs/pricing",

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1163,6 +1163,52 @@ def assert_openai_prompt_cache(output: str):
         raise AssertionError(f"missing older-model prompt cache key: {older_request}")
 
 
+def run_duckdb_openai_pricing(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SELECT ai_complete(
+            'Sol pricing smoke',
+            provider := 'openai',
+            model := 'gpt-5.6-sol',
+            base_url := '{base_url}',
+            use_builtin_model_prices := true
+        );
+        SELECT ai_complete(
+            'alias pricing smoke',
+            provider := 'openai',
+            model := 'gpt-5.6',
+            base_url := '{base_url}',
+            use_builtin_model_prices := true
+        );
+        SELECT count(*) = 2
+               AND bool_and(prompt_tokens = 7)
+               AND bool_and(completion_tokens = 3)
+               AND bool_and(abs(estimated_cost_usd - 0.000088) < 0.000000001) AS pricing_matches
+        FROM ai_usage();
+    """
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "openai-test-key"
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb OpenAI pricing smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_openai_pricing(output: str):
+    if "pricing_matches" not in output or "true" not in output:
+        raise AssertionError(f"OpenAI builtin pricing estimates did not match current rates\n{output}")
+    models = [request.get("model") for request in MockProviderHandler.completion_requests]
+    if models != ["gpt-5.6-sol", "gpt-5.6"]:
+        raise AssertionError(f"unexpected OpenAI pricing models: {MockProviderHandler.completion_requests}")
+
+
 def run_duckdb_xai_prompt_cache_header(duckdb_path: Path, base_url: str) -> str:
     sql = f"""
         SELECT ai_complete(
@@ -2490,6 +2536,9 @@ def main():
         MockProviderHandler.reset()
         openai_prompt_cache_output = run_duckdb_openai_prompt_cache(args.duckdb, f"http://127.0.0.1:{port}")
         assert_openai_prompt_cache(openai_prompt_cache_output)
+        MockProviderHandler.reset()
+        openai_pricing_output = run_duckdb_openai_pricing(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_openai_pricing(openai_pricing_output)
         MockProviderHandler.reset()
         xai_header_output = run_duckdb_xai_prompt_cache_header(args.duckdb, f"http://127.0.0.1:{port}")
         assert_xai_prompt_cache_header(xai_header_output)

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -63,9 +63,11 @@ SELECT provider, model, operation, printf('%.2f', input_token_price_per_million)
 xai	grok-4.5	completion	2.00	6.00
 
 query IIIII rowsort
-SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'openai' AND model IN ('gpt-5.6-terra', 'gpt-5.6-luna');
+SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'openai' AND model IN ('gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna');
 ----
+openai	gpt-5.6	completion	4.00	20.00
 openai	gpt-5.6-luna	completion	0.20	1.20
+openai	gpt-5.6-sol	completion	4.00	20.00
 openai	gpt-5.6-terra	completion	2.00	12.00
 
 query IIIII


### PR DESCRIPTION
## Summary

Correct built-in OpenAI cost estimates for GPT-5.6 Sol and its documented `gpt-5.6` alias.

## Why

OpenAI now lists GPT-5.6 Sol at $4 per million input tokens and $20 per million output tokens. The catalog still used $5/$30, and the alias had no built-in row, so opt-in usage logs overestimated Sol calls or returned no estimate.

## Changes

- update Sol to the current $4/$20 standard rates
- add the `gpt-5.6` alias with the same rates
- cover catalog rows and real mock-HTTP usage estimates for both IDs

## Validation

```sh
PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja TIDY_THREADS=4 make tidy-check
GEN=ninja make release
GEN=ninja make test
python3 test/smoke/mock_provider_smoke.py
python3 test/benchmarks/ai_runtime_benchmark.py --json
scripts/preview_community_docs.sh --check
npm --prefix website ci
npm --prefix website run typecheck
npm --prefix website run build
```

## Notes

Source: https://developers.openai.com/api/docs/models