### PR TITLE
release: prepare duckdb_ai 0.4.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+## 0.4.23 - 2026-08-28
+
 ### Changed
 
 - Updated the xAI / SpaceXAI completion default to `grok-4.6`, while retaining

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.22
+    EXTENSION_VERSION 0.4.23
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
Prepare duckdb_ai 0.4.23 so the corrected Sonnet 5 estimates and current xAI default from #82 can ship as a patch release.

### Codex description

- bump the extension version from 0.4.22 to 0.4.23
- move the provider maintenance changes into the dated 0.4.23 changelog section
- validate with formatting, a DuckDB v1.5.5-compatible release build, 400 SQLLogic assertions, mock-provider smoke, community-doc snapshot, and standalone artifact loading
- keep DuckDB community publication outside this release pass as requested