### PR TITLE
release: prepare duckdb_ai 0.4.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ include SQL API changes and patch versions should preserve the SQL API.
 
 ## Unreleased
 
-## 0.4.24 - 2026-09-04
+## 0.4.25 - 2026-09-04
 
 ### Fixed
 
@@ -15,6 +15,11 @@ include SQL API changes and patch versions should preserve the SQL API.
   cache-miss rates, while documenting that off-peak billing is 50% lower.
 - Replaced NVIDIA NIM's deprecated free-endpoint default with the supported
   `nvidia/nemotron-3-super-120b-a12b` model.
+
+## 0.4.24 - 2026-09-04
+
+### Fixed
+
 - Accepted Databricks reasoning-model responses with typed text content blocks
   and omitted unsupported sampling temperature for Claude Sonnet 5 and Opus 5
   model services, fixing the completion failures reported in #85.

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(ai
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    EXTENSION_VERSION 0.4.24
+    EXTENSION_VERSION 0.4.25
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
Prepares duckdb_ai 0.4.25 so the provider corrections merged after the already-published 0.4.24 tag ship from the correct immutable release commit.

### Codex description

- bump the extension version from 0.4.24 to 0.4.25
- move the DeepSeek and NVIDIA fixes into the dated 0.4.25 changelog section
- preserve the exact 0.4.24 contents and tag history