### PR TITLE
fix(embeddings): honor batched response indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Fixed and performance
+
+- Honored embedding response indexes when mapping batched provider results back
+  to inputs, preventing out-of-order OpenAI-compatible responses from silently
+  assigning vectors to the wrong rows. Malformed indexes now fail explicitly,
+  while gateways that omit indexes remain compatible.
+- Replaced quadratic JSON Schema `uniqueItems` validation with hash-bucketed
+  structural comparison, while preserving exact numeric, array, and object
+  equality checks.
+
 ## 0.4.21 - 2026-08-26
 
 ### Fixed

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -1681,6 +1681,40 @@ bool JsonValueEquals(const JsonValue &left, const JsonValue &right) {
 	return false;
 }
 
+void HashCombine(size_t &seed, size_t value) {
+	seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+size_t JsonValueHash(const JsonValue &value) {
+	auto hash = std::hash<int> {}(static_cast<int>(value.type));
+	switch (value.type) {
+	case JsonValueType::NULL_VALUE:
+		return hash;
+	case JsonValueType::BOOLEAN:
+		HashCombine(hash, std::hash<bool> {}(value.boolean_value));
+		return hash;
+	case JsonValueType::NUMBER:
+		// JsonValueEquals treats positive and negative zero as equal.
+		HashCombine(hash, std::hash<double> {}(value.number_value == 0 ? 0.0 : value.number_value));
+		return hash;
+	case JsonValueType::STRING:
+		HashCombine(hash, std::hash<std::string> {}(value.string_value));
+		return hash;
+	case JsonValueType::ARRAY:
+		for (auto &entry : value.array_value) {
+			HashCombine(hash, JsonValueHash(entry));
+		}
+		return hash;
+	case JsonValueType::OBJECT:
+		for (auto &entry : value.object_value) {
+			HashCombine(hash, std::hash<std::string> {}(entry.first));
+			HashCombine(hash, JsonValueHash(entry.second));
+		}
+		return hash;
+	}
+	return hash;
+}
+
 std::string JsonValueToJson(const JsonValue &value) {
 	switch (value.type) {
 	case JsonValueType::NULL_VALUE:
@@ -2114,13 +2148,17 @@ bool ValidateJsonValueAgainstSchema(const JsonValue &value, const JsonValue &sch
 		auto unique_items_schema = ObjectField(schema, "uniqueItems");
 		if (unique_items_schema && unique_items_schema->type == JsonValueType::BOOLEAN &&
 		    unique_items_schema->boolean_value) {
+			std::unordered_map<size_t, std::vector<const JsonValue *>> seen_items;
+			seen_items.reserve(value.array_value.size());
 			for (idx_t i = 0; i < value.array_value.size(); i++) {
-				for (idx_t j = i + 1; j < value.array_value.size(); j++) {
-					if (JsonValueEquals(value.array_value[i], value.array_value[j])) {
-						error = JsonPathIndex(path, j) + " duplicates an earlier item";
+				auto &same_hash_items = seen_items[JsonValueHash(value.array_value[i])];
+				for (auto earlier : same_hash_items) {
+					if (JsonValueEquals(*earlier, value.array_value[i])) {
+						error = JsonPathIndex(path, i) + " duplicates an earlier item";
 						return false;
 					}
 				}
+				same_hash_items.push_back(&value.array_value[i]);
 			}
 		}
 		auto items_schema = ObjectField(schema, "items");
@@ -3834,7 +3872,14 @@ std::vector<double> FindEmbeddingArray(const std::string &body, const std::strin
 	return {};
 }
 
-std::vector<std::vector<double>> ParseEmbeddingArrays(const ProviderConfig &config, const std::string &body) {
+struct ParsedEmbeddingArray {
+	std::vector<double> values;
+	bool has_index = false;
+	int64_t index = -1;
+};
+
+std::vector<std::vector<double>> ParseEmbeddingArrays(const ProviderConfig &config, const std::string &body,
+                                                      idx_t expected_count) {
 	std::string error;
 	auto doc = ReadYyjsonDocument(body, error);
 	if (!doc) {
@@ -3859,14 +3904,56 @@ std::vector<std::vector<double>> ParseEmbeddingArrays(const ProviderConfig &conf
 	}
 	auto data = YyjsonObjectGet(root, "data");
 	if (duckdb_yyjson::yyjson_is_arr(data)) {
+		std::vector<ParsedEmbeddingArray> parsed_embeddings;
 		duckdb_yyjson::yyjson_val *entry;
 		size_t index;
 		size_t max;
 		yyjson_arr_foreach(data, index, max, entry) {
-			std::vector<double> values;
-			if (YyjsonDirectNumberArray(entry, "embedding", values)) {
-				embeddings.push_back(std::move(values));
+			ParsedEmbeddingArray parsed;
+			if (YyjsonDirectNumberArray(entry, "embedding", parsed.values)) {
+				auto index_value = YyjsonObjectGet(entry, "index");
+				parsed.has_index = index_value != nullptr;
+				if (parsed.has_index && !YyjsonDirectInteger(entry, "index", parsed.index)) {
+					throw IOException("AI provider embedding response contained a non-integer index");
+				}
+				parsed_embeddings.push_back(std::move(parsed));
 			}
+		}
+		bool has_index = false;
+		bool has_unindexed = false;
+		for (auto &parsed : parsed_embeddings) {
+			has_index = has_index || parsed.has_index;
+			has_unindexed = has_unindexed || !parsed.has_index;
+		}
+		if (has_index && has_unindexed) {
+			throw IOException("AI provider embedding response mixed indexed and unindexed entries");
+		}
+		if (!has_index) {
+			for (auto &parsed : parsed_embeddings) {
+				embeddings.push_back(std::move(parsed.values));
+			}
+			return embeddings;
+		}
+		if (parsed_embeddings.size() != expected_count) {
+			throw IOException("AI provider embedding response returned %llu embeddings for %llu inputs",
+			                  static_cast<unsigned long long>(parsed_embeddings.size()),
+			                  static_cast<unsigned long long>(expected_count));
+		}
+		embeddings.resize(expected_count);
+		std::vector<bool> seen_indexes(expected_count, false);
+		for (auto &parsed : parsed_embeddings) {
+			if (parsed.index < 0 || static_cast<uint64_t>(parsed.index) >= static_cast<uint64_t>(expected_count)) {
+				throw IOException("AI provider embedding response index %lld is outside the expected range [0, %llu)",
+				                  static_cast<long long>(parsed.index),
+				                  static_cast<unsigned long long>(expected_count));
+			}
+			auto result_index = static_cast<idx_t>(parsed.index);
+			if (seen_indexes[result_index]) {
+				throw IOException("AI provider embedding response contained duplicate index %lld",
+				                  static_cast<long long>(parsed.index));
+			}
+			seen_indexes[result_index] = true;
+			embeddings[result_index] = std::move(parsed.values);
 		}
 	}
 	return embeddings;
@@ -3893,7 +3980,7 @@ EmbeddingResult ParseEmbeddingResult(const ProviderConfig &config, const HttpRes
 
 std::vector<EmbeddingResult> ParseEmbeddingResults(const ProviderConfig &config, const HttpResponse &response,
                                                    idx_t expected_count) {
-	auto values = ParseEmbeddingArrays(config, response.body);
+	auto values = ParseEmbeddingArrays(config, response.body, expected_count);
 	if (values.size() != expected_count) {
 		if (expected_count == 1) {
 			return {ParseEmbeddingResult(config, response)};

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -147,6 +147,10 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                 content = '{"score":2}'
             elif "return array violation JSON" in prompt:
                 content = '{"tags":["duck","duck"]}'
+            elif "return numeric unique violation JSON" in prompt:
+                content = '[0,-0.0,1]'
+            elif "return object unique violation JSON" in prompt:
+                content = '[{"a":1,"b":2},{"b":2,"a":1}]'
             elif "return oneOf violation JSON" in prompt:
                 content = '{"a":1,"b":2}'
             elif "Score how well the input satisfies the supplied criteria" in full_prompt:
@@ -211,8 +215,24 @@ class MockProviderHandler(BaseHTTPRequestHandler):
 
             input_values = inputs if isinstance(inputs, list) else [inputs]
             usage_tokens = 5 if any("uneven usage" in value for value in input_values) else 2 * input_count
+            embedding_data = [
+                {"embedding": embedding(value), "index": index} for index, value in enumerate(input_values)
+            ]
+            if any("unindexed response" in value for value in input_values):
+                for item in embedding_data:
+                    item.pop("index")
+            elif any("mixed index response" in value for value in input_values):
+                embedding_data[-1].pop("index")
+            elif any("duplicate index response" in value for value in input_values):
+                embedding_data[-1]["index"] = embedding_data[0]["index"]
+            elif any("out of range index response" in value for value in input_values):
+                embedding_data[0]["index"] = len(embedding_data)
+            elif any("non integer index response" in value for value in input_values):
+                embedding_data[0]["index"] = "0"
+            if any("reverse indexed response" in value for value in input_values):
+                embedding_data.reverse()
             payload = {
-                "data": [{"embedding": embedding(value)} for value in input_values],
+                "data": embedding_data,
                 "usage": {
                     "prompt_tokens": usage_tokens,
                     "total_tokens": usage_tokens,
@@ -720,6 +740,139 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
     if result.returncode != 0:
         raise AssertionError(f"duckdb exited with {result.returncode}\n{result.stdout}")
     return result.stdout
+
+
+def run_duckdb_embedding_indexes(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_embedding_model = 'mock-indexed-embedding';
+        SET duckdb_ai_base_url = '{base_url}';
+        CREATE OR REPLACE SECRET smoke_duckdb_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'openai'
+        );
+        SELECT input, embedding[1] AS x, embedding[2] AS y
+        FROM (
+            SELECT input, ai_embed(input) AS embedding
+            FROM (VALUES
+                ('alpha reverse indexed response'),
+                ('beta reverse indexed response')
+            ) AS inputs(input)
+        )
+        ORDER BY input;
+        SELECT input, embedding[1] AS x, embedding[2] AS y
+        FROM (
+            SELECT input, ai_embed(input) AS embedding
+            FROM (VALUES
+                ('alpha unindexed response'),
+                ('beta unindexed response')
+            ) AS inputs(input)
+        )
+        ORDER BY input;
+    """
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb embedding index smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_embedding_indexes(output: str):
+    expected = [
+        "alpha reverse indexed response│ 1.0 │ 0.0",
+        "beta reverse indexed response │ 0.0 │ 1.0",
+        "alpha unindexed response│ 1.0 │ 0.0",
+        "beta unindexed response │ 0.0 │ 1.0",
+    ]
+    normalized = output.replace(" ", "")
+    missing = [value.replace(" ", "") for value in expected if value.replace(" ", "") not in normalized]
+    if missing:
+        raise AssertionError(f"indexed embedding response mapped to the wrong inputs\n{output}")
+    if len(MockProviderHandler.embedding_requests) != 2:
+        raise AssertionError(
+            f"expected indexed and unindexed embedding batches, got {MockProviderHandler.embedding_requests}"
+        )
+
+
+def run_duckdb_embedding_index_error(duckdb_path: Path, base_url: str, marker: str) -> str:
+    sql = f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_embedding_model = 'mock-indexed-embedding';
+        SET duckdb_ai_base_url = '{base_url}';
+        CREATE OR REPLACE SECRET smoke_duckdb_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'openai'
+        );
+        SELECT count(ai_embed(input))
+        FROM (VALUES ('alpha {marker}'), ('beta {marker}')) AS inputs(input);
+    """
+    result = subprocess.run(
+        [str(duckdb_path), "-bail", "-c", sql],
+        cwd=repo_root(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"duckdb accepted malformed embedding indexes\n{result.stdout}")
+    return result.stdout
+
+
+def assert_embedding_index_error(output: str, expected: str):
+    if expected not in output:
+        raise AssertionError(f"embedding index error missing {expected!r}\n{output}")
+
+
+def run_duckdb_json_unique_items(duckdb_path: Path, base_url: str) -> str:
+    sql = f"""
+        SET duckdb_ai_provider = 'openai';
+        SET duckdb_ai_model = 'mock-model';
+        SET duckdb_ai_base_url = '{base_url}';
+        CREATE OR REPLACE SECRET smoke_duckdb_ai (
+            TYPE duckdb_ai,
+            API_KEY 'test-key',
+            AI_PROVIDER 'openai'
+        );
+        SELECT ai_complete_json(
+            'return numeric unique violation JSON',
+            response_schema := '{{"type":"array","uniqueItems":true}}',
+            fail_on_error := false
+        ) IS NULL AS numeric_unique_violation;
+        SELECT ai_complete_json(
+            'return object unique violation JSON',
+            response_schema := '{{"type":"array","uniqueItems":true}}',
+            fail_on_error := false
+        ) IS NULL AS object_unique_violation;
+    """
+    result = subprocess.run(
+        [str(duckdb_path), "-c", sql],
+        cwd=repo_root(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"duckdb JSON uniqueItems smoke exited with {result.returncode}\n{result.stdout}")
+    return result.stdout
+
+
+def assert_json_unique_items(output: str):
+    if "numeric_unique_violation" not in output or "object_unique_violation" not in output:
+        raise AssertionError(f"JSON uniqueItems output missing result columns\n{output}")
+    if output.count("true") < 2:
+        raise AssertionError(f"JSON uniqueItems accepted equivalent numeric or object values\n{output}")
+    if len(MockProviderHandler.completion_requests) != 2:
+        raise AssertionError(f"expected two JSON uniqueItems requests, got {MockProviderHandler.completion_requests}")
 
 
 def run_duckdb_self_correction(duckdb_path: Path, base_url: str) -> str:
@@ -2494,6 +2647,22 @@ def main():
         MockProviderHandler.reset()
         output = run_duckdb(args.duckdb, f"http://127.0.0.1:{port}")
         assert_smoke_result(output)
+        MockProviderHandler.reset()
+        embedding_index_output = run_duckdb_embedding_indexes(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_embedding_indexes(embedding_index_output)
+        embedding_index_errors = [
+            ("mixed index response", "mixed indexed and unindexed entries"),
+            ("duplicate index response", "duplicate index 0"),
+            ("out of range index response", "outside the expected range [0, 2)"),
+            ("non integer index response", "non-integer index"),
+        ]
+        for marker, expected in embedding_index_errors:
+            MockProviderHandler.reset()
+            embedding_index_error = run_duckdb_embedding_index_error(args.duckdb, f"http://127.0.0.1:{port}", marker)
+            assert_embedding_index_error(embedding_index_error, expected)
+        MockProviderHandler.reset()
+        unique_items_output = run_duckdb_json_unique_items(args.duckdb, f"http://127.0.0.1:{port}")
+        assert_json_unique_items(unique_items_output)
         MockProviderHandler.reset()
         adaptive_batch_output = run_duckdb_adaptive_batches(args.duckdb, f"http://127.0.0.1:{port}")
         assert_adaptive_batches(adaptive_batch_output)


### PR DESCRIPTION
## What changed and why

- Map indexed OpenAI-compatible embedding results back to their original batch inputs, while retaining wire-order compatibility for gateways that omit indexes.
- Reject mixed, duplicate, out-of-range, and non-integer response indexes instead of returning ambiguous vectors.
- Replace quadratic JSON Schema `uniqueItems` scans with hash-bucketed structural comparison that still resolves collisions with exact equality.

This fixes silent vector-to-row swaps when a provider returns a valid indexed batch out of wire order and removes a measured structured-output validation hotspot.

## Validation

- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja TIDY_THREADS=4 make tidy-check`
- `GEN=ninja make release`
- `GEN=ninja make test` (395 assertions)
- `python3 test/smoke/mock_provider_smoke.py --tls-only`
- `python3 test/smoke/mock_provider_smoke.py`
- `scripts/preview_community_docs.sh --check` against DuckDB v1.5.5
- `npm ci`, `npm run typecheck`, and `npm run build` in `website/`
- 1K/10K embedding and similarity benchmark matrix
- Reversed indexed-response PoC: 0.4.21 swapped alpha/beta vectors; this branch preserves the correct association.
- 20K-item `uniqueItems` PoC: 0.321s before, 0.038s after.

This is a confirmed public correctness bug; a v0.4.22 release will follow after merge.