### PR TITLE
release: prepare duckdb_ai 0.4.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.22 - 2026-08-28
+
 ### Fixed and performance
 
 - Honored embedding response indexes when mapping batched provider results back

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.21
+    EXTENSION_VERSION 0.4.22
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
## What changed and why

- Bump the extension version from 0.4.21 to 0.4.22.
- Move the indexed-embedding correctness fix and JSON Schema validation performance improvement from Unreleased into the dated 0.4.22 changelog section.

This release is warranted because [#80](https://github.com/leonardovida/duckdb-ai/pull/80) fixes a public bug that could silently associate a provider embedding with the wrong SQL input row.

## Validation

- `OVERRIDE_GIT_DESCRIBE=v1.5.5 GEN=ninja make release`
- `GEN=ninja make test` (395 assertions)
- `python3 test/smoke/mock_provider_smoke.py --tls-only`
- `python3 test/smoke/mock_provider_smoke.py`
- `PATH=/tmp/duckdb_ai_format_venv/bin:$PATH GEN=ninja make format-check`
- `scripts/preview_community_docs.sh --check`
- Loaded the built artifact in standalone DuckDB v1.5.5 and confirmed `ai` reports version 0.4.22.