### PR TITLE
release: prepare duckdb_ai 0.4.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.21 - 2026-08-26
+
 ### Fixed
 
 - Corrected GPT-5.6 Sol built-in token prices and applied the same rates to the

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.20
+    EXTENSION_VERSION 0.4.21
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
## Summary

Prepare `duckdb_ai` 0.4.21 for the corrected GPT-5.6 Sol and alias cost estimates.

## Why

PR #78 fixes a public built-in pricing defect, so this patch release makes the correction available in immutable distribution artifacts.

## Changes

- bump extension metadata from 0.4.20 to 0.4.21
- finalize the 0.4.21 changelog entry
- include positional-option binder maintenance from #77 and the pricing fix from #78 in release notes

## Validation

```sh
PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check
GEN=ninja make release
GEN=ninja make test
python3 test/smoke/mock_provider_smoke.py
scripts/preview_community_docs.sh --check
```

The locally built extension reports version `0.4.21`.