### PR TITLE
fix(providers): refresh Sonnet pricing and xAI default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Changed
+
+- Updated the xAI / SpaceXAI completion default to `grok-4.6`, while retaining
+  explicit `grok-4.5` selection and pricing metadata.
+
+### Fixed
+
+- Kept Claude Sonnet 5 built-in cost estimates at Anthropic's permanent
+  $2/M input and $10/M output rates instead of applying the canceled September
+  price increase.
+
 ## 0.4.22 - 2026-08-28
 
 ### Fixed and performance

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1171,7 +1171,7 @@ Supported provider names and aliases are:
 | `vercel` | `vercel_ai_gateway`, `vercel_gateway`, `ai_gateway` | Yes | Yes | `openai/gpt-4o-mini` |
 | `vertex` | `google_vertex`, `vertex_ai`, `gcp_vertex` | Yes | No | `google/gemini-2.5-flash` |
 | `volcengine` | `volcano_engine`, `volcengine_ark`, `doubao`, `ark` | Yes | No | `doubao-seed-2-1-pro-260628` |
-| `xai` | `x.ai`, `x-ai`, `grok` | Yes | No | `grok-4.5` |
+| `xai` | `x.ai`, `x-ai`, `grok` | Yes | No | `grok-4.6` |
 | `zai` | `zhipu` | Yes | Yes | `glm-4.7-flash` |
 | `openai_privacy_filter` | `privacy_filter`, `pii_filter`, `opf` | Redaction only | No | `openai/privacy-filter` |
 | `openai_compatible` | `local`, `openai-compatible`, `local_openai`, `local-models`, `local_models` | Yes | Yes | `gpt-4o-mini` |

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -68,7 +68,7 @@ LIMIT 1;
 | `vercel` / `vercel_ai_gateway` | OpenAI-compatible chat and embeddings | `openai/gpt-4o-mini`; embeddings use `openai/text-embedding-3-small` | `AI_GATEWAY_API_KEY`, `VERCEL_AI_GATEWAY_API_KEY`, or `VERCEL_OIDC_TOKEN` | Defaults to `https://ai-gateway.vercel.sh/v1`. |
 | `vertex` / `google_vertex` | OpenAI-compatible chat | `google/gemini-2.5-flash` | `VERTEX_AI_ACCESS_TOKEN`, `GOOGLE_CLOUD_ACCESS_TOKEN`, or `VERTEX_API_KEY` | Derives the endpoint from `GOOGLE_CLOUD_PROJECT`, or accepts `VERTEX_AI_BASE_URL`, `GOOGLE_VERTEX_BASE_URL`, or secret `BASE_URL`. |
 | `volcengine` / `doubao` | OpenAI-compatible chat | `doubao-seed-2-1-pro-260628` | `VOLCENGINE_API_KEY`, `ARK_API_KEY`, or `DOUBAO_API_KEY` | Defaults to `https://ark.cn-beijing.volces.com/api/v3`. |
-| `xai` / `grok` | OpenAI-compatible chat | `grok-4.5` | `XAI_API_KEY` | Defaults to `https://api.x.ai/v1`. |
+| `xai` / `grok` | OpenAI-compatible chat | `grok-4.6` | `XAI_API_KEY` | Defaults to `https://api.x.ai/v1`. |
 | `openai_privacy_filter` | Dedicated redaction endpoint | `openai/privacy-filter` | Optional `OPENAI_PRIVACY_FILTER_API_KEY` | Defaults to `http://localhost:8080` and calls `POST /redact`. |
 | `openai_compatible` / `local` | OpenAI-compatible chat and embeddings | `gpt-4o-mini`; embeddings use `text-embedding-3-small` | Optional `OPENAI_COMPATIBLE_API_KEY` | Requires `BASE_URL` or `OPENAI_COMPATIBLE_BASE_URL`. |
 | `llamacpp` / `llama.cpp` | OpenAI-compatible chat and embeddings | `default` (llama-server answers with its loaded model) | Optional `LLAMACPP_API_KEY` (`llama-server --api-key`) | Defaults to `http://localhost:8080/v1`. Embeddings need `llama-server --embeddings`. |
@@ -960,7 +960,7 @@ LOAD ai;
 CREATE OR REPLACE SECRET xai_ai (
     TYPE duckdb_ai,
     AI_PROVIDER 'xai',
-    MODEL 'grok-4.5'
+    MODEL 'grok-4.6'
 );
 
 SELECT ai_complete(

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -903,9 +903,8 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	     "2026-06-30"},
 	    {"anthropic", "claude-haiku-4-5", "completion", 1.00, 5.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-08-21"},
-	    {"anthropic", "claude-sonnet-5", "completion", 3.00, 15.00,
-	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing starting 2026-09-01",
-	     "2026-08-21"},
+	    {"anthropic", "claude-sonnet-5", "completion", 2.00, 10.00,
+	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-08-28"},
 	    {"anthropic", "claude-sonnet-4-5", "completion", 3.00, 15.00,
 	     "https://platform.claude.com/docs/en/about-claude/pricing", "standard text token pricing", "2026-08-21"},
 	    {"gemini", "gemini-3.5-flash", "completion", 1.50, 9.00, "https://ai.google.dev/gemini-api/docs/pricing",
@@ -934,8 +933,10 @@ const std::vector<ModelPrice> &BuiltinModelPrices() {
 	     "live model feed pricing", "2026-06-30"},
 	    {"openrouter", "z-ai/glm-4.7-flash", "completion", 0.06, 0.40, "https://openrouter.ai/api/v1/models",
 	     "live model feed pricing", "2026-06-30"},
-	    {"xai", "grok-4.5", "completion", 2.00, 6.00, "https://docs.x.ai/developers/models",
-	     "standard text token pricing", "2026-07-09"},
+	    {"xai", "grok-4.5", "completion", 2.00, 6.00, "https://docs.x.ai/developers/models/grok-4.5",
+	     "standard text token pricing for prompts below 200K tokens", "2026-08-28"},
+	    {"xai", "grok-4.6", "completion", 2.00, 6.00, "https://docs.x.ai/developers/grok-4-6",
+	     "standard text token pricing for prompts below 200K tokens", "2026-08-28"},
 	};
 	return prices;
 }
@@ -2948,7 +2949,7 @@ const std::vector<ProviderSpec> &ProviderCatalog() {
 	    {"vertex", "openai_chat", "google/gemini-2.5-flash", "", "", "VERTEX_AI_ACCESS_TOKEN", true},
 	    {"volcengine", "openai_chat", "doubao-seed-2-1-pro-260628", "", "https://ark.cn-beijing.volces.com/api/v3",
 	     "VOLCENGINE_API_KEY", true},
-	    {"xai", "openai_chat", "grok-4.5", "", "https://api.x.ai/v1", "XAI_API_KEY", true},
+	    {"xai", "openai_chat", "grok-4.6", "", "https://api.x.ai/v1", "XAI_API_KEY", true},
 	    {"zai", "openai_chat", "glm-4.7-flash", "embedding-3", "https://api.z.ai/api/paas/v4", "ZAI_API_KEY", true},
 	};
 	return providers;
@@ -5351,16 +5352,6 @@ void ClearResponseCache(ClientContext &context) {
 
 std::vector<ModelPrice> ModelPrices() {
 	auto prices = BuiltinModelPrices();
-	if (CurrentTimestamp().compare(0, 10, "2026-09-01") < 0) {
-		for (auto &price : prices) {
-			if (price.provider == "anthropic" && price.model == "claude-sonnet-5" && price.operation == "completion") {
-				price.input_token_price_per_million = 2.00;
-				price.output_token_price_per_million = 10.00;
-				price.source_note = "introductory text token pricing through 2026-08-31";
-				break;
-			}
-		}
-	}
 	if (CurrentTimestamp().compare(0, 10, "2027-01-01") < 0) {
 		for (auto &price : prices) {
 			if (price.provider == "gemini" &&

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -1396,7 +1396,7 @@ def assert_xai_prompt_cache_header(output: str):
     if len(MockProviderHandler.completion_requests) != 1:
         raise AssertionError(f"expected one xAI completion request, got {MockProviderHandler.completion_requests}")
     request = MockProviderHandler.completion_requests[0]
-    if request["model"] != "grok-4.5":
+    if request["model"] != "grok-4.6":
         raise AssertionError(f"unexpected xAI default model: {request}")
     if "prompt_cache_key" in request:
         raise AssertionError(f"xAI prompt cache key should be sent as a header, not request JSON: {request}")

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -57,10 +57,11 @@ SELECT provider, model, operation, printf('%.2f', input_token_price_per_million)
 ----
 mistral	mistral-small-latest	completion	0.15	0.60
 
-query IIIII
-SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'xai' AND model = 'grok-4.5';
+query IIIII rowsort
+SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'xai';
 ----
 xai	grok-4.5	completion	2.00	6.00
+xai	grok-4.6	completion	2.00	6.00
 
 query IIIII rowsort
 SELECT provider, model, operation, printf('%.2f', input_token_price_per_million), printf('%.2f', output_token_price_per_million) FROM ai_model_prices() WHERE provider = 'openai' AND model IN ('gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna');
@@ -77,7 +78,7 @@ anthropic	claude-haiku-4-5	completion	1.00	5.00
 anthropic	claude-sonnet-4-5	completion	3.00	15.00
 
 query I
-SELECT (input_token_price_per_million = 2.00 AND output_token_price_per_million = 10.00 AND contains(source_note, 'through 2026-08-31')) OR (input_token_price_per_million = 3.00 AND output_token_price_per_million = 15.00 AND contains(source_note, 'starting 2026-09-01')) FROM ai_model_prices() WHERE provider = 'anthropic' AND model = 'claude-sonnet-5';
+SELECT input_token_price_per_million = 2.00 AND output_token_price_per_million = 10.00 AND source_note = 'standard text token pricing' FROM ai_model_prices() WHERE provider = 'anthropic' AND model = 'claude-sonnet-5';
 ----
 true
 
@@ -242,7 +243,7 @@ SELECT contains(ai_completion_request_json('hello', provider := 'fireworks', mod
 true	true	true	true
 
 query I
-SELECT contains(ai_completion_request_json('hello', provider := 'x.ai'), '"model":"grok-4.5"');
+SELECT contains(ai_completion_request_json('hello', provider := 'x.ai'), '"model":"grok-4.6"');
 ----
 true
 


### PR DESCRIPTION
Anthropic made the Sonnet 5 introductory price permanent and xAI shipped Grok 4.6. This keeps built-in estimates and xAI defaults aligned with current public provider contracts.

### Codex description

- keep Claude Sonnet 5 estimates at the permanent $2/M input and $10/M output rates
- default xAI completions to Grok 4.6 while preserving explicit Grok 4.5 selection and pricing
- validate with formatting, release build, 400 SQLLogic assertions, mock-provider smoke, runtime benchmark, DuckDB PoCs, and website typecheck/build
- trigger a patch release after merge because the stale Sonnet rollover is a released cost-estimation bug