### PR TITLE
fix(databricks): support reasoning completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
+### Fixed
+
+- Accepted Databricks reasoning-model responses with typed text content blocks
+  and omitted unsupported sampling temperature for Claude Sonnet 5 and Opus 5
+  model services, fixing the completion failures reported in #85.
+
 ## 0.4.23 - 2026-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ include SQL API changes and patch versions should preserve the SQL API.
 - Accepted Databricks reasoning-model responses with typed text content blocks
   and omitted unsupported sampling temperature for Claude Sonnet 5 and Opus 5
   model services, fixing the completion failures reported in #85.
+- Updated the documentation lockfile to patched `fast-uri` and `qs` releases,
+  resolving their URL-confusion, SSRF, and query-parser advisories.
 
 ## 0.4.23 - 2026-08-28
 

--- a/docs/provider-guides.md
+++ b/docs/provider-guides.md
@@ -1116,6 +1116,13 @@ If `BASE_URL` is omitted, set `DATABRICKS_HOST`; the extension derives
 `/serving-endpoints`, `/ai-gateway/mlflow/v1`, or `/chat/completions` endpoint.
 Aliases `mosaic`, `mosaic_ai`, and `databricks_ai` resolve to `databricks`.
 
+Databricks reasoning models can return `message.content` as typed reasoning and
+text blocks. `duckdb_ai` returns the text blocks and ignores reasoning summaries.
+Databricks Claude Sonnet 5 and Claude Opus 5 model services reject sampling
+temperature, so the extension omits `temperature` for those model IDs even when
+the generic SQL option is set. Older Claude and other Databricks models retain
+explicit temperature support.
+
 ## Snowflake Cortex REST
 
 Snowflake Cortex REST exposes a Chat Completions API compatible with the OpenAI

--- a/src/duckdb_ai_provider.cpp
+++ b/src/duckdb_ai_provider.cpp
@@ -3679,6 +3679,18 @@ bool GeminiOmitsSamplingParameters(const ProviderConfig &config) {
 	                                       config.model == "gemini-3.5-flash-lite");
 }
 
+bool DatabricksOmitsSamplingParameters(const ProviderConfig &config) {
+	if (config.provider != "databricks") {
+		return false;
+	}
+	auto model = LowerAscii(config.model);
+	return EndsWith(model, "claude-sonnet-5") || EndsWith(model, "claude-opus-5");
+}
+
+bool ProviderOmitsSamplingParameters(const ProviderConfig &config) {
+	return GeminiOmitsSamplingParameters(config) || DatabricksOmitsSamplingParameters(config);
+}
+
 void ValidateProviderResponseFormat(const ProviderConfig &config, const CompletionOptions &options) {
 	if (config.provider != "poe") {
 		return;
@@ -3773,7 +3785,7 @@ std::string RequestPayload(const ProviderConfig &config, const std::string &prom
 	auto explicit_openai_prompt_cache = OpenAIUsesExplicitPromptCache(config, options);
 	auto payload = "{\"model\":\"" + escaped_model +
 	               "\",\"messages\":" + ChatMessagesJson(prompt, options.system_prompt, explicit_openai_prompt_cache);
-	if (options.has_temperature && !GeminiOmitsSamplingParameters(config)) {
+	if (options.has_temperature && !ProviderOmitsSamplingParameters(config)) {
 		payload += ",\"temperature\":" + JsonDouble(options.temperature);
 	}
 	if (options.has_max_tokens) {
@@ -4053,6 +4065,39 @@ std::vector<std::string> RequestHeaders(const ProviderConfig &config, const Comp
 	return headers;
 }
 
+bool ExtractMessageContentText(duckdb_yyjson::yyjson_val *message, std::string &result) {
+	auto content = YyjsonObjectGet(message, "content");
+	if (content && duckdb_yyjson::yyjson_is_str(content)) {
+		result = YyjsonString(content);
+		return true;
+	}
+	if (!content || !duckdb_yyjson::yyjson_is_arr(content)) {
+		return false;
+	}
+
+	std::string combined;
+	bool found_text = false;
+	duckdb_yyjson::yyjson_val *entry;
+	size_t index;
+	size_t max;
+	yyjson_arr_foreach(content, index, max, entry) {
+		std::string type;
+		if (YyjsonDirectString(entry, "type", type) && type != "text") {
+			continue;
+		}
+		std::string text;
+		if (YyjsonDirectString(entry, "text", text)) {
+			combined += text;
+			found_text = true;
+		}
+	}
+	if (!found_text) {
+		return false;
+	}
+	result = std::move(combined);
+	return true;
+}
+
 std::string ExtractCompletionText(const ProviderConfig &config, duckdb_yyjson::yyjson_val *root,
                                   const std::string &body) {
 	std::string value;
@@ -4086,7 +4131,7 @@ std::string ExtractCompletionText(const ProviderConfig &config, duckdb_yyjson::y
 		} else {
 			auto first_choice = YyjsonArrayGet(YyjsonObjectGet(root, "choices"), 0);
 			auto message = YyjsonObjectGet(first_choice, "message");
-			if (YyjsonDirectString(message, "content", value)) {
+			if (ExtractMessageContentText(message, value)) {
 				return value;
 			}
 			if (YyjsonDirectString(message, "refusal", value)) {

--- a/test/smoke/mock_provider_smoke.py
+++ b/test/smoke/mock_provider_smoke.py
@@ -77,6 +77,15 @@ class MockProviderHandler(BaseHTTPRequestHandler):
             self.completion_requests.append(request)
             prompt = message_text(request["messages"][-1])
             full_prompt = "\n".join(message_text(message) for message in request["messages"])
+            if (
+                request.get("model") in {"system.ai.claude-opus-5", "system.ai.claude-sonnet-5"}
+                and "temperature" in request
+            ):
+                self._send_json(
+                    {"error": {"message": "model does not support the temperature parameter"}},
+                    status=400,
+                )
+                return
             concurrency_group = None
             if prompt.startswith("cap one "):
                 concurrency_group = "cap_one"
@@ -183,6 +192,15 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                     "total_tokens": 10,
                 },
             }
+            if prompt == "databricks typed content":
+                payload["choices"][0]["message"]["content"] = [
+                    {
+                        "type": "reasoning",
+                        "summary": [{"type": "summary_text", "text": "private reasoning"}],
+                    },
+                    {"type": "text", "text": "visible "},
+                    {"type": "text", "text": "answer"},
+                ]
             if concurrency_group:
                 with self.request_lock:
                     active_name = f"active_{concurrency_group}_requests"
@@ -715,6 +733,13 @@ def run_duckdb(duckdb_path: Path, base_url: str) -> str:
         SELECT round(sum(ai_similarity('constant query', candidate)), 6) AS constant_similarity_sum
         FROM (VALUES ('candidate one'), ('candidate two'), ('candidate three')) AS input(candidate);
         SELECT ai_rerank('analytics database', 'DuckDB runs analytical SQL') AS rerank_score;
+        SELECT ai_complete(
+            'databricks typed content',
+            secret := 'smoke_databricks_ai',
+            provider := 'databricks',
+            model := 'system.ai.claude-opus-5',
+            temperature := 0.2
+        ) AS databricks_typed_content;
         SELECT event, provider, protocol, model, prompt_chars, response_chars, input_chars,
                dimensions, prompt_tokens, completion_tokens, total_tokens, http_status,
                estimated_cost_usd
@@ -1678,6 +1703,7 @@ def assert_smoke_result(output: str):
         "billing, overdue",
         "performance",
         "0.82",
+        "visible answer",
         "0.25",
         "1.0",
         "3.0",
@@ -1692,11 +1718,11 @@ def assert_smoke_result(output: str):
     if missing:
         raise AssertionError(f"duckdb output missing {missing}\n{output}")
 
-    if len(MockProviderHandler.completion_requests) != 35:
-        raise AssertionError(f"expected 35 completion requests, got {len(MockProviderHandler.completion_requests)}")
-    if len(MockProviderHandler.authorization_headers) != 41:
-        raise AssertionError(f"expected 41 auth headers, got {len(MockProviderHandler.authorization_headers)}")
-    if MockProviderHandler.authorization_headers.count("Bearer test-key") != 40:
+    if len(MockProviderHandler.completion_requests) != 36:
+        raise AssertionError(f"expected 36 completion requests, got {len(MockProviderHandler.completion_requests)}")
+    if len(MockProviderHandler.authorization_headers) != 42:
+        raise AssertionError(f"expected 42 auth headers, got {len(MockProviderHandler.authorization_headers)}")
+    if MockProviderHandler.authorization_headers.count("Bearer test-key") != 41:
         raise AssertionError(f"unexpected default authorization headers: {MockProviderHandler.authorization_headers}")
     if MockProviderHandler.authorization_headers.count("Bearer gemini-test-key") != 1:
         raise AssertionError(f"unexpected Gemini authorization headers: {MockProviderHandler.authorization_headers}")
@@ -1892,6 +1918,13 @@ def assert_smoke_result(output: str):
         != "Query:\nanalytics database\n\nCandidate:\nDuckDB runs analytical SQL"
     ):
         raise AssertionError(f"unexpected rerank prompt: {rerank_request}")
+    databricks_typed_request = MockProviderHandler.completion_requests[35]
+    if databricks_typed_request.get("model") != "system.ai.claude-opus-5":
+        raise AssertionError(f"unexpected Databricks typed-content model: {databricks_typed_request}")
+    if "temperature" in databricks_typed_request:
+        raise AssertionError(
+            f"Databricks Claude 5 request included unsupported temperature: {databricks_typed_request}"
+        )
     if len(MockProviderHandler.privacy_filter_requests) != 1:
         raise AssertionError(
             f"expected 1 Privacy Filter request, got {len(MockProviderHandler.privacy_filter_requests)}"
@@ -1958,20 +1991,20 @@ def assert_smoke_result(output: str):
         raise AssertionError(f"unexpected packed constant similarity inputs: {constant_similarity_inputs}")
 
     log_deadline = time.time() + 5
-    while len(MockProviderHandler.log_requests) < 48 and time.time() < log_deadline:
+    while len(MockProviderHandler.log_requests) < 49 and time.time() < log_deadline:
         time.sleep(0.05)
-    if len(MockProviderHandler.log_requests) != 48:
+    if len(MockProviderHandler.log_requests) != 49:
         event_counts = {}
         for request in MockProviderHandler.log_requests:
             event = "otlp" if "resourceLogs" in request else request.get("event", "unknown")
             event_counts[event] = event_counts.get(event, 0) + 1
-        raise AssertionError(f"expected 48 log requests, got {len(MockProviderHandler.log_requests)}: {event_counts}")
+        raise AssertionError(f"expected 49 log requests, got {len(MockProviderHandler.log_requests)}: {event_counts}")
     completion_logs = [
         request for request in MockProviderHandler.log_requests if request.get("event") == "ai_completion"
     ]
     embedding_logs = [request for request in MockProviderHandler.log_requests if request.get("event") == "ai_embedding"]
     otlp_logs = [request for request in MockProviderHandler.log_requests if "resourceLogs" in request]
-    if len(completion_logs) != 35 or len(embedding_logs) != 12:
+    if len(completion_logs) != 36 or len(embedding_logs) != 12:
         raise AssertionError(f"unexpected log events: {MockProviderHandler.log_requests}")
     if len(otlp_logs) != 1:
         raise AssertionError(f"expected 1 OTLP log request, got {otlp_logs}")

--- a/test/sql/duckdb_ai.test
+++ b/test/sql/duckdb_ai.test
@@ -515,6 +515,11 @@ SELECT ai_completion_request_json('hello databricks', provider := 'databricks');
 {"model":"databricks-gpt-oss-120b","messages":[{"role":"user","content":"hello databricks"}]}
 
 query I
+SELECT NOT contains(opus_request, '"temperature"') AND NOT contains(sonnet_request, '"temperature"') AND contains(older_claude_request, '"temperature":0.2') AND contains(gpt_oss_request, '"temperature":0.2') FROM (SELECT ai_completion_request_json('hello', provider := 'databricks', model := 'system.ai.claude-opus-5', temperature := 0.2) AS opus_request, ai_completion_request_json('hello', provider := 'databricks', model := 'databricks-claude-sonnet-5', temperature := 0.2) AS sonnet_request, ai_completion_request_json('hello', provider := 'databricks', model := 'system.ai.claude-sonnet-4-5', temperature := 0.2) AS older_claude_request, ai_completion_request_json('hello', provider := 'databricks', model := 'system.ai.gpt-oss-120b', temperature := 0.2) AS gpt_oss_request);
+----
+true
+
+query I
 SELECT ai_completion_request_json('hello snowflake', provider := 'snowflake');
 ----
 {"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello snowflake"}]}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9427,9 +9427,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -16391,9 +16391,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -33,10 +33,11 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "js-yaml": "4.3.1",
     "nanoid": "3.3.18",
     "postcss": "8.5.26",
+    "qs": "6.16.0",
     "serialize-javascript": "^7.0.5",
     "uuid": "11.1.1"
   },


### PR DESCRIPTION
Databricks reasoning models expose request and response shapes that currently break `ai_complete`. This fixes #85 and refreshes two vulnerable documentation dependencies.

### Codex description

- omit unsupported temperature for Databricks Claude Sonnet 5 and Opus 5 model services
- return typed text blocks without leaking reasoning summaries
- update `fast-uri` and `qs` to patched releases